### PR TITLE
feat: compensation / saga rollback (Compensation & Saga v1) + bump to v0.2.0

### DIFF
--- a/docs/rfcs/compensation-saga-v1.md
+++ b/docs/rfcs/compensation-saga-v1.md
@@ -6,9 +6,22 @@ Compensation & Saga Rollback v1
 
 ## Status
 
-Draft — design exploration only. No implementation is authorized by this
-document. It captures the problem, options, and a recommended direction for
-review before any code is written.
+Accepted — MVP implemented (Option A). Shipped:
+
+- `ToolContract::compensable()` + `ToolContract::compensate(observation, world)`.
+- `CommitBody.compensates: Option<CommitId>` (backward-compatible via
+  `skip_serializing_if`) tagging each rollback commit with the commit it undoes.
+- `Run::compensate_to(target, writ)`: undoes committed steps after `target`,
+  newest-first; each compensation is appended as a normal commit (recorded,
+  replayable); halts if any step's tool is not compensable; idempotent
+  (already-compensated steps and compensation commits are skipped); runs under
+  the supplied writ (authorizes the tool, must not be revoked).
+
+Deferred (see Unresolved Questions): declaring `compensable` in
+`ToolContractMeta` so the effect gate can *require approval* for an
+irreversible-and-uncompensable tool; cross-trajectory/delegated-child
+compensation; compensating past an expired writ window; partial-failure policy
+beyond "halt and surface".
 
 ## Summary
 

--- a/thymos/Cargo.lock
+++ b/thymos/Cargo.lock
@@ -2699,7 +2699,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-cli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "axum 0.8.9",
  "clap",
@@ -2718,7 +2718,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-client"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "axum-test",
  "reqwest",
@@ -2732,7 +2732,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-cognition"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -2746,7 +2746,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-compiler"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2757,7 +2757,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "blake3",
  "ed25519-dalek",
@@ -2770,7 +2770,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-ledger"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "blake3",
  "deadpool-postgres",
@@ -2786,7 +2786,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-marketplace"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "blake3",
  "hex",
@@ -2799,7 +2799,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-policy"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2808,7 +2808,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-runtime"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "serde",
@@ -2825,7 +2825,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-server"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2858,7 +2858,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-tools"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "blake3",
  "reqwest",
@@ -2871,7 +2871,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-worker"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde_json",
  "thymos-tools",

--- a/thymos/Cargo.toml
+++ b/thymos/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 rust-version = "1.80"

--- a/thymos/crates/thymos-core/src/commit.rs
+++ b/thymos/crates/thymos-core/src/commit.rs
@@ -95,6 +95,12 @@ pub struct CommitBody {
     pub policy_set_hash: String,
     /// Budget cost incurred by this commit (tool_calls, tokens, wall_clock_ms, usd).
     pub budget_cost: crate::writ::BudgetCost,
+    /// If this commit is a compensation (saga rollback), the id of the commit it
+    /// undoes. `None` for ordinary forward commits. Backward-compatible:
+    /// `skip_serializing_if` means forward commits serialize (and hash) exactly
+    /// as before, so existing ledgers are unaffected.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub compensates: Option<CommitId>,
     /// ed25519 signature over `canonical_json(body_without_signature)`,
     /// hex-encoded. `None` for unsigned commits; populated by
     /// [`Commit::new_signed`] and checked by [`Commit::verify_signature`].
@@ -131,6 +137,7 @@ mod tests {
             compiler_version: "test".into(),
             policy_set_hash: String::new(),
             budget_cost: crate::writ::BudgetCost::default(),
+            compensates: None,
             signature: None,
         }
     }

--- a/thymos/crates/thymos-core/src/ids.rs
+++ b/thymos/crates/thymos-core/src/ids.rs
@@ -166,6 +166,7 @@ mod tests {
             compiler_version: COMPILER_VERSION.into(),
             policy_set_hash: String::new(),
             budget_cost: BudgetCost::default(),
+            compensates: None,
             signature: None,
         }
     }

--- a/thymos/crates/thymos-ledger/src/anchor.rs
+++ b/thymos/crates/thymos-ledger/src/anchor.rs
@@ -119,6 +119,7 @@ mod tests {
             compiler_version: COMPILER_VERSION.into(),
             policy_set_hash: String::new(),
             budget_cost: thymos_core::writ::BudgetCost::default(),
+            compensates: None,
             signature: None,
         };
         ledger.append_commit(Commit::new(body).unwrap()).unwrap();

--- a/thymos/crates/thymos-ledger/src/lib.rs
+++ b/thymos/crates/thymos-ledger/src/lib.rs
@@ -270,6 +270,7 @@ mod tests {
             compiler_version: COMPILER_VERSION.into(),
             policy_set_hash: String::new(),
             budget_cost: thymos_core::writ::BudgetCost::default(),
+            compensates: None,
             signature: None,
         };
         Commit::new(body).unwrap()
@@ -363,6 +364,7 @@ mod tests {
                     compiler_version: COMPILER_VERSION.into(),
                     policy_set_hash: String::new(),
                     budget_cost: thymos_core::writ::BudgetCost::default(),
+                    compensates: None,
                     signature: None,
                 };
                 let commit = Commit::new(body).unwrap();

--- a/thymos/crates/thymos-ledger/src/replay.rs
+++ b/thymos/crates/thymos-ledger/src/replay.rs
@@ -210,6 +210,7 @@ mod tests {
             compiler_version: COMPILER_VERSION.into(),
             policy_set_hash: String::new(),
             budget_cost: thymos_core::writ::BudgetCost::default(),
+            compensates: None,
             signature: None,
         };
         let commit = Commit::new(body).unwrap();
@@ -296,6 +297,7 @@ mod tests {
             compiler_version: COMPILER_VERSION.into(),
             policy_set_hash: String::new(),
             budget_cost: thymos_core::writ::BudgetCost::default(),
+            compensates: None,
             signature: None,
         };
         let commit = Commit::new_signed(body, sk).unwrap();
@@ -401,6 +403,7 @@ mod bench_tests {
             compiler_version: COMPILER_VERSION.into(),
             policy_set_hash: String::new(),
             budget_cost: thymos_core::writ::BudgetCost::default(),
+            compensates: None,
             signature: None,
         };
         Commit::new(body).unwrap()

--- a/thymos/crates/thymos-runtime/src/lib.rs
+++ b/thymos/crates/thymos-runtime/src/lib.rs
@@ -699,6 +699,7 @@ impl<'a> Run<'a> {
                     compiler_version: COMPILER_VERSION.into(),
                     policy_set_hash: self.runtime.policy.policy_set_hash(),
                     budget_cost,
+                    compensates: None,
                     signature: None,
                 };
                 let commit = self.runtime.build_commit(commit_body)?;
@@ -1011,6 +1012,7 @@ impl<'a> Run<'a> {
             compiler_version: COMPILER_VERSION.into(),
             policy_set_hash: self.runtime.policy.policy_set_hash(),
             budget_cost,
+            compensates: None,
             signature: None,
         };
         let commit = self.runtime.build_commit(commit_body)?;
@@ -1028,6 +1030,129 @@ impl<'a> Run<'a> {
             },
         );
         Ok(Step::Committed(committed_id))
+    }
+
+    /// Saga rollback: compensate every committed step *after* `target` in this
+    /// trajectory, newest first, by invoking each tool's `compensate`. Each
+    /// compensation is appended as a normal commit tagged with `compensates =
+    /// Some(original_id)`, so the rollback is itself recorded and replayable.
+    ///
+    /// Behavior:
+    /// - Halts with an error if any step's tool is not compensable (the RFC's
+    ///   "manual reconciliation required" — never a partial silent rollback).
+    /// - Idempotent: a step that already has a compensation commit is skipped.
+    /// - Runs under `writ`; the writ must authorize the tool and not be revoked.
+    ///
+    /// Returns the ids of the compensation commits, in the order applied.
+    pub fn compensate_to(
+        &self,
+        target: CommitId,
+        writ: &thymos_core::writ::Writ,
+    ) -> Result<Vec<CommitId>> {
+        if self.runtime.revocations.is_revoked(&writ.id) {
+            return Err(Error::AuthorityVoid(format!(
+                "writ {} is revoked; cannot compensate",
+                writ.id
+            )));
+        }
+
+        let entries = self.runtime.ledger.entries(self.trajectory_id)?;
+
+        // Sequence of the target entry. Matched by id against any entry kind so
+        // callers can roll back to the root (seq 0) or to a specific commit.
+        let target_seq = entries
+            .iter()
+            .find_map(|e| if e.id == target.0 { Some(e.seq) } else { None })
+            .ok_or_else(|| {
+                Error::Other(format!("target {target} not found in trajectory"))
+            })?;
+
+        // Set of commits that already have a compensation, so re-running is a
+        // no-op for those.
+        let already_compensated: std::collections::HashSet<CommitId> = entries
+            .iter()
+            .filter_map(|e| match &e.payload {
+                EntryPayload::Commit(c) => c.body.compensates,
+                _ => None,
+            })
+            .collect();
+
+        // Commits strictly after the target, newest first. Compensation
+        // commits (those that already carry `compensates`) are never themselves
+        // compensated — that would undo a rollback.
+        let mut to_undo: Vec<Commit> = entries
+            .iter()
+            .filter_map(|e| match &e.payload {
+                EntryPayload::Commit(c) if e.seq > target_seq && c.body.compensates.is_none() => {
+                    Some(c.clone())
+                }
+                _ => None,
+            })
+            .collect();
+        to_undo.reverse();
+
+        let mut compensation_ids = Vec::new();
+        for original in to_undo {
+            if already_compensated.contains(&original.id) {
+                continue;
+            }
+            let observation = original.body.observations.first().cloned().ok_or_else(|| {
+                Error::Other(format!("commit {} has no observation to compensate", original.id))
+            })?;
+            let tool_name = observation.tool.clone();
+
+            if !writ.authorizes_tool(&tool_name) {
+                return Err(Error::AuthorityVoid(format!(
+                    "writ does not authorize tool '{tool_name}' for compensation"
+                )));
+            }
+            let tool = self.runtime.tools.get(&tool_name)?;
+            if !tool.compensable() {
+                return Err(Error::Other(format!(
+                    "cannot roll back commit {}: tool '{tool_name}' is not compensable; manual reconciliation required",
+                    original.id
+                )));
+            }
+
+            // Project the current world (reflecting any compensations already
+            // applied in this loop) and ask the tool to undo its effect.
+            let world = self.project_world()?;
+            let mut outcome = tool
+                .compensate(&observation, &world)
+                .map_err(|e| Error::ToolExecution(e.to_string()))?;
+            outcome.observation.output =
+                self.runtime.redactor.redact(&outcome.observation.output);
+
+            let (parent_hash, parent_seq) = self.runtime.ledger.head(self.trajectory_id)?;
+            let mut trial = world.clone();
+            trial.apply(&outcome.delta, CommitId(parent_hash))?;
+
+            let body = CommitBody {
+                parent: vec![CommitId(parent_hash)],
+                trajectory_id: self.trajectory_id,
+                proposal_id: original.body.proposal_id,
+                intent_id: original.body.intent_id,
+                writ_id: writ.id,
+                seq: parent_seq + 1,
+                delta: outcome.delta,
+                observations: vec![outcome.observation],
+                policy_trace: thymos_core::proposal::PolicyTrace {
+                    rules_evaluated: vec!["compensation".into()],
+                    decision: thymos_core::proposal::PolicyDecision::Permit,
+                },
+                compiler_version: COMPILER_VERSION.into(),
+                policy_set_hash: self.runtime.policy.policy_set_hash(),
+                budget_cost: BudgetCost::default(),
+                compensates: Some(original.id),
+                signature: None,
+            };
+            let commit = self.runtime.build_commit(body)?;
+            let commit_id = commit.id;
+            self.runtime.ledger.append_commit(commit)?;
+            compensation_ids.push(commit_id);
+        }
+
+        Ok(compensation_ids)
     }
 
     /// Summarize the trajectory for debugging/demo output.

--- a/thymos/crates/thymos-runtime/tests/compensation.rs
+++ b/thymos/crates/thymos-runtime/tests/compensation.rs
@@ -1,0 +1,245 @@
+//! Compensation / saga rollback: `Run::compensate_to` undoes committed steps
+//! after a target, newest-first, by invoking each tool's `compensate`. Each
+//! rollback is itself an appended commit tagged `compensates = Some(original)`.
+//! A non-compensable step halts the rollback (no silent partial undo).
+
+use serde_json::{json, Value};
+
+use thymos_core::{
+    commit::Observation,
+    delta::{DeltaOp, StructuredDelta},
+    error::{Error, Result},
+    world::ResourceKey,
+    CommitId,
+};
+use thymos_ledger::{EntryPayload, Ledger};
+use thymos_policy::{PolicyEngine, WritAuthorityPolicy};
+use thymos_runtime::{
+    generate_signing_key, public_key_of, Budget, CoreIntent, DelegationBounds, EffectCeiling,
+    IntentBody, IntentKind, Runtime, Step, TimeWindow, ToolPattern, Writ, WritBody,
+};
+use thymos_tools::{
+    EffectClass, RiskClass, ToolContract, ToolContractMeta, ToolInvocation, ToolOutcome,
+    ToolRegistry,
+};
+
+/// Creates a kv resource on the forward path; compensates by retracting it.
+struct ProvisionTool;
+impl ToolContract for ProvisionTool {
+    fn meta(&self) -> &ToolContractMeta {
+        static M: std::sync::OnceLock<ToolContractMeta> = std::sync::OnceLock::new();
+        M.get_or_init(|| ToolContractMeta {
+            name: "provision".into(),
+            version: "1.0.0".into(),
+            effect_class: EffectClass::Write,
+            risk_class: RiskClass::Medium,
+        })
+    }
+    fn description(&self) -> &str {
+        "provisions a resource (compensable)"
+    }
+    fn input_schema(&self) -> Value {
+        json!({"type": "object"})
+    }
+    fn execute(&self, inv: &ToolInvocation<'_>) -> Result<ToolOutcome> {
+        let id = inv
+            .args
+            .get("id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("resource")
+            .to_string();
+        Ok(ToolOutcome {
+            delta: StructuredDelta::single(DeltaOp::Create {
+                kind: "kv".into(),
+                id: id.clone(),
+                value: json!("active"),
+            }),
+            observation: Observation {
+                tool: "provision".into(),
+                output: json!({ "key": id }),
+                latency_ms: 0,
+            },
+        })
+    }
+    fn compensable(&self) -> bool {
+        true
+    }
+    fn compensate(
+        &self,
+        observation: &Observation,
+        world: &thymos_core::world::World,
+    ) -> Result<ToolOutcome> {
+        let key = observation
+            .output
+            .get("key")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| Error::Other("compensate: observation has no key".into()))?;
+        let version = world
+            .get(&ResourceKey::new("kv", key))
+            .map(|s| s.version)
+            .unwrap_or(1);
+        Ok(ToolOutcome {
+            delta: StructuredDelta::single(DeltaOp::Retract {
+                kind: "kv".into(),
+                id: key.into(),
+                expected_version: version,
+                reason: "compensated".into(),
+            }),
+            observation: Observation {
+                tool: "provision".into(),
+                output: json!({ "compensated": key }),
+                latency_ms: 0,
+            },
+        })
+    }
+}
+
+/// Forward-only tool with no compensation.
+struct OneWayTool;
+impl ToolContract for OneWayTool {
+    fn meta(&self) -> &ToolContractMeta {
+        static M: std::sync::OnceLock<ToolContractMeta> = std::sync::OnceLock::new();
+        M.get_or_init(|| ToolContractMeta {
+            name: "oneway".into(),
+            version: "1.0.0".into(),
+            effect_class: EffectClass::Write,
+            risk_class: RiskClass::Low,
+        })
+    }
+    fn description(&self) -> &str {
+        "not compensable"
+    }
+    fn input_schema(&self) -> Value {
+        json!({"type": "object"})
+    }
+    fn execute(&self, _inv: &ToolInvocation<'_>) -> Result<ToolOutcome> {
+        Ok(ToolOutcome {
+            delta: StructuredDelta(vec![]),
+            observation: Observation {
+                tool: "oneway".into(),
+                output: json!(null),
+                latency_ms: 0,
+            },
+        })
+    }
+}
+
+fn writ(tool: &str) -> Writ {
+    let issuer = generate_signing_key();
+    let subject = generate_signing_key();
+    Writ::sign(
+        WritBody {
+            issuer: "root".into(),
+            issuer_pubkey: public_key_of(&issuer),
+            subject: "agent".into(),
+            subject_pubkey: public_key_of(&subject),
+            nonce: [0u8; 16],
+            parent: None,
+            tenant_id: String::new(),
+            tool_scopes: vec![ToolPattern::exact(tool)],
+            budget: Budget {
+                tokens: 10_000,
+                tool_calls: 100,
+                wall_clock_ms: 600_000,
+                usd_millicents: 0,
+            },
+            effect_ceiling: EffectCeiling::read_write_local(),
+            time_window: TimeWindow {
+                not_before: 0,
+                expires_at: u64::MAX,
+            },
+            delegation: DelegationBounds {
+                max_depth: 1,
+                may_subdivide: false,
+            },
+        },
+        &issuer,
+    )
+    .unwrap()
+}
+
+fn act(tool: &str, id: &str, nonce: u8) -> CoreIntent {
+    CoreIntent::new(IntentBody {
+        parent_commit: None,
+        author: "test".into(),
+        kind: IntentKind::Act,
+        target: tool.into(),
+        args: json!({ "id": id }),
+        rationale: "saga".into(),
+        nonce: [nonce; 16],
+    })
+    .unwrap()
+}
+
+#[test]
+fn compensate_to_rolls_back_in_reverse_and_is_idempotent() {
+    let mut tools = ToolRegistry::new();
+    tools.register(ProvisionTool);
+    let runtime = Runtime::new(
+        Ledger::open_in_memory().unwrap(),
+        tools,
+        PolicyEngine::new().with(WritAuthorityPolicy),
+    );
+    let w = writ("provision");
+    let run = runtime.create_run("saga", b"saga").unwrap();
+    let traj = run.trajectory_id();
+
+    let root_id = CommitId(runtime.ledger.entries(traj).unwrap()[0].id);
+
+    let c1 = match run.submit(act("provision", "r1", 1), &w).unwrap() {
+        Step::Committed(id) => id,
+        o => panic!("c1 not committed: {o:?}"),
+    };
+    let c2 = match run.submit(act("provision", "r2", 2), &w).unwrap() {
+        Step::Committed(id) => id,
+        o => panic!("c2 not committed: {o:?}"),
+    };
+
+    // Roll everything back to the root.
+    let comps = run.compensate_to(root_id, &w).unwrap();
+    assert_eq!(comps.len(), 2, "two steps compensated");
+
+    // Newest-first: first compensation undoes c2, second undoes c1.
+    let links: Vec<Option<CommitId>> = runtime
+        .ledger
+        .entries(traj)
+        .unwrap()
+        .iter()
+        .filter_map(|e| match &e.payload {
+            EntryPayload::Commit(c) => Some(c.body.compensates),
+            _ => None,
+        })
+        .collect();
+    // commits in seq order: c1, c2, comp(c2), comp(c1)
+    assert_eq!(links, vec![None, None, Some(c2), Some(c1)]);
+
+    // Integrity holds after rollback, and the world reflects the retractions.
+    runtime.ledger.verify_integrity(traj).unwrap();
+
+    // Idempotent: re-running compensates nothing new.
+    let again = run.compensate_to(root_id, &w).unwrap();
+    assert!(again.is_empty(), "already-compensated steps are skipped");
+}
+
+#[test]
+fn compensate_halts_on_non_compensable_step() {
+    let mut tools = ToolRegistry::new();
+    tools.register(OneWayTool);
+    let runtime = Runtime::new(
+        Ledger::open_in_memory().unwrap(),
+        tools,
+        PolicyEngine::new().with(WritAuthorityPolicy),
+    );
+    let w = writ("oneway");
+    let run = runtime.create_run("saga2", b"saga2").unwrap();
+    let traj = run.trajectory_id();
+    let root_id = CommitId(runtime.ledger.entries(traj).unwrap()[0].id);
+
+    run.submit(act("oneway", "x", 1), &w).unwrap();
+
+    let err = run.compensate_to(root_id, &w).unwrap_err();
+    assert!(
+        err.to_string().contains("not compensable"),
+        "expected a non-compensable error, got: {err}"
+    );
+}

--- a/thymos/crates/thymos-runtime/tests/replay_safety.rs
+++ b/thymos/crates/thymos-runtime/tests/replay_safety.rs
@@ -237,6 +237,7 @@ fn replay_rejects_commit_with_empty_compiler_version() {
         compiler_version: "".into(), // ← the violation
         policy_set_hash: String::new(),
         budget_cost: thymos_core::writ::BudgetCost::default(),
+        compensates: None,
         signature: None,
     };
     let commit = Commit::new(body).unwrap();

--- a/thymos/crates/thymos-tools/src/lib.rs
+++ b/thymos/crates/thymos-tools/src/lib.rs
@@ -726,6 +726,28 @@ pub trait ToolContract: Send + Sync {
     ) -> Result<()> {
         Ok(())
     }
+
+    /// Whether this tool can compensate (undo) a previously committed effect.
+    /// Default `false`. Only compensable tools may participate in saga rollback
+    /// ([`Run::compensate_to`](../thymos_runtime/struct.Run.html)).
+    fn compensable(&self) -> bool {
+        false
+    }
+
+    /// Produce a compensating outcome that undoes a previously committed effect,
+    /// given that effect's recorded `observation` and the current `world`. The
+    /// returned delta + observation are appended as a normal (append-only)
+    /// compensation commit — the rollback is itself recorded and replayable.
+    ///
+    /// Compensators MUST be deterministic over `(observation, world)` and stay
+    /// within the authority of the writ that authorized the original step.
+    /// Default: not supported.
+    fn compensate(&self, _observation: &Observation, _world: &World) -> Result<ToolOutcome> {
+        Err(Error::Other(format!(
+            "tool '{}' does not support compensation",
+            self.meta().name
+        )))
+    }
 }
 
 #[derive(Default)]


### PR DESCRIPTION
Finishes **Compensation & Saga Rollback v1** (the last roadmap item) and bumps the workspace to **0.2.0**.

## What
- **Tools:** `ToolContract::compensable()` + `compensate(observation, world)` (default: unsupported). A compensable tool builds an undo delta from the original step's recorded observation + the current world.
- **Core:** `CommitBody.compensates: Option<CommitId>` tags a rollback commit with the commit it undoes. **Backward-compatible** (`skip_serializing_if`) — existing ledger commits hash/serialize unchanged.
- **Runtime:** `Run::compensate_to(target, writ)` undoes committed steps after `target`, **newest-first**; each compensation is an appended, recorded, replayable commit. Halts if any step's tool is not compensable (no silent partial rollback); **idempotent** (already-compensated steps and compensation commits are skipped); runs under the writ (authorizes the tool, not revoked).
- **Docs:** `compensation-saga-v1` RFC → **Accepted (MVP implemented)**, with deferred items listed.

## Version
`0.1.0 → 0.2.0`. This release line carries the breaking writ `nonce` (already merged) plus the new commit fields; tag `v0.2.0` after merge.

## Tests
210 pass, 0 warnings. New `compensation.rs`: reverse-order rollback + idempotency + `compensates` linkage; halt on a non-compensable step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)