### PR TITLE
feat(server): /routed-submit + WisePick integration guide (v0.4.1)

### DIFF
--- a/docs/integrations/wisepick.md
+++ b/docs/integrations/wisepick.md
@@ -1,0 +1,124 @@
+# Integrating WisePick with OpenThymos
+
+WisePick is a pre-Proposal **routing advisor**: it scores candidate capabilities
+and returns a route plus decision metadata *before* governed execution begins.
+OpenThymos owns everything after that — authority, execution, side effects,
+recovery, and the durable record of what happened.
+
+```
+Intent
+  → WisePick scores candidate capabilities (off-runtime)
+  → returns routing evidence (selected route + alternatives + estimates)
+  → THYMOS compiles a Proposal and attaches the evidence
+  → writ / effect-ceiling / budget / policy decide whether it runs
+  → THYMOS executes through its tool fabric
+  → result / rejection / suspension / delegation is ledgered
+```
+
+**The boundary:** routing decides what *looks* optimal; governance decides what
+is *allowed*; execution proves what actually *happened*. WisePick never gains
+execution authority — its evidence is recorded for audit/replay and is **never**
+read by the runtime for authority, budget, or policy decisions.
+
+## The routing-evidence contract (Proposal Contract v1, Option 2)
+
+`routing_evidence` is a first-class **optional** field on `Proposal` — it lives
+*outside* `ProposalBody`, so it does **not** affect `ProposalId`. When recorded
+it is bound into the ledgered envelope (the `Commit` / `PendingApproval` entry
+hashes), so it is immutable and replay-safe. See
+[`docs/rfcs/proposal-contract-v1.md`](../rfcs/proposal-contract-v1.md).
+
+Wire shape (JSON):
+
+```json
+{
+  "decision_hash": "<hex digest over the integer-valued payload>",
+  "selected": "provider:capability",
+  "alternatives": ["provider:capabilityA", "provider:capabilityB"],
+  "confidence_bps": 9500,
+  "reason_codes": ["cost_optimal"],
+  "latency_estimate_ms": 800,
+  "cost_estimate_millicents": 4200,
+  "fallback_hint": { "provider": "openai", "model": "gpt-4o", "reason": "primary overloaded" }
+}
+```
+
+Rules:
+
+- **No floating point.** `confidence_bps` is basis points (0–10000); cost is USD
+  millicents (`cost_estimate_millicents`). Both are fixed-point integers, so the
+  payload is deterministic and replay-stable.
+- **`decision_hash`** is a hex digest derived deterministically over those
+  integer values — no ephemeral provider/request identifiers — so it is the
+  stable rehydration key across replays.
+- **`alternatives`** is the ranked fallback list. Retry/fallback topology stays
+  THYMOS-owned; alternatives let it fall back without re-querying WisePick
+  mid-execution.
+- `fallback_hint` and `fallback_hint.model` are optional; all other fields are
+  required.
+
+Minimum version: the **types** ship in `v0.4.0`. The **HTTP endpoint** below
+ships in `v0.4.1`.
+
+## Integration path A — HTTP (`POST /routed-submit`)
+
+For adapters that talk to the THYMOS server. One request = one governed action.
+
+Request:
+
+```json
+{
+  "tool": "kv_set",
+  "args": { "key": "k", "value": "v" },
+  "rationale": "wisepick selected this route",
+  "routing_evidence": { /* the object above */ }
+}
+```
+
+Response (one of):
+
+```json
+{ "status": "committed", "trajectory_id": "<hex>", "commit_id": "<hex>", "routing_evidence_recorded": true }
+{ "status": "rejected",  "trajectory_id": "<hex>", "reason": "writ does not authorize tool '...'": }
+{ "status": "suspended", "trajectory_id": "<hex>", "channel": "ops", "reason": "..." }
+{ "status": "delegated", "trajectory_id": "<hex>", "child_trajectory_id": "<hex>" }
+```
+
+The server mints a writ scoped to the requested tool, compiles the proposal,
+attaches `routing_evidence`, and runs it through the full governance pipeline.
+The evidence is recorded immutably on the commit.
+
+## Integration path B — Rust runtime
+
+For embedding directly against `thymos-runtime`:
+
+```rust
+let evidence = RoutingEvidence { /* ... */ };
+let step = run.submit_with_routing_evidence(intent, &writ, evidence)?;
+```
+
+`Proposal::with_routing_evidence(evidence)` is also available if you construct
+proposals yourself.
+
+## Replay & determinism
+
+THYMOS replay folds committed ledger deltas to reproduce the same world
+projection. WisePick's routing state evolves over time from execution feedback,
+which is **not** deterministic — so replay must never call back into WisePick.
+
+This is why the artifact is recorded immutably at commit time. On replay, the
+runtime reads `routing_evidence` straight from the ledgered entry (keyed by
+`decision_hash`); it does not re-query the advisor. Your adapter's
+cached-decision mode is the canonical replay path.
+
+## What stays on each side
+
+| WisePick | OpenThymos |
+|----------|------------|
+| capability scoring | proposal lifecycle |
+| route suggestion + ranked alternatives | authority / governance (writ, effect ceiling, budget, policy) |
+| cost / latency / confidence estimates | execution + retries / fallback / compensation |
+| feedback-shaped routing efficacy | durable execution truth (the ledger) |
+
+See issue [#1](https://github.com/gryszzz/open-thymos/issues/1) for the design
+discussion this integration formalizes.

--- a/thymos/Cargo.lock
+++ b/thymos/Cargo.lock
@@ -2699,7 +2699,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-cli"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "axum 0.8.9",
  "clap",
@@ -2718,7 +2718,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-client"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "axum-test",
  "reqwest",
@@ -2732,7 +2732,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-cognition"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -2746,7 +2746,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-compiler"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -2757,7 +2757,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "blake3",
  "ed25519-dalek",
@@ -2770,7 +2770,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-ledger"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "blake3",
  "deadpool-postgres",
@@ -2786,7 +2786,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-marketplace"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "blake3",
  "hex",
@@ -2799,7 +2799,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-policy"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -2808,7 +2808,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-runtime"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "serde",
@@ -2825,7 +2825,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-server"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2858,7 +2858,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-tools"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "blake3",
  "reqwest",
@@ -2871,7 +2871,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-worker"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "serde_json",
  "thymos-tools",

--- a/thymos/Cargo.toml
+++ b/thymos/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license = "Apache-2.0"
 rust-version = "1.80"

--- a/thymos/crates/thymos-server/src/lib.rs
+++ b/thymos/crates/thymos-server/src/lib.rs
@@ -43,6 +43,8 @@ use thymos_cognition::{build_cognition, CognitionConfig, CognitionEvent, NonStre
 use thymos_core::{
     content_hash,
     crypto::{generate_signing_key, public_key_of},
+    intent::{Intent, IntentBody, IntentKind},
+    proposal::RoutingEvidence,
     writ::{Budget, DelegationBounds, EffectCeiling, TimeWindow, ToolPattern, Writ, WritBody},
     TrajectoryId,
 };
@@ -50,7 +52,8 @@ use thymos_ledger::{EntryPayload, Ledger};
 use thymos_policy::{PolicyEngine, WritAuthorityPolicy};
 use thymos_runtime::agent_async::ApprovalDecision;
 use thymos_runtime::{
-    AgentEventCallback, AgentRunOptions, AgentRunSummary, AgentTraceEvent, Runtime, Termination,
+    AgentEventCallback, AgentRunOptions, AgentRunSummary, AgentTraceEvent, Runtime, Step,
+    Termination,
 };
 use thymos_tools::{
     DelegateTool, FsPatchTool, FsReadTool, GrepTool, HttpTool, KvGetTool, KvSetTool, ListFilesTool,
@@ -457,6 +460,7 @@ pub fn app(state: Arc<AppState>) -> Router {
         .route("/runs/{id}/cancel", post(cancel_run))
         .route("/writs/{writ_id}/revoke", post(revoke_writ_handler))
         .route("/writs/{writ_id}/restore", post(restore_writ_handler))
+        .route("/routed-submit", post(routed_submit))
         .route("/runs/{id}/delegations", get(get_delegations))
         .route("/runs/{id}/branch", post(post_branch))
         .route("/usage", get(get_usage))
@@ -620,6 +624,147 @@ fn writ_id_from_hex(writ_hex: &str) -> Result<thymos_core::WritId, &'static str>
     let mut arr = [0u8; 32];
     arr.copy_from_slice(&bytes);
     Ok(thymos_core::WritId(thymos_core::ContentHash(arr)))
+}
+
+/// One governed action submitted with pre-Proposal routing evidence. This is the
+/// WisePick integration path: the advisor decides the route, the client posts the
+/// action + evidence, THYMOS governs (writ/effect/budget/policy), executes, and
+/// ledgers the result — with `routing_evidence` recorded immutably on the commit.
+#[derive(Debug, Deserialize)]
+pub struct RoutedSubmitRequest {
+    /// Tool to invoke.
+    pub tool: String,
+    /// Tool arguments.
+    #[serde(default)]
+    pub args: serde_json::Value,
+    /// Optional rationale recorded on the intent.
+    #[serde(default)]
+    pub rationale: String,
+    /// Routing evidence to bind into the ledgered proposal (audit/replay only).
+    #[serde(default)]
+    pub routing_evidence: Option<RoutingEvidence>,
+}
+
+/// Submit a single routed action. Creates its own trajectory, mints a writ
+/// scoped to the requested tool, attaches `routing_evidence`, and returns the
+/// governed outcome.
+async fn routed_submit(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<RoutedSubmitRequest>,
+) -> impl IntoResponse {
+    let runtime = state.runtime.clone();
+
+    // Fresh trajectory per routed action.
+    let seed = thymos_core::crypto::random_nonce();
+    let run = match runtime.create_run(&format!("routed:{}", req.tool), &seed) {
+        Ok(r) => r,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": e.to_string() })),
+            )
+                .into_response()
+        }
+    };
+    let trajectory_hex = run.trajectory_id().to_string();
+
+    // Mint a writ scoped to just this tool.
+    let root_key = generate_signing_key();
+    let agent_key = generate_signing_key();
+    let writ = match Writ::sign(
+        WritBody {
+            issuer: "server".into(),
+            issuer_pubkey: public_key_of(&root_key),
+            subject: "routed".into(),
+            subject_pubkey: public_key_of(&agent_key),
+            nonce: thymos_core::crypto::random_nonce(),
+            parent: None,
+            tenant_id: String::new(),
+            tool_scopes: vec![ToolPattern::exact(&req.tool)],
+            budget: Budget {
+                tokens: 100_000,
+                tool_calls: 8,
+                wall_clock_ms: 300_000,
+                usd_millicents: 0,
+            },
+            effect_ceiling: EffectCeiling::read_write_local(),
+            time_window: TimeWindow {
+                not_before: 0,
+                expires_at: u64::MAX,
+            },
+            delegation: DelegationBounds {
+                max_depth: 1,
+                may_subdivide: false,
+            },
+        },
+        &root_key,
+    ) {
+        Ok(w) => w,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": e.to_string() })),
+            )
+                .into_response()
+        }
+    };
+
+    let intent = match Intent::new(IntentBody {
+        parent_commit: None,
+        author: "routed-submit".into(),
+        kind: IntentKind::Act,
+        target: req.tool.clone(),
+        args: req.args.clone(),
+        rationale: req.rationale.clone(),
+        nonce: thymos_core::crypto::random_nonce(),
+    }) {
+        Ok(i) => i,
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "error": e.to_string() })),
+            )
+                .into_response()
+        }
+    };
+
+    let result = match req.routing_evidence.clone() {
+        Some(ev) => run.submit_with_routing_evidence(intent, &writ, ev),
+        None => run.submit(intent, &writ),
+    };
+
+    let body = match result {
+        Ok(Step::Committed(id)) => serde_json::json!({
+            "status": "committed",
+            "trajectory_id": trajectory_hex,
+            "commit_id": id.to_string(),
+            "routing_evidence_recorded": req.routing_evidence.is_some(),
+        }),
+        Ok(Step::Rejected(reason)) => serde_json::json!({
+            "status": "rejected",
+            "trajectory_id": trajectory_hex,
+            "reason": reason.to_string(),
+        }),
+        Ok(Step::Suspended { channel, reason }) => serde_json::json!({
+            "status": "suspended",
+            "trajectory_id": trajectory_hex,
+            "channel": channel,
+            "reason": reason,
+        }),
+        Ok(Step::Delegated { child_trajectory_id, .. }) => serde_json::json!({
+            "status": "delegated",
+            "trajectory_id": trajectory_hex,
+            "child_trajectory_id": child_trajectory_id.to_string(),
+        }),
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": e.to_string() })),
+            )
+                .into_response()
+        }
+    };
+    (StatusCode::OK, Json(body)).into_response()
 }
 
 /// Revoke a writ by id. Subsequent submissions under it (or under any child

--- a/thymos/crates/thymos-server/tests/e2e.rs
+++ b/thymos/crates/thymos-server/tests/e2e.rs
@@ -131,6 +131,45 @@ async fn revoke_writ_invalid_id_returns_400() {
 }
 
 #[tokio::test]
+async fn routed_submit_commits_and_records_routing_evidence() {
+    let server = test_server(test_state());
+    let resp = server
+        .post("/routed-submit")
+        .json(&json!({
+            "tool": "kv_set",
+            "args": { "key": "k", "value": "v" },
+            "rationale": "wisepick route",
+            "routing_evidence": {
+                "decision_hash": "abc123",
+                "selected": "anthropic:claude",
+                "alternatives": ["openai:gpt"],
+                "confidence_bps": 9500,
+                "reason_codes": ["cost_optimal"],
+                "latency_estimate_ms": 800,
+                "cost_estimate_millicents": 4200
+            }
+        }))
+        .await;
+    resp.assert_status_ok();
+    let body: Value = resp.json();
+    assert_eq!(body["status"], "committed");
+    assert_eq!(body["routing_evidence_recorded"], true);
+    assert!(body["commit_id"].is_string());
+}
+
+#[tokio::test]
+async fn routed_submit_unknown_tool_is_rejected_not_executed() {
+    let server = test_server(test_state());
+    let resp = server
+        .post("/routed-submit")
+        .json(&json!({ "tool": "ghost_tool", "args": {} }))
+        .await;
+    resp.assert_status_ok();
+    let body: Value = resp.json();
+    assert_eq!(body["status"], "rejected");
+}
+
+#[tokio::test]
 async fn create_run_with_cognition_config() {
     let server = test_server(test_state());
     let resp = server


### PR DESCRIPTION
The HTTP integration path for WisePick (#1), plus docs and the release bump.

## What
- **`POST /routed-submit`** `{ tool, args, rationale?, routing_evidence? }` — mints a tool-scoped writ, governs (writ/effect/budget/policy), executes, ledgers, and records `routing_evidence` immutably on the commit. Returns `committed`/`rejected`/`suspended`/`delegated`. Evidence is never read for authority.
- **`docs/integrations/wisepick.md`** — routing-advisor boundary, the `routing_evidence` wire contract (fixed-point, `decision_hash`, `ProposalId`-insulated, replay-safe), both integration paths (HTTP + Rust runtime), and replay/cached-decision semantics.
- **version 0.4.0 → 0.4.1.**

## Tests
e2e: routed-submit commits + records routing_evidence; unknown tool → rejected. **229 pass, 0 warnings.**

Merging this + tagging **v0.4.1** makes the HTTP adapter path fully good-to-go for WisePick.