### PR TITLE
feat(policy): declarative JSON policy language (policy-language-v1 MVP)

### DIFF
--- a/docs/rfcs/policy-language-v1.md
+++ b/docs/rfcs/policy-language-v1.md
@@ -6,9 +6,27 @@ Declarative Policy Language v1
 
 ## Status
 
-Draft — design exploration only. No implementation is authorized by this
-document. This stub exists to capture the problem, options, and a recommended
-direction for review before any code is written.
+Accepted — MVP implemented (Option A: minimal JSON predicate DSL). Shipped in
+`thymos-policy::json_policy`:
+
+- `JsonPolicySet::from_json(&str)` loads a bundle `{ name, version, rules[] }` at
+  runtime (no recompile) and implements the existing `Policy` trait, so it plugs
+  straight into `PolicyEngine::with(...)`.
+- Rule `when` is a closed predicate DSL: leaf `{field, op, value}` with ops
+  `eq/ne/gt/lt/gte/lte/contains/starts_with/in`, combined by `all`/`any`/`not`.
+  Field paths resolve over `(Intent, Writ)` (`intent.target`, `intent.kind`,
+  `intent.author`, `intent.args.<k>`, `writ.tenant_id`, `writ.subject`,
+  `writ.issuer`).
+- Decisions: `permit` / `deny{reason}` / `require_approval{channel,reason}`.
+- Evaluation is deterministic over `(Intent, Writ)` — no clock, RNG, network, or
+  floats in rule data — and fail-closed (a bundle that does not parse, or names
+  an unknown op, is rejected at load).
+- The bundle `name@version` already flows into `PolicyEngine::policy_set_hash`,
+  so a changed bundle is detected by replay drift checks.
+
+Deferred to a follow-up (see Unresolved Questions): **signed bundles**
+(ed25519 over the canonical bundle, verified at load), `world.*` accessors, and
+CEL/Rego (Options B/C) if the closed DSL proves too limited.
 
 ## Summary
 

--- a/thymos/crates/thymos-policy/src/json_policy.rs
+++ b/thymos/crates/thymos-policy/src/json_policy.rs
@@ -1,0 +1,317 @@
+//! Declarative JSON policy bundles — the implementation of the
+//! `policy-language-v1` RFC (Option A: a minimal, closed predicate DSL).
+//!
+//! A bundle is loadable at runtime (no recompile) and evaluates deterministically
+//! over `(Intent, Writ)` — no wall clock, no RNG, no floats in the rule data, no
+//! network — preserving the determinism the ledger and replay depend on. It
+//! plugs into the existing [`PolicyEngine`](crate::PolicyEngine) as one
+//! [`Policy`](crate::Policy).
+//!
+//! Example bundle:
+//! ```json
+//! {
+//!   "name": "ops.policy",
+//!   "version": "3",
+//!   "rules": [
+//!     { "name": "no-deletes",
+//!       "when": { "field": "intent.target", "op": "eq", "value": "kv_del" },
+//!       "decision": { "kind": "deny", "reason": "deletes are not allowed" } },
+//!     { "name": "big-spend-approval",
+//!       "when": { "field": "intent.args.amount", "op": "gt", "value": 1000 },
+//!       "decision": { "kind": "require_approval", "channel": "ops", "reason": "amount over 1000" } }
+//!   ]
+//! }
+//! ```
+//!
+//! Evaluation semantics: rules are tried in order; the **first rule whose
+//! `when` matches** decides (its `decision` is returned). If no rule matches,
+//! the bundle permits. A field path that does not resolve makes its leaf
+//! condition false.
+
+use serde::Deserialize;
+use serde_json::Value;
+
+use thymos_core::{intent::Intent, proposal::PolicyDecision, world::World, writ::Writ};
+
+use crate::Policy;
+
+/// A loaded, named set of declarative rules. Construct with
+/// [`JsonPolicySet::from_json`].
+#[derive(Debug, Clone, Deserialize)]
+pub struct JsonPolicySet {
+    name: String,
+    #[serde(default = "default_version")]
+    version: String,
+    rules: Vec<Rule>,
+}
+
+fn default_version() -> String {
+    "1".to_string()
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct Rule {
+    #[allow(dead_code)]
+    name: String,
+    when: Condition,
+    decision: Decision,
+}
+
+/// A boolean predicate over the evaluation context. Untagged: the JSON shape
+/// (`all`/`any`/`not`/leaf) selects the variant.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+enum Condition {
+    All { all: Vec<Condition> },
+    Any { any: Vec<Condition> },
+    Not { not: Box<Condition> },
+    Leaf { field: String, op: Op, value: Value },
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum Op {
+    Eq,
+    Ne,
+    Gt,
+    Lt,
+    Gte,
+    Lte,
+    Contains,
+    StartsWith,
+    In,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum Decision {
+    Permit,
+    Deny { reason: String },
+    RequireApproval { channel: String, reason: String },
+}
+
+impl JsonPolicySet {
+    /// Parse a bundle from JSON. Fails on malformed JSON / unknown ops (the
+    /// loader is fail-closed: a bundle that does not parse is not loaded).
+    pub fn from_json(s: &str) -> Result<Self, serde_json::Error> {
+        serde_json::from_str(s)
+    }
+}
+
+impl Policy for JsonPolicySet {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn version(&self) -> &str {
+        &self.version
+    }
+
+    fn evaluate(&self, intent: &Intent, writ: &Writ, _world: &World) -> PolicyDecision {
+        for rule in &self.rules {
+            if rule.when.eval(intent, writ) {
+                return match &rule.decision {
+                    Decision::Permit => PolicyDecision::Permit,
+                    Decision::Deny { reason } => PolicyDecision::Deny(reason.clone()),
+                    Decision::RequireApproval { channel, reason } => {
+                        PolicyDecision::RequireApproval {
+                            channel: channel.clone(),
+                            reason: reason.clone(),
+                        }
+                    }
+                };
+            }
+        }
+        PolicyDecision::Permit
+    }
+}
+
+impl Condition {
+    fn eval(&self, intent: &Intent, writ: &Writ) -> bool {
+        match self {
+            Condition::All { all } => all.iter().all(|c| c.eval(intent, writ)),
+            Condition::Any { any } => any.iter().any(|c| c.eval(intent, writ)),
+            Condition::Not { not } => !not.eval(intent, writ),
+            Condition::Leaf { field, op, value } => {
+                eval_leaf(resolve(field, intent, writ).as_ref(), *op, value)
+            }
+        }
+    }
+}
+
+/// Resolve a dotted field path against the (Intent, Writ) context. Returns
+/// `None` for unknown paths or missing args.
+fn resolve(path: &str, intent: &Intent, writ: &Writ) -> Option<Value> {
+    match path {
+        "intent.target" => Some(Value::String(intent.body.target.clone())),
+        "intent.author" => Some(Value::String(intent.body.author.clone())),
+        "intent.kind" => serde_json::to_value(intent.body.kind).ok(),
+        "writ.tenant_id" => Some(Value::String(writ.body.tenant_id.clone())),
+        "writ.subject" => Some(Value::String(writ.body.subject.clone())),
+        "writ.issuer" => Some(Value::String(writ.body.issuer.clone())),
+        _ => path
+            .strip_prefix("intent.args.")
+            .and_then(|key| intent.body.args.get(key).cloned()),
+    }
+}
+
+fn eval_leaf(field: Option<&Value>, op: Op, rule_value: &Value) -> bool {
+    let field = match field {
+        Some(v) => v,
+        None => return false, // unresolved path → leaf is false
+    };
+    match op {
+        Op::Eq => field == rule_value,
+        Op::Ne => field != rule_value,
+        Op::Gt => num_or_str_cmp(field, rule_value).map(|o| o.is_gt()).unwrap_or(false),
+        Op::Lt => num_or_str_cmp(field, rule_value).map(|o| o.is_lt()).unwrap_or(false),
+        Op::Gte => num_or_str_cmp(field, rule_value).map(|o| o.is_ge()).unwrap_or(false),
+        Op::Lte => num_or_str_cmp(field, rule_value).map(|o| o.is_le()).unwrap_or(false),
+        Op::Contains => match (field, rule_value) {
+            (Value::String(s), Value::String(sub)) => s.contains(sub.as_str()),
+            (Value::Array(arr), v) => arr.contains(v),
+            _ => false,
+        },
+        Op::StartsWith => match (field.as_str(), rule_value.as_str()) {
+            (Some(s), Some(p)) => s.starts_with(p),
+            _ => false,
+        },
+        Op::In => rule_value
+            .as_array()
+            .map(|arr| arr.contains(field))
+            .unwrap_or(false),
+    }
+}
+
+/// Compare two JSON values as integers when both are integers, otherwise as
+/// strings. Returns `None` for incomparable pairs. Floats are intentionally not
+/// special-cased — rule data should use integers (Section: determinism).
+fn num_or_str_cmp(a: &Value, b: &Value) -> Option<std::cmp::Ordering> {
+    if let (Some(x), Some(y)) = (a.as_i64(), b.as_i64()) {
+        return Some(x.cmp(&y));
+    }
+    if let (Some(x), Some(y)) = (a.as_str(), b.as_str()) {
+        return Some(x.cmp(y));
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use thymos_core::{
+        crypto::{generate_signing_key, public_key_of},
+        intent::{Intent, IntentBody, IntentKind},
+        writ::{Budget, DelegationBounds, EffectCeiling, TimeWindow, ToolPattern, Writ, WritBody},
+    };
+
+    fn intent(target: &str, args: serde_json::Value) -> Intent {
+        Intent::new(IntentBody {
+            parent_commit: None,
+            author: "tester".into(),
+            kind: IntentKind::Act,
+            target: target.into(),
+            args,
+            rationale: "t".into(),
+            nonce: [0u8; 16],
+        })
+        .unwrap()
+    }
+
+    fn writ() -> Writ {
+        let k = generate_signing_key();
+        Writ::sign(
+            WritBody {
+                issuer: "root".into(),
+                issuer_pubkey: public_key_of(&k),
+                subject: "agent".into(),
+                subject_pubkey: public_key_of(&generate_signing_key()),
+                nonce: [0u8; 16],
+                parent: None,
+                tenant_id: "acme".into(),
+                tool_scopes: vec![ToolPattern::exact("*")],
+                budget: Budget {
+                    tokens: 1,
+                    tool_calls: 1,
+                    wall_clock_ms: 1,
+                    usd_millicents: 1,
+                },
+                effect_ceiling: EffectCeiling::read_write_local(),
+                time_window: TimeWindow {
+                    not_before: 0,
+                    expires_at: u64::MAX,
+                },
+                delegation: DelegationBounds {
+                    max_depth: 0,
+                    may_subdivide: false,
+                },
+            },
+            &k,
+        )
+        .unwrap()
+    }
+
+    fn eval(bundle: &str, target: &str, args: serde_json::Value) -> PolicyDecision {
+        let set = JsonPolicySet::from_json(bundle).unwrap();
+        set.evaluate(&intent(target, args), &writ(), &World::default())
+    }
+
+    #[test]
+    fn deny_rule_matches_target() {
+        let b = r#"{"name":"p","rules":[
+            {"name":"no-del","when":{"field":"intent.target","op":"eq","value":"kv_del"},
+             "decision":{"kind":"deny","reason":"no deletes"}}]}"#;
+        assert!(matches!(eval(b, "kv_del", json!({})), PolicyDecision::Deny(r) if r == "no deletes"));
+        assert!(matches!(eval(b, "kv_set", json!({})), PolicyDecision::Permit));
+    }
+
+    #[test]
+    fn numeric_threshold_requires_approval() {
+        let b = r#"{"name":"p","rules":[
+            {"name":"big","when":{"field":"intent.args.amount","op":"gt","value":1000},
+             "decision":{"kind":"require_approval","channel":"ops","reason":"big"}}]}"#;
+        assert!(matches!(
+            eval(b, "pay", json!({"amount": 5000})),
+            PolicyDecision::RequireApproval { .. }
+        ));
+        assert!(matches!(eval(b, "pay", json!({"amount": 10})), PolicyDecision::Permit));
+    }
+
+    #[test]
+    fn boolean_combinators_and_first_match_wins() {
+        let b = r#"{"name":"p","version":"7","rules":[
+            {"name":"r","when":{"all":[
+                {"field":"intent.target","op":"eq","value":"deploy"},
+                {"any":[
+                    {"field":"writ.tenant_id","op":"eq","value":"acme"},
+                    {"field":"writ.subject","op":"eq","value":"root"}]},
+                {"not":{"field":"intent.args.dryrun","op":"eq","value":true}}]},
+             "decision":{"kind":"deny","reason":"guarded deploy"}}]}"#;
+        // all() true: target=deploy, tenant=acme, dryrun != true
+        assert!(matches!(eval(b, "deploy", json!({})), PolicyDecision::Deny(_)));
+        // not() flips: dryrun == true → all() false → no match → permit
+        assert!(matches!(eval(b, "deploy", json!({"dryrun": true})), PolicyDecision::Permit));
+        // version carried through
+        assert_eq!(JsonPolicySet::from_json(b).unwrap().version(), "7");
+    }
+
+    #[test]
+    fn in_and_contains_ops() {
+        let b = r#"{"name":"p","rules":[
+            {"name":"r","when":{"field":"intent.target","op":"in","value":["a","b","c"]},
+             "decision":{"kind":"deny","reason":"listed"}}]}"#;
+        assert!(matches!(eval(b, "b", json!({})), PolicyDecision::Deny(_)));
+        assert!(matches!(eval(b, "z", json!({})), PolicyDecision::Permit));
+    }
+
+    #[test]
+    fn malformed_bundle_fails_closed() {
+        assert!(JsonPolicySet::from_json("{ not json").is_err());
+        // unknown op is rejected
+        assert!(JsonPolicySet::from_json(
+            r#"{"name":"p","rules":[{"name":"r","when":{"field":"x","op":"regex","value":"y"},"decision":{"kind":"permit"}}]}"#
+        )
+        .is_err());
+    }
+}

--- a/thymos/crates/thymos-policy/src/lib.rs
+++ b/thymos/crates/thymos-policy/src/lib.rs
@@ -11,15 +11,20 @@ use thymos_core::{
     writ::Writ,
 };
 
+pub mod json_policy;
+pub use json_policy::JsonPolicySet;
+
 pub trait Policy: Send + Sync {
-    /// Stable name used in `PolicyTrace.rules_evaluated`.
-    fn name(&self) -> &'static str;
+    /// Stable name used in `PolicyTrace.rules_evaluated`. Borrowed from the
+    /// policy so dynamically-loaded policies (e.g. JSON bundles) can carry their
+    /// own name; built-in policies return a string literal.
+    fn name(&self) -> &str;
 
     /// Version tag for this policy's logic. Bump it when the rule's behavior
     /// changes so the engine's `policy_set_hash` changes too — that lets replay
     /// detect that a trajectory was produced under a different policy version.
     /// Default: `"1"`.
-    fn version(&self) -> &'static str {
+    fn version(&self) -> &str {
         "1"
     }
 
@@ -99,7 +104,7 @@ impl Default for PolicyEngine {
 /// Denies anything not authorized by the Writ's tool scopes.
 pub struct WritAuthorityPolicy;
 impl Policy for WritAuthorityPolicy {
-    fn name(&self) -> &'static str {
+    fn name(&self) -> &str {
         "writ.authority"
     }
     fn applies_to(&self, intent: &Intent) -> bool {
@@ -128,7 +133,7 @@ impl Policy for WritAuthorityPolicy {
 pub struct TenantIsolationPolicy;
 
 impl Policy for TenantIsolationPolicy {
-    fn name(&self) -> &'static str {
+    fn name(&self) -> &str {
         "tenant.isolation"
     }
 
@@ -166,7 +171,7 @@ pub struct ThresholdApprovalPolicy {
 }
 
 impl Policy for ThresholdApprovalPolicy {
-    fn name(&self) -> &'static str {
+    fn name(&self) -> &str {
         "threshold.approval"
     }
     fn applies_to(&self, intent: &Intent) -> bool {

--- a/thymos/crates/thymos-runtime/tests/json_policy_e2e.rs
+++ b/thymos/crates/thymos-runtime/tests/json_policy_e2e.rs
@@ -1,0 +1,147 @@
+//! End-to-end: a declarative JSON policy bundle governs a real run — a tool the
+//! writ authorizes by name is still denied by a loaded policy rule, and a
+//! threshold rule suspends for approval. Proves the policy language plugs into
+//! the live Intent → Proposal → Commit pipeline.
+
+use serde_json::{json, Value};
+
+use thymos_core::{commit::Observation, delta::StructuredDelta, error::Result};
+use thymos_ledger::Ledger;
+use thymos_policy::{JsonPolicySet, PolicyEngine, WritAuthorityPolicy};
+use thymos_runtime::{
+    generate_signing_key, public_key_of, Budget, CoreIntent, DelegationBounds, EffectCeiling,
+    IntentBody, IntentKind, Runtime, Step, TimeWindow, ToolPattern, Writ, WritBody,
+};
+use thymos_tools::{
+    EffectClass, RiskClass, ToolContract, ToolContractMeta, ToolInvocation, ToolOutcome,
+    ToolRegistry,
+};
+
+struct NoopTool {
+    name: &'static str,
+}
+impl ToolContract for NoopTool {
+    fn meta(&self) -> &ToolContractMeta {
+        Box::leak(Box::new(ToolContractMeta {
+            name: self.name.into(),
+            version: "1.0.0".into(),
+            effect_class: EffectClass::Write,
+            risk_class: RiskClass::Low,
+        }))
+    }
+    fn description(&self) -> &str {
+        "noop"
+    }
+    fn input_schema(&self) -> Value {
+        json!({"type": "object"})
+    }
+    fn execute(&self, _inv: &ToolInvocation<'_>) -> Result<ToolOutcome> {
+        Ok(ToolOutcome {
+            delta: StructuredDelta(vec![]),
+            observation: Observation {
+                tool: self.name.into(),
+                output: json!(null),
+                latency_ms: 0,
+            },
+        })
+    }
+}
+
+const BUNDLE: &str = r#"{
+  "name": "ops.policy",
+  "version": "1",
+  "rules": [
+    { "name": "no-danger",
+      "when": { "field": "intent.target", "op": "eq", "value": "danger" },
+      "decision": { "kind": "deny", "reason": "danger tool is forbidden by policy bundle" } },
+    { "name": "big-spend",
+      "when": { "field": "intent.args.amount", "op": "gt", "value": 1000 },
+      "decision": { "kind": "require_approval", "channel": "ops", "reason": "amount over 1000" } }
+  ]
+}"#;
+
+fn runtime() -> Runtime {
+    let mut tools = ToolRegistry::new();
+    tools.register(NoopTool { name: "danger" });
+    tools.register(NoopTool { name: "pay" });
+    let policy = PolicyEngine::new()
+        .with(WritAuthorityPolicy)
+        .with(JsonPolicySet::from_json(BUNDLE).unwrap());
+    Runtime::new(Ledger::open_in_memory().unwrap(), tools, policy)
+}
+
+fn writ() -> Writ {
+    let issuer = generate_signing_key();
+    let subject = generate_signing_key();
+    Writ::sign(
+        WritBody {
+            issuer: "root".into(),
+            issuer_pubkey: public_key_of(&issuer),
+            subject: "agent".into(),
+            subject_pubkey: public_key_of(&subject),
+            nonce: [0u8; 16],
+            parent: None,
+            tenant_id: String::new(),
+            // Writ authorizes BOTH tools by name; the JSON bundle is what governs.
+            tool_scopes: vec![ToolPattern::exact("danger"), ToolPattern::exact("pay")],
+            budget: Budget {
+                tokens: 10_000,
+                tool_calls: 100,
+                wall_clock_ms: 600_000,
+                usd_millicents: 0,
+            },
+            effect_ceiling: EffectCeiling::read_write_local(),
+            time_window: TimeWindow {
+                not_before: 0,
+                expires_at: u64::MAX,
+            },
+            delegation: DelegationBounds {
+                max_depth: 1,
+                may_subdivide: false,
+            },
+        },
+        &issuer,
+    )
+    .unwrap()
+}
+
+fn intent(target: &str, args: Value) -> CoreIntent {
+    CoreIntent::new(IntentBody {
+        parent_commit: None,
+        author: "test".into(),
+        kind: IntentKind::Act,
+        target: target.into(),
+        args,
+        rationale: "json policy".into(),
+        nonce: [1; 16],
+    })
+    .unwrap()
+}
+
+#[test]
+fn json_bundle_denies_an_in_scope_tool() {
+    let rt = runtime();
+    let w = writ();
+    let run = rt.create_run("jp", b"jp").unwrap();
+    // 'danger' is in the writ's scope but the bundle denies it.
+    match run.submit(intent("danger", json!({})), &w).unwrap() {
+        Step::Rejected(reason) => assert!(reason.to_string().contains("forbidden by policy bundle")),
+        other => panic!("expected policy denial, got {other:?}"),
+    }
+}
+
+#[test]
+fn json_bundle_threshold_suspends_for_approval() {
+    let rt = runtime();
+    let w = writ();
+    let run = rt.create_run("jp2", b"jp2").unwrap();
+    match run.submit(intent("pay", json!({ "amount": 5000 })), &w).unwrap() {
+        Step::Suspended { channel, .. } => assert_eq!(channel, "ops"),
+        other => panic!("expected suspension, got {other:?}"),
+    }
+    // Under the threshold → permitted (commits).
+    match run.submit(intent("pay", json!({ "amount": 10 })), &w).unwrap() {
+        Step::Committed(_) => {}
+        other => panic!("expected commit, got {other:?}"),
+    }
+}


### PR DESCRIPTION
Implements the **policy-language-v1** RFC (was a design-only stub) — Option A, a minimal closed JSON predicate DSL. Policy can now be authored and loaded at runtime, no recompile.

## What
- `JsonPolicySet::from_json(&str)` loads `{ name, version, rules[] }` and implements the existing `Policy` trait → plugs straight into `PolicyEngine::with(...)`.
- `when` DSL: leaf `{field, op, value}` with `eq/ne/gt/lt/gte/lte/contains/starts_with/in`, combined by `all`/`any`/`not`. Field paths over `(Intent, Writ)`: `intent.target|kind|author|args.<k>`, `writ.tenant_id|subject|issuer`.
- Decisions: `permit` / `deny{reason}` / `require_approval{channel,reason}`.
- **Deterministic** (no clock/RNG/network/floats in rule data) and **fail-closed** (unparseable bundle or unknown op is rejected at load).
- Bundle `name@version` flows into `policy_set_hash`, so replay drift detection already covers policy changes.
- `Policy::name()/version()` relaxed `&'static str → &str` so bundles carry dynamic names (built-in policies unaffected).

## Tests
5 unit + 2 end-to-end (a JSON bundle denies an in-scope tool; a threshold rule suspends a real run for approval). **217 pass, 0 warnings.**

## Deferred (follow-up)
Signed bundles (ed25519, verified at load), `world.*` accessors, CEL/Rego if the closed DSL proves limiting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)