### PR TITLE
feat: compensation gate — require approval for irreversible, non-compensable tools

### DIFF
--- a/docs/rfcs/compensation-saga-v1.md
+++ b/docs/rfcs/compensation-saga-v1.md
@@ -17,9 +17,14 @@ Accepted — MVP implemented (Option A). Shipped:
   (already-compensated steps and compensation commits are skipped); runs under
   the supplied writ (authorizes the tool, must not be revoked).
 
-Deferred (see Unresolved Questions): declaring `compensable` in
-`ToolContractMeta` so the effect gate can *require approval* for an
-irreversible-and-uncompensable tool; cross-trajectory/delegated-child
+Also shipped: the **compensation gate** (compiler stage 9b) — when
+`Runtime::with_require_compensation_for_irreversible(true)` is set, an
+`Irreversible` tool that is not `compensable()` is escalated to *require
+approval* even on a bare policy permit (you can't undo it and the runtime can't
+roll it back, so a human signs off). Implemented via the `ToolContract::compensable()`
+trait method, so no `ToolContractMeta` change was needed.
+
+Deferred (see Unresolved Questions): cross-trajectory/delegated-child
 compensation; compensating past an expired writ window; partial-failure policy
 beyond "halt and surface".
 

--- a/thymos/crates/thymos-compiler/src/lib.rs
+++ b/thymos/crates/thymos-compiler/src/lib.rs
@@ -16,6 +16,8 @@
 //!   7. Type check        — delegate to ToolContract::validate_args.
 //!   8. Precondition      — contract-declared; evaluated against World.
 //!   9. Policy eval       — run the PolicyEngine over (Intent, Writ, World).
+//!   9b. Compensation gate — optionally require approval for an irreversible,
+//!                           non-compensable tool.
 //!  10. Emit Proposal     — with full PolicyTrace, or a typed rejection.
 
 use std::collections::HashSet;
@@ -65,6 +67,13 @@ pub struct CompileContext {
     /// here is treated as void even if its signature and time window are valid —
     /// the revocation mechanism for capabilities pulled before expiry.
     pub revoked: HashSet<WritId>,
+    /// When true, an `Irreversible` tool that is **not** compensable
+    /// (`ToolContract::compensable() == false`) is escalated to `Suspended`
+    /// (require approval) even if policy permitted — it cannot be undone and the
+    /// runtime cannot roll it back, so a human must sign off. Default `false`
+    /// (preserves prior behavior); enable via
+    /// `Runtime::with_require_compensation_for_irreversible`.
+    pub require_compensation_for_irreversible: bool,
 }
 
 impl CompileContext {
@@ -75,6 +84,7 @@ impl CompileContext {
             now_unix: 0,
             budget_used: BudgetCost::default(),
             revoked: HashSet::new(),
+            require_compensation_for_irreversible: false,
         }
     }
 }
@@ -240,6 +250,31 @@ pub fn compile_with_context(
             },
             Some((channel.clone(), reason.clone())),
         ),
+    };
+
+    // 9b. Compensation gate. If enabled, an Irreversible tool that cannot be
+    // compensated (no rollback path) must not proceed on a bare permit — it is
+    // escalated to require approval, so a human signs off on an effect neither
+    // the tool nor the runtime can undo.
+    let (status, suspension) = if ctx.require_compensation_for_irreversible
+        && suspension.is_none()
+        && effect_class == EffectClass::Irreversible
+        && !tool.compensable()
+    {
+        let channel = "irreversible-uncompensable".to_string();
+        let reason = format!(
+            "tool '{}' has an irreversible effect and is not compensable; approval required",
+            effective_tool
+        );
+        (
+            ProposalStatus::Suspended {
+                channel: channel.clone(),
+                reason: reason.clone(),
+            },
+            Some((channel, reason)),
+        )
+    } else {
+        (status, suspension)
     };
 
     // 10. Emit Proposal.

--- a/thymos/crates/thymos-runtime/src/lib.rs
+++ b/thymos/crates/thymos-runtime/src/lib.rs
@@ -170,6 +170,10 @@ pub struct Runtime {
     /// before its time window expires. Shared (cheap to clone) so a control
     /// surface can revoke while runs are in flight.
     pub revocations: Revocations,
+    /// When true, an `Irreversible` tool that is not compensable is escalated to
+    /// require approval (compiler stage 9b) instead of executing on a bare
+    /// policy permit. Default `false`.
+    pub require_compensation_for_irreversible: bool,
 }
 
 /// Thread-safe set of revoked writ ids, consulted by the compiler on every
@@ -266,6 +270,7 @@ impl Runtime {
             commit_signer: None,
             redactor: thymos_core::Redactor::default_secrets(),
             revocations: Revocations::new(),
+            require_compensation_for_irreversible: false,
             clock: std::sync::Arc::new(SystemClock),
             approval_quorum: 1,
             quorum: QuorumTracker::new(),
@@ -276,6 +281,13 @@ impl Runtime {
     /// attested time source, or a [`FixedClock`] in tests).
     pub fn with_clock(mut self, clock: std::sync::Arc<dyn Clock>) -> Self {
         self.clock = clock;
+        self
+    }
+
+    /// Builder: require approval for any irreversible, non-compensable tool
+    /// (compiler stage 9b). Off by default.
+    pub fn with_require_compensation_for_irreversible(mut self, on: bool) -> Self {
+        self.require_compensation_for_irreversible = on;
         self
     }
 
@@ -513,6 +525,9 @@ impl<'a> Run<'a> {
             now_unix,
             budget_used,
             revoked: self.runtime.revocations.snapshot(),
+            require_compensation_for_irreversible: self
+                .runtime
+                .require_compensation_for_irreversible,
         };
 
         // Compile (with budget + time-window checks).

--- a/thymos/crates/thymos-runtime/tests/compensation_gate.rs
+++ b/thymos/crates/thymos-runtime/tests/compensation_gate.rs
@@ -1,0 +1,149 @@
+//! Compensation gate (compiler stage 9b): when enabled, an irreversible tool
+//! that is not compensable is escalated to require approval, even on a bare
+//! policy permit. A compensable irreversible tool proceeds. Off by default.
+
+use serde_json::{json, Value};
+
+use thymos_core::{commit::Observation, delta::StructuredDelta, error::Result};
+use thymos_ledger::Ledger;
+use thymos_policy::{PolicyEngine, WritAuthorityPolicy};
+use thymos_runtime::{
+    generate_signing_key, public_key_of, Budget, CoreIntent, DelegationBounds, EffectCeiling,
+    IntentBody, IntentKind, Runtime, Step, TimeWindow, ToolPattern, Writ, WritBody,
+};
+use thymos_tools::{
+    EffectClass, RiskClass, ToolContract, ToolContractMeta, ToolInvocation, ToolOutcome,
+    ToolRegistry,
+};
+
+struct IrreversibleTool {
+    compensable: bool,
+}
+impl ToolContract for IrreversibleTool {
+    fn meta(&self) -> &ToolContractMeta {
+        Box::leak(Box::new(ToolContractMeta {
+            name: "wire_transfer".into(),
+            version: "1.0.0".into(),
+            effect_class: EffectClass::Irreversible,
+            risk_class: RiskClass::Critical,
+        }))
+    }
+    fn description(&self) -> &str {
+        "irreversible action"
+    }
+    fn input_schema(&self) -> Value {
+        json!({"type": "object"})
+    }
+    fn execute(&self, _inv: &ToolInvocation<'_>) -> Result<ToolOutcome> {
+        Ok(ToolOutcome {
+            delta: StructuredDelta(vec![]),
+            observation: Observation {
+                tool: "wire_transfer".into(),
+                output: json!(null),
+                latency_ms: 0,
+            },
+        })
+    }
+    fn compensable(&self) -> bool {
+        self.compensable
+    }
+}
+
+fn writ() -> Writ {
+    let issuer = generate_signing_key();
+    let subject = generate_signing_key();
+    Writ::sign(
+        WritBody {
+            issuer: "root".into(),
+            issuer_pubkey: public_key_of(&issuer),
+            subject: "agent".into(),
+            subject_pubkey: public_key_of(&subject),
+            nonce: [0u8; 16],
+            parent: None,
+            tenant_id: String::new(),
+            tool_scopes: vec![ToolPattern::exact("wire_transfer")],
+            budget: Budget {
+                tokens: 10_000,
+                tool_calls: 100,
+                wall_clock_ms: 600_000,
+                usd_millicents: 1_000_000,
+            },
+            // Grant irreversible so the effect-ceiling gate (5b) admits it; 9b is
+            // what this test exercises.
+            effect_ceiling: EffectCeiling {
+                read: true,
+                write: true,
+                external: true,
+                irreversible: true,
+            },
+            time_window: TimeWindow {
+                not_before: 0,
+                expires_at: u64::MAX,
+            },
+            delegation: DelegationBounds {
+                max_depth: 1,
+                may_subdivide: false,
+            },
+        },
+        &issuer,
+    )
+    .unwrap()
+}
+
+fn act() -> CoreIntent {
+    CoreIntent::new(IntentBody {
+        parent_commit: None,
+        author: "test".into(),
+        kind: IntentKind::Act,
+        target: "wire_transfer".into(),
+        args: json!({}),
+        rationale: "gate".into(),
+        nonce: [5; 16],
+    })
+    .unwrap()
+}
+
+fn runtime(compensable: bool, gate_on: bool) -> Runtime {
+    let mut tools = ToolRegistry::new();
+    tools.register(IrreversibleTool { compensable });
+    let rt = Runtime::new(
+        Ledger::open_in_memory().unwrap(),
+        tools,
+        PolicyEngine::new().with(WritAuthorityPolicy),
+    );
+    if gate_on {
+        rt.with_require_compensation_for_irreversible(true)
+    } else {
+        rt
+    }
+}
+
+#[test]
+fn gate_on_suspends_irreversible_uncompensable() {
+    let rt = runtime(false, true);
+    let run = rt.create_run("g1", b"g1").unwrap();
+    match run.submit(act(), &writ()).unwrap() {
+        Step::Suspended { channel, .. } => assert_eq!(channel, "irreversible-uncompensable"),
+        other => panic!("expected suspension, got {other:?}"),
+    }
+}
+
+#[test]
+fn gate_on_allows_compensable_irreversible() {
+    let rt = runtime(true, true);
+    let run = rt.create_run("g2", b"g2").unwrap();
+    assert!(matches!(
+        run.submit(act(), &writ()).unwrap(),
+        Step::Committed(_)
+    ));
+}
+
+#[test]
+fn gate_off_is_default_behavior() {
+    let rt = runtime(false, false);
+    let run = rt.create_run("g3", b"g3").unwrap();
+    assert!(matches!(
+        run.submit(act(), &writ()).unwrap(),
+        Step::Committed(_)
+    ));
+}


### PR DESCRIPTION
Deferred compensation item from the saga RFC. An `Irreversible` tool that isn't compensable has no rollback path, so running it on a bare policy permit is unsafe.

## What
- **Compiler stage 9b:** when `CompileContext.require_compensation_for_irreversible` is set, a tool with `EffectClass::Irreversible` and `compensable() == false` is escalated to **Suspended** (require approval) even if policy permitted. Uses the existing `ToolContract::compensable()` trait method — **no `ToolContractMeta` change needed**.
- **Runtime:** `with_require_compensation_for_irreversible(true)` opt-in (default off, preserves behavior).

## Tests
3 tests: gate on → suspends uncompensable irreversible; gate on → allows compensable irreversible; gate off → default commit. **213 pass, 0 warnings.**

## Still deferred
Cross-trajectory / delegated-child compensation (the remaining bigger saga item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)