### PR TITLE
feat: writ revocation (compiler stage 2b + runtime registry)

### DIFF
--- a/thymos/crates/thymos-compiler/src/lib.rs
+++ b/thymos/crates/thymos-compiler/src/lib.rs
@@ -7,6 +7,7 @@
 //! Stages (order matters — authority precedes surface visibility):
 //!   1. Kind gate         — Phase 1 only supports `Act` intents.
 //!   2. Signature check   — writ signature must verify.
+//!   2b. Revocation check — writ (or its parent) must not be revoked.
 //!   3. Time-window check — now must lie within [not_before, expires_at].
 //!   4. Writ binding      — tool scope check (before tool surface is consulted).
 //!   5. Tool resolution   — lookup in the ToolRegistry; unknown -> UnknownTool.
@@ -17,8 +18,11 @@
 //!   9. Policy eval       — run the PolicyEngine over (Intent, Writ, World).
 //!  10. Emit Proposal     — with full PolicyTrace, or a typed rejection.
 
+use std::collections::HashSet;
+
 use thymos_core::{
     error::{Error, Result},
+    ids::WritId,
     intent::{Intent, IntentKind},
     proposal::{
         ExecutionPlan, PolicyDecision, PolicyTrace, Proposal, ProposalBody, ProposalStatus,
@@ -57,15 +61,20 @@ pub struct CompileContext {
     /// Accumulated budget usage so far in this trajectory. The compiler
     /// checks that `accumulated + estimate <= writ.budget`.
     pub budget_used: BudgetCost,
+    /// Revoked writ ids. A writ whose id (or whose immediate parent id) appears
+    /// here is treated as void even if its signature and time window are valid —
+    /// the revocation mechanism for capabilities pulled before expiry.
+    pub revoked: HashSet<WritId>,
 }
 
 impl CompileContext {
-    /// A deterministic context with `now_unix = 0` and an empty budget — use
-    /// in tests or when the writ has an unbounded time window.
+    /// A deterministic context with `now_unix = 0`, empty budget, and no
+    /// revocations — use in tests or when the writ has an unbounded time window.
     pub fn deterministic() -> Self {
         CompileContext {
             now_unix: 0,
             budget_used: BudgetCost::default(),
+            revoked: HashSet::new(),
         }
     }
 }
@@ -124,6 +133,24 @@ pub fn compile_with_context(
         return Ok(Compiled::Rejected(RejectionReason::AuthorityVoid(format!(
             "writ signature invalid: {e}"
         ))));
+    }
+
+    // 2b. Revocation check. A validly-signed writ can still be void if it (or
+    // its immediate parent) has been revoked. Checked before the time window so
+    // a revoked-but-unexpired writ is rejected as soon as possible.
+    if ctx.revoked.contains(&writ.id) {
+        return Ok(Compiled::Rejected(RejectionReason::AuthorityVoid(format!(
+            "writ {} has been revoked",
+            writ.id
+        ))));
+    }
+    if let Some(parent) = writ.body.parent {
+        if ctx.revoked.contains(&parent) {
+            return Ok(Compiled::Rejected(RejectionReason::AuthorityVoid(format!(
+                "writ {} is void: parent {} has been revoked",
+                writ.id, parent
+            ))));
+        }
     }
 
     // 3. Time-window check.

--- a/thymos/crates/thymos-runtime/src/lib.rs
+++ b/thymos/crates/thymos-runtime/src/lib.rs
@@ -126,6 +126,43 @@ pub struct Runtime {
     /// [`Redactor::default_secrets`]; replace via [`Runtime::with_redactor`] or
     /// disable with `Redactor::none()`.
     pub redactor: thymos_core::Redactor,
+    /// Revoked writs. Consulted on every compile so a capability can be pulled
+    /// before its time window expires. Shared (cheap to clone) so a control
+    /// surface can revoke while runs are in flight.
+    pub revocations: Revocations,
+}
+
+/// Thread-safe set of revoked writ ids, consulted by the compiler on every
+/// submission. Revoking a writ also voids any child whose immediate parent is
+/// the revoked writ (one-level cascade enforced in the compiler).
+#[derive(Clone, Default)]
+pub struct Revocations {
+    inner: std::sync::Arc<std::sync::RwLock<std::collections::HashSet<thymos_core::WritId>>>,
+}
+
+impl Revocations {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Revoke a writ by id. Idempotent.
+    pub fn revoke(&self, writ_id: thymos_core::WritId) {
+        self.inner.write().unwrap().insert(writ_id);
+    }
+
+    /// Restore a previously revoked writ (e.g. an erroneous revocation).
+    pub fn restore(&self, writ_id: &thymos_core::WritId) {
+        self.inner.write().unwrap().remove(writ_id);
+    }
+
+    pub fn is_revoked(&self, writ_id: &thymos_core::WritId) -> bool {
+        self.inner.read().unwrap().contains(writ_id)
+    }
+
+    /// A snapshot of the current revocation set, handed to the compiler.
+    pub fn snapshot(&self) -> std::collections::HashSet<thymos_core::WritId> {
+        self.inner.read().unwrap().clone()
+    }
 }
 
 impl Runtime {
@@ -137,7 +174,15 @@ impl Runtime {
             delegation_keyring: None,
             commit_signer: None,
             redactor: thymos_core::Redactor::default_secrets(),
+            revocations: Revocations::new(),
         }
+    }
+
+    /// Revoke a writ: subsequent submissions under it (or any child whose
+    /// immediate parent is it) are rejected as `AuthorityVoid`, even if the
+    /// signature and time window are still valid.
+    pub fn revoke_writ(&self, writ_id: thymos_core::WritId) {
+        self.revocations.revoke(writ_id);
     }
 
     /// Builder: attach a [`DelegationKeyring`] so child writs in delegations
@@ -349,6 +394,7 @@ impl<'a> Run<'a> {
         let ctx = CompileContext {
             now_unix,
             budget_used,
+            revoked: self.runtime.revocations.snapshot(),
         };
 
         // Compile (with budget + time-window checks).

--- a/thymos/crates/thymos-runtime/tests/revocation.rs
+++ b/thymos/crates/thymos-runtime/tests/revocation.rs
@@ -1,0 +1,189 @@
+//! Writ revocation: a validly-signed, unexpired writ can be pulled at runtime.
+//! Subsequent submissions under it — or under any child whose immediate parent
+//! is the revoked writ — are rejected as AuthorityVoid before the tool runs.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use serde_json::{json, Value};
+
+use thymos_core::{crypto::SigningKey, ContentHash, WritId};
+use thymos_core::{commit::Observation, delta::StructuredDelta, error::Result};
+use thymos_ledger::Ledger;
+use thymos_policy::{PolicyEngine, WritAuthorityPolicy};
+use thymos_runtime::{
+    generate_signing_key, public_key_of, Budget, CoreIntent, DelegationBounds, EffectCeiling,
+    IntentBody, IntentKind, Runtime, Step, TimeWindow, ToolPattern, Writ, WritBody,
+};
+use thymos_tools::{
+    EffectClass, RiskClass, ToolContract, ToolContractMeta, ToolInvocation, ToolOutcome,
+    ToolRegistry,
+};
+
+struct NoopTool {
+    counter: Arc<AtomicUsize>,
+}
+impl ToolContract for NoopTool {
+    fn meta(&self) -> &ToolContractMeta {
+        static M: std::sync::OnceLock<ToolContractMeta> = std::sync::OnceLock::new();
+        M.get_or_init(|| ToolContractMeta {
+            name: "noop".into(),
+            version: "1.0.0".into(),
+            effect_class: EffectClass::Write,
+            risk_class: RiskClass::Low,
+        })
+    }
+    fn description(&self) -> &str {
+        "noop"
+    }
+    fn input_schema(&self) -> Value {
+        json!({"type": "object"})
+    }
+    fn execute(&self, _inv: &ToolInvocation<'_>) -> Result<ToolOutcome> {
+        self.counter.fetch_add(1, Ordering::SeqCst);
+        Ok(ToolOutcome {
+            delta: StructuredDelta(vec![]),
+            observation: Observation {
+                tool: "noop".into(),
+                output: json!(null),
+                latency_ms: 0,
+            },
+        })
+    }
+}
+
+fn writ_with_parent(parent: Option<WritId>) -> Writ {
+    let issuer = generate_signing_key();
+    let subject = generate_signing_key();
+    sign_writ(&issuer, &subject, parent)
+}
+
+fn sign_writ(issuer: &SigningKey, subject: &SigningKey, parent: Option<WritId>) -> Writ {
+    Writ::sign(
+        WritBody {
+            issuer: "root".into(),
+            issuer_pubkey: public_key_of(issuer),
+            subject: "agent".into(),
+            subject_pubkey: public_key_of(subject),
+            parent,
+            tenant_id: String::new(),
+            tool_scopes: vec![ToolPattern::exact("noop")],
+            budget: Budget {
+                tokens: 10_000,
+                tool_calls: 100,
+                wall_clock_ms: 600_000,
+                usd_millicents: 0,
+            },
+            effect_ceiling: EffectCeiling::read_write_local(),
+            time_window: TimeWindow {
+                not_before: 0,
+                expires_at: u64::MAX,
+            },
+            delegation: DelegationBounds {
+                max_depth: 1,
+                may_subdivide: false,
+            },
+        },
+        issuer,
+    )
+    .unwrap()
+}
+
+fn act(nonce: u8) -> CoreIntent {
+    CoreIntent::new(IntentBody {
+        parent_commit: None,
+        author: "test".into(),
+        kind: IntentKind::Act,
+        target: "noop".into(),
+        args: json!({}),
+        rationale: "revocation".into(),
+        nonce: [nonce; 16],
+    })
+    .unwrap()
+}
+
+fn runtime_with_noop() -> (Runtime, Arc<AtomicUsize>) {
+    let counter = Arc::new(AtomicUsize::new(0));
+    let mut tools = ToolRegistry::new();
+    tools.register(NoopTool {
+        counter: Arc::clone(&counter),
+    });
+    let runtime = Runtime::new(
+        Ledger::open_in_memory().unwrap(),
+        tools,
+        PolicyEngine::new().with(WritAuthorityPolicy),
+    );
+    (runtime, counter)
+}
+
+#[test]
+fn revoked_writ_is_rejected_before_execution() {
+    let (runtime, counter) = runtime_with_noop();
+    let writ = writ_with_parent(None);
+    let run = runtime.create_run("revoke", b"revoke").unwrap();
+
+    // Works before revocation.
+    assert!(matches!(
+        run.submit(act(1), &writ).unwrap(),
+        Step::Committed(_)
+    ));
+    assert_eq!(counter.load(Ordering::SeqCst), 1);
+
+    // Pull the capability.
+    runtime.revoke_writ(writ.id);
+
+    // Now rejected — and the tool must not run again.
+    match run.submit(act(2), &writ).unwrap() {
+        Step::Rejected(reason) => assert!(
+            reason.to_string().contains("revoked"),
+            "expected a revocation reason, got: {reason}"
+        ),
+        other => panic!("expected rejection after revocation, got {other:?}"),
+    }
+    assert_eq!(counter.load(Ordering::SeqCst), 1, "no execution under revoked writ");
+}
+
+#[test]
+fn revoking_parent_voids_child_writ() {
+    let (runtime, counter) = runtime_with_noop();
+    let parent_id = WritId(ContentHash::ZERO);
+    // A child writ that names `parent_id` as its parent.
+    let child = writ_with_parent(Some(parent_id));
+    let run = runtime.create_run("revoke-parent", b"revoke-parent").unwrap();
+
+    assert!(matches!(
+        run.submit(act(1), &child).unwrap(),
+        Step::Committed(_)
+    ));
+    assert_eq!(counter.load(Ordering::SeqCst), 1);
+
+    // Revoke the PARENT; the child must become void too.
+    runtime.revoke_writ(parent_id);
+
+    match run.submit(act(2), &child).unwrap() {
+        Step::Rejected(reason) => assert!(reason.to_string().contains("revoked")),
+        other => panic!("expected child rejection after parent revocation, got {other:?}"),
+    }
+    assert_eq!(counter.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn restore_reinstates_a_writ() {
+    let (runtime, counter) = runtime_with_noop();
+    let writ = writ_with_parent(None);
+    let run = runtime.create_run("restore", b"restore").unwrap();
+
+    runtime.revoke_writ(writ.id);
+    assert!(matches!(
+        run.submit(act(1), &writ).unwrap(),
+        Step::Rejected(_)
+    ));
+    assert_eq!(counter.load(Ordering::SeqCst), 0);
+
+    runtime.revocations.restore(&writ.id);
+    assert!(matches!(
+        run.submit(act(2), &writ).unwrap(),
+        Step::Committed(_)
+    ));
+    assert_eq!(counter.load(Ordering::SeqCst), 1);
+}


### PR DESCRIPTION
Adds **writ revocation** — the next item on the hardening roadmap.

A validly-signed, unexpired writ can be pulled at runtime. Compiler **stage 2b**
rejects any submission whose writ id (or whose immediate parent id) is revoked,
as `AuthorityVoid`, before the tool runs. Revocation lives in the pure compile
path (passed via `CompileContext.revoked`), preserving "all authority checks
happen in the compiler."

## Changes
- `thymos-compiler`: `CompileContext.revoked` + stage 2b revocation check (one-level parent cascade).
- `thymos-runtime`: `Revocations` registry (`Arc<RwLock<HashSet<WritId>>>`), `Runtime::revoke_writ`, and `Revocations::{revoke,restore,is_revoked,snapshot}`; `submit` passes a snapshot into the compile context.

## Tests
`thymos-runtime/tests/revocation.rs`: rejects before execution; revoking a parent voids the child; restore reinstates. Full suite **201 passed / 0 failed / 0 warnings**.

## Not included (deliberate)
Anti-replay **nonce** on `WritBody` is a writ wire-format break and is tracked for v0.2.0 as its own change — not piggybacked onto the writ format just shipped in v0.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)