### PR TITLE
feat: cross-trajectory compensation + bump to v0.3.0

### DIFF
--- a/docs/rfcs/compensation-saga-v1.md
+++ b/docs/rfcs/compensation-saga-v1.md
@@ -24,9 +24,15 @@ approval* even on a bare policy permit (you can't undo it and the runtime can't
 roll it back, so a human signs off). Implemented via the `ToolContract::compensable()`
 trait method, so no `ToolContractMeta` change was needed.
 
-Deferred (see Unresolved Questions): cross-trajectory/delegated-child
-compensation; compensating past an expired writ window; partial-failure policy
-beyond "halt and surface".
+Also shipped: **cross-trajectory compensation** — `compensate_to` walks the
+target trajectory's entries newest-first and, on each `Delegation` edge,
+recursively compensates the entire child trajectory it spawned (back to the
+child's root). A parent rollback therefore unwinds delegated work too;
+children form a DAG so recursion terminates, and the child rollback is recorded
+in the child's own ledger.
+
+Deferred (see Unresolved Questions): compensating past an expired writ window;
+partial-failure policy beyond "halt and surface".
 
 ## Summary
 

--- a/thymos/Cargo.lock
+++ b/thymos/Cargo.lock
@@ -2699,7 +2699,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-cli"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "axum 0.8.9",
  "clap",
@@ -2718,7 +2718,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-client"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "axum-test",
  "reqwest",
@@ -2732,7 +2732,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-cognition"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -2746,7 +2746,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-compiler"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2757,7 +2757,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "blake3",
  "ed25519-dalek",
@@ -2770,7 +2770,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-ledger"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "blake3",
  "deadpool-postgres",
@@ -2786,7 +2786,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-marketplace"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "blake3",
  "hex",
@@ -2799,7 +2799,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-policy"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2808,7 +2808,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-runtime"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "serde",
@@ -2825,7 +2825,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-server"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2858,7 +2858,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-tools"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "blake3",
  "reqwest",
@@ -2871,7 +2871,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-worker"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "serde_json",
  "thymos-tools",

--- a/thymos/Cargo.toml
+++ b/thymos/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 rust-version = "1.80"

--- a/thymos/crates/thymos-runtime/src/lib.rs
+++ b/thymos/crates/thymos-runtime/src/lib.rs
@@ -1092,25 +1092,43 @@ impl<'a> Run<'a> {
             })
             .collect();
 
-        // Commits strictly after the target, newest first. Compensation
-        // commits (those that already carry `compensates`) are never themselves
-        // compensated — that would undo a rollback.
-        let mut to_undo: Vec<Commit> = entries
+        // Walk every entry strictly after the target, newest-first, and undo it:
+        //   - Commit (not itself a compensation): invoke the tool's compensate.
+        //   - Delegation: recursively compensate the entire child trajectory it
+        //     spawned (back to the child's root), so a parent rollback also
+        //     unwinds delegated work. Children form a DAG, so this terminates.
+        let mut after: Vec<Entry> = entries
             .iter()
-            .filter_map(|e| match &e.payload {
-                EntryPayload::Commit(c) if e.seq > target_seq && c.body.compensates.is_none() => {
-                    Some(c.clone())
-                }
-                _ => None,
-            })
+            .filter(|e| e.seq > target_seq)
+            .cloned()
             .collect();
-        to_undo.reverse();
+        after.reverse();
 
         let mut compensation_ids = Vec::new();
-        for original in to_undo {
-            if already_compensated.contains(&original.id) {
+        for entry in after {
+            let original = match entry.payload {
+                EntryPayload::Delegation {
+                    child_trajectory_id,
+                    ..
+                } => {
+                    // Recursively roll back the child trajectory to its root.
+                    let child_entries = self.runtime.ledger.entries(child_trajectory_id)?;
+                    if let Some(first) = child_entries.first() {
+                        let child_run = self.runtime.resume_run(child_trajectory_id)?;
+                        let child_ids = child_run.compensate_to(CommitId(first.id), writ)?;
+                        compensation_ids.extend(child_ids);
+                    }
+                    continue;
+                }
+                EntryPayload::Commit(c) => c,
+                _ => continue,
+            };
+
+            // Never compensate a compensation, and skip steps already undone.
+            if original.body.compensates.is_some() || already_compensated.contains(&original.id) {
                 continue;
             }
+
             let observation = original.body.observations.first().cloned().ok_or_else(|| {
                 Error::Other(format!("commit {} has no observation to compensate", original.id))
             })?;

--- a/thymos/crates/thymos-runtime/tests/cross_trajectory_compensation.rs
+++ b/thymos/crates/thymos-runtime/tests/cross_trajectory_compensation.rs
@@ -1,0 +1,192 @@
+//! Cross-trajectory compensation: rolling back a parent trajectory also unwinds
+//! the committed work of any child trajectory it delegated to (recursively).
+
+use serde_json::{json, Value};
+
+use thymos_core::{
+    commit::Observation,
+    delta::{DeltaOp, StructuredDelta},
+    error::{Error, Result},
+    world::ResourceKey,
+    CommitId,
+};
+use thymos_ledger::{EntryPayload, Ledger};
+use thymos_policy::{PolicyEngine, WritAuthorityPolicy};
+use thymos_runtime::{
+    generate_signing_key, public_key_of, Budget, CoreIntent, DelegationBounds, EffectCeiling,
+    IntentBody, IntentKind, Runtime, Step, TimeWindow, ToolPattern, Writ, WritBody,
+};
+use thymos_tools::{
+    EffectClass, RiskClass, ToolContract, ToolContractMeta, ToolInvocation, ToolOutcome,
+    ToolRegistry,
+};
+
+/// Compensable tool: creates a kv on the forward path, retracts it to compensate.
+struct ProvisionTool;
+impl ToolContract for ProvisionTool {
+    fn meta(&self) -> &ToolContractMeta {
+        static M: std::sync::OnceLock<ToolContractMeta> = std::sync::OnceLock::new();
+        M.get_or_init(|| ToolContractMeta {
+            name: "provision".into(),
+            version: "1.0.0".into(),
+            effect_class: EffectClass::Write,
+            risk_class: RiskClass::Medium,
+        })
+    }
+    fn description(&self) -> &str {
+        "provision (compensable)"
+    }
+    fn input_schema(&self) -> Value {
+        json!({"type": "object"})
+    }
+    fn execute(&self, inv: &ToolInvocation<'_>) -> Result<ToolOutcome> {
+        let id = inv
+            .args
+            .get("id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("r")
+            .to_string();
+        Ok(ToolOutcome {
+            delta: StructuredDelta::single(DeltaOp::Create {
+                kind: "kv".into(),
+                id: id.clone(),
+                value: json!("active"),
+            }),
+            observation: Observation {
+                tool: "provision".into(),
+                output: json!({ "key": id }),
+                latency_ms: 0,
+            },
+        })
+    }
+    fn compensable(&self) -> bool {
+        true
+    }
+    fn compensate(
+        &self,
+        observation: &Observation,
+        world: &thymos_core::world::World,
+    ) -> Result<ToolOutcome> {
+        let key = observation
+            .output
+            .get("key")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| Error::Other("no key".into()))?;
+        let version = world
+            .get(&ResourceKey::new("kv", key))
+            .map(|s| s.version)
+            .unwrap_or(1);
+        Ok(ToolOutcome {
+            delta: StructuredDelta::single(DeltaOp::Retract {
+                kind: "kv".into(),
+                id: key.into(),
+                expected_version: version,
+                reason: "compensated".into(),
+            }),
+            observation: Observation {
+                tool: "provision".into(),
+                output: json!({ "compensated": key }),
+                latency_ms: 0,
+            },
+        })
+    }
+}
+
+fn writ() -> Writ {
+    let issuer = generate_signing_key();
+    let subject = generate_signing_key();
+    Writ::sign(
+        WritBody {
+            issuer: "root".into(),
+            issuer_pubkey: public_key_of(&issuer),
+            subject: "agent".into(),
+            subject_pubkey: public_key_of(&subject),
+            nonce: [0u8; 16],
+            parent: None,
+            tenant_id: String::new(),
+            tool_scopes: vec![ToolPattern::exact("provision")],
+            budget: Budget {
+                tokens: 10_000,
+                tool_calls: 100,
+                wall_clock_ms: 600_000,
+                usd_millicents: 0,
+            },
+            effect_ceiling: EffectCeiling::read_write_local(),
+            time_window: TimeWindow {
+                not_before: 0,
+                expires_at: u64::MAX,
+            },
+            delegation: DelegationBounds {
+                max_depth: 2,
+                may_subdivide: true,
+            },
+        },
+        &issuer,
+    )
+    .unwrap()
+}
+
+fn act(id: &str, nonce: u8) -> CoreIntent {
+    CoreIntent::new(IntentBody {
+        parent_commit: None,
+        author: "test".into(),
+        kind: IntentKind::Act,
+        target: "provision".into(),
+        args: json!({ "id": id }),
+        rationale: "x".into(),
+        nonce: [nonce; 16],
+    })
+    .unwrap()
+}
+
+#[test]
+fn parent_rollback_compensates_delegated_child_work() {
+    let mut tools = ToolRegistry::new();
+    tools.register(ProvisionTool);
+    let runtime = Runtime::new(
+        Ledger::open_in_memory().unwrap(),
+        tools,
+        PolicyEngine::new().with(WritAuthorityPolicy),
+    );
+    let w = writ();
+
+    // A child trajectory that committed real work.
+    let child = runtime.create_run("child", b"child").unwrap();
+    let child_traj = child.trajectory_id();
+    let child_commit = match child.submit(act("child-res", 1), &w).unwrap() {
+        Step::Committed(id) => id,
+        o => panic!("child not committed: {o:?}"),
+    };
+
+    // A parent trajectory that delegated to that child.
+    let parent = runtime.create_run("parent", b"parent").unwrap();
+    let parent_traj = parent.trajectory_id();
+    runtime
+        .ledger
+        .append_delegation(parent_traj, child_traj, "do work", None)
+        .unwrap();
+
+    // Roll the parent back to its root.
+    let parent_root = CommitId(runtime.ledger.entries(parent_traj).unwrap()[0].id);
+    let comps = parent.compensate_to(parent_root, &w).unwrap();
+    assert_eq!(comps.len(), 1, "the child's one commit was compensated via the parent rollback");
+
+    // The compensation landed in the CHILD trajectory, linked to the child commit.
+    let child_links: Vec<Option<CommitId>> = runtime
+        .ledger
+        .entries(child_traj)
+        .unwrap()
+        .iter()
+        .filter_map(|e| match &e.payload {
+            EntryPayload::Commit(c) => Some(c.body.compensates),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(child_links, vec![None, Some(child_commit)]);
+
+    runtime.ledger.verify_integrity(child_traj).unwrap();
+    runtime.ledger.verify_integrity(parent_traj).unwrap();
+
+    // Idempotent: re-running compensates nothing new.
+    assert!(parent.compensate_to(parent_root, &w).unwrap().is_empty());
+}


### PR DESCRIPTION
The remaining saga item: a parent rollback now also unwinds **delegated child-trajectory** work.

## What
- `compensate_to` walks the target trajectory's entries newest-first; on each `Delegation` edge it recursively compensates the whole child trajectory (back to the child's root). Recursion terminates (children form a DAG); each child's rollback is recorded in the child's own ledger; idempotent end to end.
- Version `0.2.0 → 0.3.0` — this release line carries the **policy language (#9)**, the **compensation gate (#10)**, and **cross-trajectory compensation** (all additive, no breaking changes).

## Test
`cross_trajectory_compensation.rs`: a parent rolled back to root compensates a delegated child's commit (landed in the child ledger, linked to the original commit); re-running is a no-op. **221 pass, 0 warnings.**

After merge: tag **v0.3.0** (release workflow builds all four platforms + container).

🤖 Generated with [Claude Code](https://claude.com/claude-code)