### PR TITLE
stabilize: freeze proposal-contract v1 (remove experimental routing_evidence)

### DIFF
--- a/docs/rfcs/proposal-contract-v1.md
+++ b/docs/rfcs/proposal-contract-v1.md
@@ -6,16 +6,17 @@ Proposal Contract v1
 
 ## Status
 
-Accepted
+Stable (v1). The proposal contract is frozen: the `Proposal` / `ProposalBody` /
+`ProposalStatus` shapes below are the stable surface downstreams may depend on.
 
 ## Summary
 
-This RFC formalizes the proposal contract as it exists after Phase I stabilization.
-It specifies the canonical `Proposal` type, the `ProposalStatus` enumeration, the
-`RoutingEvidence` supplementary field, and the content-addressing rules for
-`ProposalId`. It affects runtime semantics (compilation output), ledger
-compatibility (serialized `PendingApproval` payloads), and provider semantics
-(routing metadata boundary). It does not affect replay correctness for entries
+This RFC specifies the stable v1 proposal contract: the canonical `Proposal`
+type, the `ProposalStatus` enumeration, and the content-addressing rules for
+`ProposalId`. A `Proposal` is fully content-addressed — it carries only its id
+and its body, with no experimental or provider-supplied fields. It affects
+runtime semantics (compilation output) and ledger compatibility (serialized
+`PendingApproval` payloads). It does not affect replay correctness for entries
 that contain no `PendingApproval` payloads.
 
 ## Motivation
@@ -29,11 +30,11 @@ data; the `Rejected` variant had no reason field. Both mismatched the grammar:
 Status := Staged | Suspended { channel, reason } | Rejected { reason }
 ```
 
-Additionally, the specification allows providers to attach routing metadata that
-influences capability registry resolution (step 5 of compilation) without
-granting additional authority. No type existed to carry this metadata, leaving
-providers with no protocol-compliant way to communicate routing decisions to the
-compiler.
+An earlier draft of this RFC also proposed an experimental `routing_evidence`
+field for provider routing metadata. It was never read by the runtime and was
+removed before stabilization (see "Proposed Semantics") so the v1 contract has
+no inert fields on its compatibility surface. Provider routing metadata, if ever
+needed, will be introduced by a separate RFC.
 
 ## Current Semantics
 
@@ -85,57 +86,37 @@ pub struct ProposalBody {
 pub struct Proposal {
     pub id: ProposalId,
     pub body: ProposalBody,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub routing_evidence: Option<RoutingEvidence>,
-}
-
-pub struct RoutingEvidence {
-    pub decision_hash: String,
-    pub selected: String,
-    pub alternatives: Vec<String>,
-    pub confidence: u32,           // basis points, 0–10000
-    pub reason_codes: Vec<String>,
-    pub latency_estimate_ms: u64,
-    pub cost_estimate_usd: u64,    // USD millicents
-    pub fallback_hint: Option<FallbackHint>,
-}
-
-pub struct FallbackHint {
-    pub provider: String,
-    pub model: Option<String>,
-    pub reason: String,
 }
 ```
 
-`ProposalId` remains `content_hash(body)`. `routing_evidence` is NOT part of
-`ProposalBody` and therefore does NOT affect `ProposalId`.
+`ProposalId` remains `content_hash(body)`. A `Proposal` carries exactly its
+content-addressed id and its body — nothing else. There is no provider-supplied
+or experimental field, so the contract is fully content-addressed and stable.
 
-The `Suspended` variant now embeds `channel` and `reason` directly in the
-status, matching Section 2. The compiler populates both fields from the policy
-engine's `RequireApproval` decision; the runtime reads them from the status
-when appending `PendingApproval` ledger entries.
+The `Suspended` variant embeds `channel` and `reason` directly in the status,
+matching Section 2. The compiler populates both fields from the policy engine's
+`RequireApproval` decision; the runtime reads them from the status when
+appending `PendingApproval` ledger entries.
 
-`confidence` and `cost_estimate_usd` use fixed-point integers to avoid
-floating-point values in canonical data paths (Section 10 requires deterministic
-serialization).
+> **Provider routing metadata** (previously a proposed experimental
+> `routing_evidence` field) is intentionally **not** part of this stable v1
+> contract. It was removed to avoid shipping an inert field on the
+> compatibility surface. If a future need arises to surface provider routing
+> decisions, it must be introduced by a separate RFC — outside `ProposalBody`,
+> signed, and never able to influence authority, policy, budget, or replay.
 
 ## Invariants
 
 - `ProposalId = blake3(canonical_json(ProposalBody))`.
-- `routing_evidence` MUST NOT influence ProposalId.
-- `routing_evidence` MUST NOT influence writ authority, budget checks, policy
-  decisions, or ledger entry hashes for any entry kind.
-- `routing_evidence` MAY influence step 5 (capability registry resolution) of
-  the compilation pipeline, and only step 5.
-- Provider adapters MUST NOT use `routing_evidence` to grant additional tool
-  authority, bypass policy, or mutate ledger state.
+- A `Proposal` contains only `id` and `body`; there are no fields outside the
+  content-addressed body.
 - `ProposalStatus::Suspended` MUST carry the same `channel` and `reason` values
   that appear in the `PendingApproval` ledger entry.
 - `ProposalStatus::Rejected::reason` is a human-readable summary string; it is
   distinct from `RejectionReason`, which is the structured enum used in
   `Rejection` ledger entries.
 - Floating-point values MUST NOT appear in any type that is part of a canonical
-  payload hash input. `RoutingEvidence` fields use fixed-point integers.
+  payload hash input.
 
 ## Ledger Impact
 
@@ -183,11 +164,9 @@ rather than being passed out-of-band from the compiler.
 Providers that implement the `Cognition` trait are unaffected. The trait
 signature `step(ctx) -> Result<CognitionStep>` does not change.
 
-Providers that supply routing metadata MAY attach a `RoutingEvidence` value to
-the `Proposal` via `Proposal::with_routing_evidence`. They MUST NOT use this
-field to influence compilation authority. The runtime MUST ignore
-`routing_evidence` for all purposes other than step 5 capability registry
-resolution.
+Providers cannot attach metadata to a `Proposal`: the contract has no
+provider-supplied field. Provider routing decisions, if ever surfaced, will be
+specified by a separate RFC and carried outside this contract.
 
 ## Tool Contract Impact
 
@@ -211,74 +190,48 @@ affect this interface.
 
 ## Security Considerations
 
-- `routing_evidence` is unauthenticated supplementary data. A malicious or
-  misconfigured provider could supply false routing metadata. The runtime MUST
-  enforce that `routing_evidence` cannot influence authority, budget, policy, or
-  ledger write access — only step 5 registry resolution.
-- `decision_hash` in `RoutingEvidence` is informational only. The runtime MUST
-  NOT use it as an authority proof.
-- `ProposalId` continues to be derived from `ProposalBody` only. A provider
-  cannot influence `ProposalId` by manipulating `routing_evidence`.
+- `ProposalId` is derived from `ProposalBody` only and the body contains no
+  provider-supplied data, so a provider cannot influence a proposal's identity.
 - The `Rejected { reason }` string in `ProposalStatus` is a human-readable
   summary and MUST NOT be used for authorization or policy decisions.
+- There is no unauthenticated metadata on the contract: removing the experimental
+  `routing_evidence` field eliminates a class of provider-supplied data that
+  would otherwise have to be carefully prevented from influencing authority.
 
 ## Alternatives
 
-**Embed `routing_evidence` in `ProposalBody`**: Rejected because this would
-include routing metadata in `ProposalId`, making provider routing decisions part
-of the proposal's canonical identity. This would couple provider behavior to the
-hash chain and complicate determinism guarantees.
+**Embed routing/provider metadata in `ProposalBody`**: Rejected because it would
+include provider routing decisions in `ProposalId`, coupling nondeterministic
+provider behavior to the proposal's canonical identity and the hash chain.
+
+**Keep an experimental `routing_evidence` field on `Proposal` (outside the
+body)**: Rejected for v1. The runtime never read it, yet it sat on the
+`PendingApproval` wire format and carried unresolved signing/storage questions —
+an inert field on the stability surface. Removed; reintroduce by RFC only when a
+concrete consumer and a signed design exist.
 
 **Use `channel` and `reason` as separate fields on `Proposal` alongside
 `status`**: Rejected because it duplicates data already carried by the status
 variant. Embedding in `Suspended { channel, reason }` keeps the status
 self-describing.
 
-**Floating-point `confidence` and `cost_estimate_usd`**: Rejected because
-floating-point JSON serialization is not guaranteed to be identical across
-platforms or Rust releases. Fixed-point integers (basis points, millicents)
-are deterministic and follow the pattern established by `Budget` fields.
-
 ## Test Plan
 
 - [x] `proposal_id_is_content_addressed`: same `ProposalBody` inputs → same ID
 - [x] `different_tool_yields_different_id`: tool name change → different ID
-- [x] `routing_evidence_does_not_affect_id`: presence of evidence → same ID
 - [x] `proposal_status_staged_serializes`: `{"kind":"staged"}`
 - [x] `proposal_status_suspended_serializes`: embeds channel and reason
 - [x] `proposal_status_rejected_serializes`: embeds reason
 - [x] `proposal_status_roundtrips`: all three variants survive serde roundtrip
+- [x] `proposal_id_is_stable_across_serialization_boundary`: serialize → deserialize → recompute id is stable
 - [x] Compiler: `RequireApproval` decision → `Suspended { channel, reason }` status
-- [x] Integration: `PendingApproval` ledger entry round-trips with new status format
+- [x] Integration: `PendingApproval` ledger entry round-trips with the status format
 - [x] Replay: pre-RFC ledger with `PendingApproval` entries returns a clear
   deserialization error rather than silently misfiring
 
 ## Unresolved Questions
 
-These questions do not affect **replay correctness**: `routing_evidence` lives on
-`Proposal` (not `ProposalBody`), is excluded from `ProposalId`, is not part of any
-commit delta, and is never folded by the replay verifier.
-
-They are **not** compatibility-neutral, however. `routing_evidence` is serialized
-inside `PendingApproval` ledger payloads, so its on-wire shape is part of the
-ledger compatibility surface, and answering either question later will change that
-wire format. For that reason `routing_evidence` is marked **experimental** and is
-**excluded from the v1 compatibility guarantee** (see `thymos-core`
-`Proposal::routing_evidence`). It is also currently **inert** — the runtime does
-not read it.
-
-- Should `routing_evidence` be signed by the provider to provide an audit trail?
-  Until resolved, `routing_evidence` is unauthenticated (its `decision_hash` is
-  provider-self-asserted) and MUST NOT be surfaced as a trustworthy audit
-  artifact. Adding a signature will add fields and break the `PendingApproval`
-  wire format. (Phase II concern, requires RFC.)
-- Should the ledger store `routing_evidence` separately from the `Proposal` to
-  avoid bloating `PendingApproval` payloads with supplementary data? Moving it
-  will also break the `PendingApproval` wire format. (Phase III ledger segment
-  format RFC.)
-- If `routing_evidence` is ever allowed to influence step 5 (capability registry
-  resolution), an unauthenticated provider field would influence execution. That
-  must be resolved (at minimum, signing) **before** any step-5 use is enabled.
-
-A v1 "stable" promise MUST NOT silently cover `routing_evidence` until the
-signing and storage questions are closed.
+None. The v1 contract is stable: `Proposal` carries only `id` and `body`, with
+no experimental or provider-supplied fields. Provider routing metadata is
+explicitly deferred to a future RFC and is not part of this contract's
+compatibility surface.

--- a/thymos/crates/thymos-core/src/lib.rs
+++ b/thymos/crates/thymos-core/src/lib.rs
@@ -28,8 +28,8 @@ pub use hash::{canonical_json_bytes, content_hash, ContentHash};
 pub use ids::{CommitId, IntentId, LedgerEntryId, ProposalId, TrajectoryId, WritId};
 pub use intent::{Intent, IntentBody, IntentKind};
 pub use proposal::{
-    ExecutionPlan, FallbackHint, PolicyDecision, PolicyTrace, Proposal, ProposalBody,
-    ProposalStatus, RejectionReason, RoutingEvidence,
+    ExecutionPlan, PolicyDecision, PolicyTrace, Proposal, ProposalBody, ProposalStatus,
+    RejectionReason,
 };
 pub use world::{ResourceKey, World};
 pub use writ::{Budget, EffectCeiling, ToolPattern, Writ, WritBody};

--- a/thymos/crates/thymos-core/src/proposal.rs
+++ b/thymos/crates/thymos-core/src/proposal.rs
@@ -2,10 +2,11 @@
 //!
 //! Spec reference: Section 2 (Execution Grammar), Section 3 (Compilation).
 //!
-//! ProposalId is content-addressed from the canonical hash of ProposalBody.
-//! routing_evidence lives on Proposal, NOT inside ProposalBody, so it does
-//! not affect ProposalId. It is supplementary data that influences only
-//! step 5 (capability registry resolution) per Section 3.
+//! `ProposalId` is content-addressed from the canonical hash of `ProposalBody`.
+//! The proposal contract is **v1-stable** (see `docs/rfcs/proposal-contract-v1.md`):
+//! it carries exactly the fields that define the action and its authorization,
+//! with no experimental or provider-supplied metadata. Provider routing metadata
+//! is deferred to a future RFC and is intentionally not part of this contract.
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -20,42 +21,13 @@ use crate::ids::{IntentId, ProposalId, WritId};
 pub struct Proposal {
     pub id: ProposalId,
     pub body: ProposalBody,
-    /// EXPERIMENTAL — excluded from any v1 compatibility guarantee.
-    ///
-    /// Supplementary routing metadata. Never affects ProposalId, authority,
-    /// policy, or replay semantics. See Section 9 for the provider authority
-    /// boundary.
-    ///
-    /// NOTE (Phase I): the runtime does **not** read this field. It is inert.
-    /// Two unresolved questions must be answered before it can be relied upon
-    /// (see RFC `proposal-contract-v1.md`, "Unresolved Questions"):
-    ///   1. Signing — until resolved, `routing_evidence` is unauthenticated and
-    ///      MUST NOT be surfaced as a trustworthy audit artifact. Adding a
-    ///      signature will change the `PendingApproval` wire format.
-    ///   2. Storage — moving it to a separate ledger segment will also change
-    ///      the `PendingApproval` wire format.
-    /// Because it is serialized inside `PendingApproval` payloads, its on-wire
-    /// shape is part of the ledger compatibility surface. Treat it as unstable
-    /// until both questions are closed; prefer not depending on it in v1.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub routing_evidence: Option<RoutingEvidence>,
 }
 
 impl Proposal {
-    /// Construct a Proposal from a body. The id is the content-hash of body;
-    /// routing_evidence is not hashed.
+    /// Construct a Proposal from a body. The id is the content-hash of body.
     pub fn new(body: ProposalBody) -> Result<Self> {
         let id = ProposalId(content_hash(&body)?);
-        Ok(Proposal {
-            id,
-            body,
-            routing_evidence: None,
-        })
-    }
-
-    pub fn with_routing_evidence(mut self, evidence: RoutingEvidence) -> Self {
-        self.routing_evidence = Some(evidence);
-        self
+        Ok(Proposal { id, body })
     }
 }
 
@@ -141,43 +113,6 @@ impl std::fmt::Display for RejectionReason {
     }
 }
 
-// ── RoutingEvidence ───────────────────────────────────────────────────────────
-//
-// Supplementary metadata from the provider routing layer. Lives on Proposal
-// (not ProposalBody) and MUST NOT affect authority, policy, or ledger hashes.
-// Influences only compiler step 5 (capability registry resolution).
-
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct RoutingEvidence {
-    /// Hex-encoded content digest of the full routing decision payload, for
-    /// audit. The runtime treats this as opaque; the project's canonical hash
-    /// is BLAKE3 (see `crate::hash`), but providers MAY use any hex digest as
-    /// long as it is stable across their routing decisions.
-    pub decision_hash: String,
-    /// The provider:model string the router selected.
-    pub selected: String,
-    /// Other provider:model strings considered but not selected.
-    pub alternatives: Vec<String>,
-    /// Confidence in the selection, in basis points (0–10000 = 0.00%–100.00%).
-    /// Fixed-point to avoid floating-point in canonical data paths.
-    pub confidence: u32,
-    /// Machine-readable reason codes explaining the routing decision.
-    pub reason_codes: Vec<String>,
-    /// Estimated provider round-trip latency in milliseconds.
-    pub latency_estimate_ms: u64,
-    /// Estimated cost in USD millicents (1 USD = 100_000 millicents).
-    pub cost_estimate_usd: u64,
-    /// Fallback provider hint if the selected provider is unavailable.
-    pub fallback_hint: Option<FallbackHint>,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct FallbackHint {
-    pub provider: String,
-    pub model: Option<String>,
-    pub reason: String,
-}
-
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -216,32 +151,6 @@ mod tests {
         let p1 = Proposal::new(make_body("kv_set")).unwrap();
         let p2 = Proposal::new(make_body("kv_del")).unwrap();
         assert_ne!(p1.id, p2.id);
-    }
-
-    #[test]
-    fn routing_evidence_does_not_affect_id() {
-        let body = make_body("kv_set");
-        let p_no_evidence = Proposal::new(body.clone()).unwrap();
-        let p_with_evidence = Proposal::new(body)
-            .unwrap()
-            .with_routing_evidence(RoutingEvidence {
-                decision_hash: "abc123".into(),
-                selected: "anthropic:claude-opus-4-7".into(),
-                alternatives: vec!["openai:gpt-4o".into()],
-                confidence: 9500,
-                reason_codes: vec!["cost_optimal".into()],
-                latency_estimate_ms: 800,
-                cost_estimate_usd: 42,
-                fallback_hint: Some(FallbackHint {
-                    provider: "openai".into(),
-                    model: Some("gpt-4o".into()),
-                    reason: "primary overloaded".into(),
-                }),
-            });
-        assert_eq!(
-            p_no_evidence.id, p_with_evidence.id,
-            "routing_evidence must not affect ProposalId"
-        );
     }
 
     #[test]
@@ -310,35 +219,6 @@ mod tests {
             "ProposalId must be identical after serialize → deserialize → recompute"
         );
         assert_eq!(original.id, round_tripped.id);
-    }
-
-    #[test]
-    fn proposal_id_is_stable_with_routing_evidence_round_trip() {
-        // The same property must hold even when routing_evidence is attached
-        // — it is serialized along with the Proposal but excluded from the id.
-        let body = make_body("kv_set");
-        let original = Proposal::new(body)
-            .unwrap()
-            .with_routing_evidence(RoutingEvidence {
-                decision_hash: "deadbeef".into(),
-                selected: "anthropic:opus".into(),
-                alternatives: vec![],
-                confidence: 8800,
-                reason_codes: vec!["primary".into()],
-                latency_estimate_ms: 200,
-                cost_estimate_usd: 17,
-                fallback_hint: None,
-            });
-
-        let json = serde_json::to_string(&original).unwrap();
-        let round_tripped: Proposal = serde_json::from_str(&json).unwrap();
-
-        let recomputed_id = ProposalId(content_hash(&round_tripped.body).unwrap());
-        assert_eq!(
-            original.id, recomputed_id,
-            "routing_evidence must not affect ProposalId after roundtrip"
-        );
-        assert_eq!(original.routing_evidence, round_tripped.routing_evidence);
     }
 
     #[test]


### PR DESCRIPTION
Stabilizes the proposal contract so downstreams (wisepick) can depend on a frozen v1.

## Change
- Removes the inert experimental `routing_evidence` field (+ `RoutingEvidence`/`FallbackHint` types and `Proposal::with_routing_evidence`). A `Proposal` now carries only `id` + `body` — fully content-addressed, no experimental or provider-supplied fields.
- RFC `proposal-contract-v1.md`: **Status → Stable (v1)**, routing_evidence removed from the spec, **Unresolved Questions → none**, provider routing metadata explicitly deferred to a future RFC.

## Compatibility
Wire-compatible: the field was `Option` + `skip_serializing_if = "Option::is_none"`, so existing `PendingApproval` payloads without it still deserialize, and new ones simply omit it. No ledger migration needed.

## Tests
199 pass, 0 warnings (the two `routing_evidence_*` tests were removed with the field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)