### PR TITLE
feat: routing_evidence (Proposal Contract v1, Option 2) — WisePick integration

### DIFF
--- a/docs/rfcs/proposal-contract-v1.md
+++ b/docs/rfcs/proposal-contract-v1.md
@@ -6,8 +6,12 @@ Proposal Contract v1
 
 ## Status
 
-Stable (v1). The proposal contract is frozen: the `Proposal` / `ProposalBody` /
-`ProposalStatus` shapes below are the stable surface downstreams may depend on.
+Stable (v1). The `Proposal` / `ProposalBody` / `ProposalStatus` shapes below are
+the stable surface downstreams may depend on. **Option 2 is formalized**:
+`Proposal::routing_evidence` is a typed, optional first-class field for
+pre-Proposal routing advisors (e.g. WisePick) — it lives outside `ProposalBody`
+(so it does not affect `ProposalId`) but is bound into the ledgered envelope
+(`Commit` / `PendingApproval` hashes) so it is immutable and replay-safe.
 
 ## Summary
 
@@ -86,24 +90,43 @@ pub struct ProposalBody {
 pub struct Proposal {
     pub id: ProposalId,
     pub body: ProposalBody,
+    // Option 2: optional provider routing metadata. Outside ProposalBody, so it
+    // does NOT affect ProposalId. Omitted entirely when None (skip_serializing_if).
+    pub routing_evidence: Option<RoutingEvidence>,
 }
+
+pub struct RoutingEvidence {
+    pub decision_hash: String,            // hex digest over the integer-valued payload
+    pub selected: String,                 // chosen provider:capability (ECU)
+    pub alternatives: Vec<String>,        // ranked fallbacks (governance-owned)
+    pub confidence_bps: u32,              // basis points, 0..=10000 (fixed-point)
+    pub reason_codes: Vec<String>,
+    pub latency_estimate_ms: u64,
+    pub cost_estimate_millicents: u64,    // USD millicents (fixed-point)
+    pub fallback_hint: Option<FallbackHint>,
+}
+
+pub struct FallbackHint { pub provider: String, pub model: Option<String>, pub reason: String }
 ```
 
-`ProposalId` remains `content_hash(body)`. A `Proposal` carries exactly its
-content-addressed id and its body — nothing else. There is no provider-supplied
-or experimental field, so the contract is fully content-addressed and stable.
+`ProposalId` remains `content_hash(body)`. `routing_evidence` is **not** part of
+`ProposalBody`, so a routing advisor cannot influence `ProposalId`. All numeric
+fields are fixed-point integers (no floats in a canonical/ledgered payload), and
+`decision_hash` is derived deterministically over those integers, so the artifact
+is stable across replays. The runtime **never** reads `routing_evidence` for
+authority, budget, or policy — it is audit/replay evidence only.
 
 The `Suspended` variant embeds `channel` and `reason` directly in the status,
 matching Section 2. The compiler populates both fields from the policy engine's
 `RequireApproval` decision; the runtime reads them from the status when
 appending `PendingApproval` ledger entries.
 
-> **Provider routing metadata** (previously a proposed experimental
-> `routing_evidence` field) is intentionally **not** part of this stable v1
-> contract. It was removed to avoid shipping an inert field on the
-> compatibility surface. If a future need arises to surface provider routing
-> decisions, it must be introduced by a separate RFC — outside `ProposalBody`,
-> signed, and never able to influence authority, policy, budget, or replay.
+Routing evidence is recorded durably: for suspended proposals it rides in the
+`PendingApproval` entry (which embeds the full `Proposal`); for committed
+proposals the runtime copies it onto `CommitBody.routing_evidence`. Both are
+content-hashed, so the artifact is immutable and rehydrates deterministically at
+replay via its `decision_hash`. Providers attach it with
+`Proposal::with_routing_evidence` or `Run::submit_with_routing_evidence`.
 
 ## Invariants
 

--- a/thymos/Cargo.lock
+++ b/thymos/Cargo.lock
@@ -2699,7 +2699,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-cli"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "axum 0.8.9",
  "clap",
@@ -2718,7 +2718,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-client"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "axum-test",
  "reqwest",
@@ -2732,7 +2732,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-cognition"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -2746,7 +2746,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-compiler"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2757,7 +2757,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "blake3",
  "ed25519-dalek",
@@ -2770,7 +2770,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-ledger"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "blake3",
  "deadpool-postgres",
@@ -2786,7 +2786,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-marketplace"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "blake3",
  "hex",
@@ -2799,7 +2799,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-policy"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2808,7 +2808,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-runtime"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "serde",
@@ -2825,7 +2825,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-server"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2858,7 +2858,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-tools"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "blake3",
  "reqwest",
@@ -2871,7 +2871,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-worker"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "serde_json",
  "thymos-tools",

--- a/thymos/Cargo.toml
+++ b/thymos/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license = "Apache-2.0"
 rust-version = "1.80"

--- a/thymos/crates/thymos-core/src/commit.rs
+++ b/thymos/crates/thymos-core/src/commit.rs
@@ -7,7 +7,7 @@ use crate::crypto::{PublicKey, SignatureBytes, SigningKey};
 use crate::error::{Error, Result};
 use crate::hash::{canonical_json_bytes, content_hash};
 use crate::ids::{CommitId, IntentId, ProposalId, TrajectoryId, WritId};
-use crate::proposal::PolicyTrace;
+use crate::proposal::{PolicyTrace, RoutingEvidence};
 
 /// An observation captured from a tool execution. Persisted verbatim.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -101,6 +101,12 @@ pub struct CommitBody {
     /// as before, so existing ledgers are unaffected.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub compensates: Option<CommitId>,
+    /// Provider routing evidence carried from the proposal, recorded here so a
+    /// committed (not just suspended) proposal's routing decision is durably
+    /// ledgered and replay-safe. Excluded from the proposal id; backward-
+    /// compatible (`skip_serializing_if`), so commits without it hash unchanged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub routing_evidence: Option<RoutingEvidence>,
     /// ed25519 signature over `canonical_json(body_without_signature)`,
     /// hex-encoded. `None` for unsigned commits; populated by
     /// [`Commit::new_signed`] and checked by [`Commit::verify_signature`].
@@ -138,6 +144,7 @@ mod tests {
             policy_set_hash: String::new(),
             budget_cost: crate::writ::BudgetCost::default(),
             compensates: None,
+            routing_evidence: None,
             signature: None,
         }
     }

--- a/thymos/crates/thymos-core/src/ids.rs
+++ b/thymos/crates/thymos-core/src/ids.rs
@@ -167,6 +167,7 @@ mod tests {
             policy_set_hash: String::new(),
             budget_cost: BudgetCost::default(),
             compensates: None,
+            routing_evidence: None,
             signature: None,
         }
     }

--- a/thymos/crates/thymos-core/src/lib.rs
+++ b/thymos/crates/thymos-core/src/lib.rs
@@ -28,8 +28,8 @@ pub use hash::{canonical_json_bytes, content_hash, ContentHash};
 pub use ids::{CommitId, IntentId, LedgerEntryId, ProposalId, TrajectoryId, WritId};
 pub use intent::{Intent, IntentBody, IntentKind};
 pub use proposal::{
-    ExecutionPlan, PolicyDecision, PolicyTrace, Proposal, ProposalBody, ProposalStatus,
-    RejectionReason,
+    ExecutionPlan, FallbackHint, PolicyDecision, PolicyTrace, Proposal, ProposalBody,
+    ProposalStatus, RejectionReason, RoutingEvidence,
 };
 pub use world::{ResourceKey, World};
 pub use writ::{Budget, EffectCeiling, ToolPattern, Writ, WritBody};

--- a/thymos/crates/thymos-core/src/proposal.rs
+++ b/thymos/crates/thymos-core/src/proposal.rs
@@ -3,10 +3,13 @@
 //! Spec reference: Section 2 (Execution Grammar), Section 3 (Compilation).
 //!
 //! `ProposalId` is content-addressed from the canonical hash of `ProposalBody`.
-//! The proposal contract is **v1-stable** (see `docs/rfcs/proposal-contract-v1.md`):
-//! it carries exactly the fields that define the action and its authorization,
-//! with no experimental or provider-supplied metadata. Provider routing metadata
-//! is deferred to a future RFC and is intentionally not part of this contract.
+//! Per `docs/rfcs/proposal-contract-v1.md`, `Proposal` also carries an optional
+//! `routing_evidence` — provider routing metadata supplied by a pre-Proposal
+//! routing advisor (e.g. WisePick). It lives on `Proposal`, **not** inside
+//! `ProposalBody`, so it does **not** affect `ProposalId`; but it IS bound into
+//! the ledgered envelope (the `Commit` / `PendingApproval` entry hashes) so it is
+//! immutable and replay-safe once recorded. The runtime never reads it for
+//! authority — it is an audit/replay artifact only.
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -21,14 +24,70 @@ use crate::ids::{IntentId, ProposalId, WritId};
 pub struct Proposal {
     pub id: ProposalId,
     pub body: ProposalBody,
+    /// Optional provider routing metadata (Option 2 of the proposal-contract
+    /// RFC). Excluded from `ProposalId` (it is outside `ProposalBody`), so a
+    /// provider cannot influence proposal identity by manipulating it. Bound
+    /// into ledger entry hashes when recorded. The runtime MUST NOT use it for
+    /// authority, budget, or policy decisions — it is audit/replay evidence.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub routing_evidence: Option<RoutingEvidence>,
 }
 
 impl Proposal {
-    /// Construct a Proposal from a body. The id is the content-hash of body.
+    /// Construct a Proposal from a body. The id is the content-hash of body;
+    /// `routing_evidence` is not hashed into the id.
     pub fn new(body: ProposalBody) -> Result<Self> {
         let id = ProposalId(content_hash(&body)?);
-        Ok(Proposal { id, body })
+        Ok(Proposal {
+            id,
+            body,
+            routing_evidence: None,
+        })
     }
+
+    /// Attach routing evidence (does not change `ProposalId`).
+    pub fn with_routing_evidence(mut self, evidence: RoutingEvidence) -> Self {
+        self.routing_evidence = Some(evidence);
+        self
+    }
+}
+
+// ── RoutingEvidence ─────────────────────────────────────────────────────────
+//
+// The replay-safe routing decision artifact produced by a pre-Proposal routing
+// advisor. All numeric fields are fixed-point integers — no floating point in a
+// canonical/ledgered payload (Section 10 determinism). `decision_hash` is a
+// hex digest derived deterministically over the integer-valued payload, so it
+// is stable across replays and free of ephemeral provider identifiers.
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RoutingEvidence {
+    /// Hex digest over the routing decision's canonical (integer-valued) payload.
+    pub decision_hash: String,
+    /// The selected `provider:capability` (ECU) string.
+    pub selected: String,
+    /// Ranked alternatives considered but not selected (for governance-owned
+    /// fallback without re-querying the advisor mid-execution).
+    pub alternatives: Vec<String>,
+    /// Confidence in basis points (0–10000 = 0.00%–100.00%). Fixed-point.
+    pub confidence_bps: u32,
+    /// Machine-readable reason codes for the decision.
+    pub reason_codes: Vec<String>,
+    /// Estimated round-trip latency in milliseconds.
+    pub latency_estimate_ms: u64,
+    /// Estimated cost in USD millicents (1 USD = 100_000 millicents). Fixed-point.
+    pub cost_estimate_millicents: u64,
+    /// Optional fallback hint if the selected route is unavailable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fallback_hint: Option<FallbackHint>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FallbackHint {
+    pub provider: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    pub reason: String,
 }
 
 // ── ProposalBody ──────────────────────────────────────────────────────────────
@@ -151,6 +210,49 @@ mod tests {
         let p1 = Proposal::new(make_body("kv_set")).unwrap();
         let p2 = Proposal::new(make_body("kv_del")).unwrap();
         assert_ne!(p1.id, p2.id);
+    }
+
+    fn sample_evidence() -> RoutingEvidence {
+        RoutingEvidence {
+            decision_hash: "deadbeef".into(),
+            selected: "anthropic:claude".into(),
+            alternatives: vec!["openai:gpt".into()],
+            confidence_bps: 9500,
+            reason_codes: vec!["cost_optimal".into()],
+            latency_estimate_ms: 800,
+            cost_estimate_millicents: 4200,
+            fallback_hint: Some(FallbackHint {
+                provider: "openai".into(),
+                model: Some("gpt-4o".into()),
+                reason: "primary overloaded".into(),
+            }),
+        }
+    }
+
+    #[test]
+    fn routing_evidence_does_not_affect_proposal_id() {
+        let body = make_body("kv_set");
+        let plain = Proposal::new(body.clone()).unwrap();
+        let with_ev = Proposal::new(body).unwrap().with_routing_evidence(sample_evidence());
+        assert_eq!(
+            plain.id, with_ev.id,
+            "routing_evidence lives outside ProposalBody and must not affect ProposalId"
+        );
+    }
+
+    #[test]
+    fn proposal_with_routing_evidence_round_trips() {
+        let p = Proposal::new(make_body("kv_set"))
+            .unwrap()
+            .with_routing_evidence(sample_evidence());
+        let json = serde_json::to_string(&p).unwrap();
+        let back: Proposal = serde_json::from_str(&json).unwrap();
+        assert_eq!(p, back);
+        assert_eq!(back.routing_evidence.unwrap().confidence_bps, 9500);
+
+        // A proposal without evidence omits the field entirely (backward-compat).
+        let plain = Proposal::new(make_body("kv_set")).unwrap();
+        assert!(!serde_json::to_string(&plain).unwrap().contains("routing_evidence"));
     }
 
     #[test]

--- a/thymos/crates/thymos-ledger/src/anchor.rs
+++ b/thymos/crates/thymos-ledger/src/anchor.rs
@@ -120,6 +120,7 @@ mod tests {
             policy_set_hash: String::new(),
             budget_cost: thymos_core::writ::BudgetCost::default(),
             compensates: None,
+            routing_evidence: None,
             signature: None,
         };
         ledger.append_commit(Commit::new(body).unwrap()).unwrap();

--- a/thymos/crates/thymos-ledger/src/lib.rs
+++ b/thymos/crates/thymos-ledger/src/lib.rs
@@ -271,6 +271,7 @@ mod tests {
             policy_set_hash: String::new(),
             budget_cost: thymos_core::writ::BudgetCost::default(),
             compensates: None,
+            routing_evidence: None,
             signature: None,
         };
         Commit::new(body).unwrap()
@@ -365,6 +366,7 @@ mod tests {
                     policy_set_hash: String::new(),
                     budget_cost: thymos_core::writ::BudgetCost::default(),
                     compensates: None,
+                    routing_evidence: None,
                     signature: None,
                 };
                 let commit = Commit::new(body).unwrap();

--- a/thymos/crates/thymos-ledger/src/replay.rs
+++ b/thymos/crates/thymos-ledger/src/replay.rs
@@ -211,6 +211,7 @@ mod tests {
             policy_set_hash: String::new(),
             budget_cost: thymos_core::writ::BudgetCost::default(),
             compensates: None,
+            routing_evidence: None,
             signature: None,
         };
         let commit = Commit::new(body).unwrap();
@@ -298,6 +299,7 @@ mod tests {
             policy_set_hash: String::new(),
             budget_cost: thymos_core::writ::BudgetCost::default(),
             compensates: None,
+            routing_evidence: None,
             signature: None,
         };
         let commit = Commit::new_signed(body, sk).unwrap();
@@ -404,6 +406,7 @@ mod bench_tests {
             policy_set_hash: String::new(),
             budget_cost: thymos_core::writ::BudgetCost::default(),
             compensates: None,
+            routing_evidence: None,
             signature: None,
         };
         Commit::new(body).unwrap()

--- a/thymos/crates/thymos-runtime/src/agent.rs
+++ b/thymos/crates/thymos-runtime/src/agent.rs
@@ -267,7 +267,7 @@ pub fn run_agent(
                 },
             );
             let result =
-                match run.submit_with_trace(intent.clone(), writ, step_idx, event_tx.as_ref()) {
+                match run.submit_with_trace(intent.clone(), writ, step_idx, event_tx.as_ref(), None) {
                     Ok(result) => result,
                     Err(err) => {
                         failures += 1;

--- a/thymos/crates/thymos-runtime/src/agent_async.rs
+++ b/thymos/crates/thymos-runtime/src/agent_async.rs
@@ -194,7 +194,7 @@ pub async fn run_agent_streaming(
             let result = {
                 let intent_clone = intent.clone();
                 let writ_clone = writ.clone();
-                run.submit_with_trace(intent_clone, &writ_clone, step_idx, trace_tx.as_ref())
+                run.submit_with_trace(intent_clone, &writ_clone, step_idx, trace_tx.as_ref(), None)
             };
             let result = match result {
                 Ok(result) => result,

--- a/thymos/crates/thymos-runtime/src/lib.rs
+++ b/thymos/crates/thymos-runtime/src/lib.rs
@@ -490,17 +490,33 @@ impl<'a> Run<'a> {
 
     /// Submit one Intent. Runs it through the full Triad.
     pub fn submit(&self, intent: Intent, writ: &thymos_core::writ::Writ) -> Result<Step> {
-        self.submit_with_trace(intent, writ, 0, None)
+        self.submit_with_trace(intent, writ, 0, None, None)
+    }
+
+    /// Submit one Intent with provider routing evidence from a pre-Proposal
+    /// routing advisor (e.g. WisePick). The evidence is attached to the compiled
+    /// proposal — it does not affect `ProposalId`, but is recorded into the
+    /// ledgered envelope (commit / pending-approval), so it is immutable and
+    /// replay-safe. It never influences authority, budget, or policy.
+    pub fn submit_with_routing_evidence(
+        &self,
+        intent: Intent,
+        writ: &thymos_core::writ::Writ,
+        routing_evidence: thymos_core::proposal::RoutingEvidence,
+    ) -> Result<Step> {
+        self.submit_with_trace(intent, writ, 0, None, Some(routing_evidence))
     }
 
     /// Submit one intent while emitting structured trace events for operator
     /// surfaces that need live Intent → Proposal → Execution → Result state.
+    /// `routing_evidence`, if present, is attached to the compiled proposal.
     pub fn submit_with_trace(
         &self,
         intent: Intent,
         writ: &thymos_core::writ::Writ,
         step_index: u32,
         trace: Option<&crate::AgentEventCallback>,
+        routing_evidence: Option<thymos_core::proposal::RoutingEvidence>,
     ) -> Result<Step> {
         #[cfg(feature = "telemetry")]
         let _span = tracing::info_span!(
@@ -545,6 +561,29 @@ impl<'a> Run<'a> {
 
         #[cfg(feature = "telemetry")]
         drop(_compile_span);
+
+        // Attach routing evidence (if supplied) to the compiled proposal. It is
+        // outside ProposalBody, so ProposalId is unchanged; it rides into the
+        // ledgered envelope from here.
+        let compiled = match compiled {
+            Compiled::Staged(mut proposal) => {
+                proposal.routing_evidence = routing_evidence.clone();
+                Compiled::Staged(proposal)
+            }
+            Compiled::Suspended {
+                mut proposal,
+                channel,
+                reason,
+            } => {
+                proposal.routing_evidence = routing_evidence.clone();
+                Compiled::Suspended {
+                    proposal,
+                    channel,
+                    reason,
+                }
+            }
+            other => other,
+        };
 
         match compiled {
             Compiled::Rejected(reason) => {
@@ -715,6 +754,7 @@ impl<'a> Run<'a> {
                     policy_set_hash: self.runtime.policy.policy_set_hash(),
                     budget_cost,
                     compensates: None,
+                    routing_evidence: proposal.routing_evidence.clone(),
                     signature: None,
                 };
                 let commit = self.runtime.build_commit(commit_body)?;
@@ -1028,6 +1068,7 @@ impl<'a> Run<'a> {
             policy_set_hash: self.runtime.policy.policy_set_hash(),
             budget_cost,
             compensates: None,
+            routing_evidence: proposal.routing_evidence.clone(),
             signature: None,
         };
         let commit = self.runtime.build_commit(commit_body)?;
@@ -1177,6 +1218,7 @@ impl<'a> Run<'a> {
                 policy_set_hash: self.runtime.policy.policy_set_hash(),
                 budget_cost: BudgetCost::default(),
                 compensates: Some(original.id),
+                routing_evidence: None,
                 signature: None,
             };
             let commit = self.runtime.build_commit(body)?;

--- a/thymos/crates/thymos-runtime/tests/replay_safety.rs
+++ b/thymos/crates/thymos-runtime/tests/replay_safety.rs
@@ -238,6 +238,7 @@ fn replay_rejects_commit_with_empty_compiler_version() {
         policy_set_hash: String::new(),
         budget_cost: thymos_core::writ::BudgetCost::default(),
         compensates: None,
+        routing_evidence: None,
         signature: None,
     };
     let commit = Commit::new(body).unwrap();

--- a/thymos/crates/thymos-runtime/tests/routing_evidence.rs
+++ b/thymos/crates/thymos-runtime/tests/routing_evidence.rs
@@ -1,0 +1,168 @@
+//! Routing evidence (WisePick / Option 2): evidence attached at submit time is
+//! recorded into the committed (ledgered) record — durable and replay-safe — and
+//! does not affect the proposal id.
+
+use serde_json::{json, Value};
+
+use thymos_core::{
+    commit::Observation, delta::StructuredDelta, error::Result, proposal::FallbackHint,
+    RoutingEvidence,
+};
+use thymos_ledger::{EntryPayload, Ledger};
+use thymos_policy::{PolicyEngine, WritAuthorityPolicy};
+use thymos_runtime::{
+    generate_signing_key, public_key_of, Budget, CoreIntent, DelegationBounds, EffectCeiling,
+    IntentBody, IntentKind, Runtime, Step, TimeWindow, ToolPattern, Writ, WritBody,
+};
+use thymos_tools::{
+    EffectClass, RiskClass, ToolContract, ToolContractMeta, ToolInvocation, ToolOutcome,
+    ToolRegistry,
+};
+
+struct NoopTool;
+impl ToolContract for NoopTool {
+    fn meta(&self) -> &ToolContractMeta {
+        static M: std::sync::OnceLock<ToolContractMeta> = std::sync::OnceLock::new();
+        M.get_or_init(|| ToolContractMeta {
+            name: "act".into(),
+            version: "1.0.0".into(),
+            effect_class: EffectClass::Write,
+            risk_class: RiskClass::Low,
+        })
+    }
+    fn description(&self) -> &str {
+        "noop"
+    }
+    fn input_schema(&self) -> Value {
+        json!({"type": "object"})
+    }
+    fn execute(&self, _inv: &ToolInvocation<'_>) -> Result<ToolOutcome> {
+        Ok(ToolOutcome {
+            delta: StructuredDelta(vec![]),
+            observation: Observation {
+                tool: "act".into(),
+                output: json!(null),
+                latency_ms: 0,
+            },
+        })
+    }
+}
+
+fn writ() -> Writ {
+    let issuer = generate_signing_key();
+    let subject = generate_signing_key();
+    Writ::sign(
+        WritBody {
+            issuer: "root".into(),
+            issuer_pubkey: public_key_of(&issuer),
+            subject: "agent".into(),
+            subject_pubkey: public_key_of(&subject),
+            nonce: [0u8; 16],
+            parent: None,
+            tenant_id: String::new(),
+            tool_scopes: vec![ToolPattern::exact("act")],
+            budget: Budget {
+                tokens: 10_000,
+                tool_calls: 100,
+                wall_clock_ms: 600_000,
+                usd_millicents: 0,
+            },
+            effect_ceiling: EffectCeiling::read_write_local(),
+            time_window: TimeWindow {
+                not_before: 0,
+                expires_at: u64::MAX,
+            },
+            delegation: DelegationBounds {
+                max_depth: 1,
+                may_subdivide: false,
+            },
+        },
+        &issuer,
+    )
+    .unwrap()
+}
+
+fn evidence() -> RoutingEvidence {
+    RoutingEvidence {
+        decision_hash: "abc123".into(),
+        selected: "anthropic:claude".into(),
+        alternatives: vec!["openai:gpt".into()],
+        confidence_bps: 9000,
+        reason_codes: vec!["cost_optimal".into()],
+        latency_estimate_ms: 700,
+        cost_estimate_millicents: 1234,
+        fallback_hint: Some(FallbackHint {
+            provider: "openai".into(),
+            model: Some("gpt-4o".into()),
+            reason: "primary overloaded".into(),
+        }),
+    }
+}
+
+fn intent() -> CoreIntent {
+    CoreIntent::new(IntentBody {
+        parent_commit: None,
+        author: "test".into(),
+        kind: IntentKind::Act,
+        target: "act".into(),
+        args: json!({}),
+        rationale: "routing".into(),
+        nonce: [7; 16],
+    })
+    .unwrap()
+}
+
+#[test]
+fn routing_evidence_is_recorded_in_the_commit_and_replay_safe() {
+    let mut tools = ToolRegistry::new();
+    tools.register(NoopTool);
+    let runtime = Runtime::new(
+        Ledger::open_in_memory().unwrap(),
+        tools,
+        PolicyEngine::new().with(WritAuthorityPolicy),
+    );
+    let w = writ();
+    let run = runtime.create_run("re", b"re").unwrap();
+
+    let committed = run
+        .submit_with_routing_evidence(intent(), &w, evidence())
+        .unwrap();
+    assert!(matches!(committed, Step::Committed(_)));
+
+    // The committed ledger entry carries the routing evidence verbatim.
+    let entries = runtime.ledger.entries(run.trajectory_id()).unwrap();
+    let recorded = entries
+        .iter()
+        .find_map(|e| match &e.payload {
+            EntryPayload::Commit(c) => c.body.routing_evidence.clone(),
+            _ => None,
+        })
+        .expect("commit should carry routing_evidence");
+    assert_eq!(recorded, evidence());
+    assert_eq!(recorded.confidence_bps, 9000);
+    assert_eq!(recorded.cost_estimate_millicents, 1234);
+
+    // It is bound into the hash chain (integrity holds with it present).
+    runtime.ledger.verify_integrity(run.trajectory_id()).unwrap();
+}
+
+#[test]
+fn submit_without_evidence_omits_it() {
+    let mut tools = ToolRegistry::new();
+    tools.register(NoopTool);
+    let runtime = Runtime::new(
+        Ledger::open_in_memory().unwrap(),
+        tools,
+        PolicyEngine::new().with(WritAuthorityPolicy),
+    );
+    let w = writ();
+    let run = runtime.create_run("re2", b"re2").unwrap();
+    run.submit(intent(), &w).unwrap();
+
+    let entries = runtime.ledger.entries(run.trajectory_id()).unwrap();
+    let has_evidence = entries.iter().any(|e| match &e.payload {
+        EntryPayload::Commit(c) => c.body.routing_evidence.is_some(),
+        _ => false,
+    });
+    assert!(!has_evidence, "no evidence attached → field stays None");
+}


### PR DESCRIPTION
Deploys the **Option-2 routing-evidence types** agreed in #1, so the WisePick adapter (`adapters/thymos_adapter.py`) can integrate. *(An earlier stabilization pass had removed the then-inert field; it is reinstated now that there's a concrete consumer, with real ledger storage + replay safety.)*

## What
- **`Proposal.routing_evidence: Option<RoutingEvidence>`** — outside `ProposalBody`, so it does **not** affect `ProposalId`. `RoutingEvidence { decision_hash, selected, alternatives, confidence_bps, reason_codes, latency_estimate_ms, cost_estimate_millicents, fallback_hint }` + `FallbackHint`. **All fixed-point integers** (no floats); `decision_hash` deterministic. Optional + `skip_serializing_if` → backward-compatible.
- **`CommitBody.routing_evidence`** — committed proposals durably carry the artifact (replay-safe); suspended ones already do via `PendingApproval`. Bound into the entry hash.
- **`Run::submit_with_routing_evidence(intent, writ, evidence)`** — attaches evidence post-compile; never read for authority/budget/policy.
- RFC `proposal-contract-v1` formalizes Option 2; version `0.3.0 → 0.4.0` (additive).

## Matches the adapter
The schema mirrors what WisePick built: top-level Proposal envelope, `ProposalBody` insulated, basis-point confidence, millicent cost, deterministic `decision_hash`.

## Tests
routing_evidence excluded from `ProposalId` + round-trips; recorded in the commit & replay-safe; omitted when absent. **227 pass, 0 warnings.**

Closes the core-side blocker for #1.
