### PR TITLE
feat: safe routing-feedback export (pull, ledger-derived, no egress) — v0.4.3

### DIFF
--- a/docs/integrations/wisepick.md
+++ b/docs/integrations/wisepick.md
@@ -111,6 +111,38 @@ runtime reads `routing_evidence` straight from the ledgered entry (keyed by
 `decision_hash`); it does not re-query the advisor. Your adapter's
 cached-decision mode is the canonical replay path.
 
+## Routing feedback (safe, pull-based)
+
+A routing advisor improves from execution outcomes. THYMOS can supply that
+signal without breaking determinism or data sovereignty:
+
+- **`GET /runs/{id_or_trajectory}/routing-outcomes`** returns the outcomes for a
+  trajectory (also accepts the `trajectory_id` returned by `/routed-submit`).
+- Each record is minimal and non-sensitive:
+
+  ```json
+  { "decision_hash": "deadbeef", "selected": "anthropic:claude", "status": "committed", "latency_ms": 42 }
+  ```
+
+  Keyed by `decision_hash` so the advisor joins it back to its own decision —
+  **never** intent args, tool output, tenant, writ, resource values, or any free
+  text.
+
+Properties that keep this safe and THYMOS-consistent:
+
+- **Pull, not push.** THYMOS initiates no egress; the advisor fetches outcomes
+  and decides what to do with them. The operator owns the data boundary.
+- **Out of the replay path.** Outcomes are derived from the committed ledger
+  after the fact; they are never read back into execution, so they cannot make
+  the same intent route differently on replay.
+- **Derived from the ledger** (the audit source of truth), so the export is
+  exactly what was committed — auditable and stable.
+
+A live, third-party *shared* feedback pool is a separate decision: any such loop
+must stay strictly on the forward path (never replay), and the operator should
+weigh telemetry egress explicitly. This endpoint is the building block that lets
+you do that on your own terms.
+
 ## What stays on each side
 
 | WisePick | OpenThymos |

--- a/thymos/Cargo.lock
+++ b/thymos/Cargo.lock
@@ -2699,7 +2699,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-cli"
-version = "0.4.1"
+version = "0.4.3"
 dependencies = [
  "axum 0.8.9",
  "clap",
@@ -2718,7 +2718,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-client"
-version = "0.4.1"
+version = "0.4.3"
 dependencies = [
  "axum-test",
  "reqwest",
@@ -2732,7 +2732,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-cognition"
-version = "0.4.1"
+version = "0.4.3"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -2746,7 +2746,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-compiler"
-version = "0.4.1"
+version = "0.4.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -2757,7 +2757,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-core"
-version = "0.4.1"
+version = "0.4.3"
 dependencies = [
  "blake3",
  "ed25519-dalek",
@@ -2770,7 +2770,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-ledger"
-version = "0.4.1"
+version = "0.4.3"
 dependencies = [
  "blake3",
  "deadpool-postgres",
@@ -2786,7 +2786,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-marketplace"
-version = "0.4.1"
+version = "0.4.3"
 dependencies = [
  "blake3",
  "hex",
@@ -2799,7 +2799,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-policy"
-version = "0.4.1"
+version = "0.4.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -2808,7 +2808,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-runtime"
-version = "0.4.1"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "serde",
@@ -2825,7 +2825,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-server"
-version = "0.4.1"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2858,7 +2858,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-tools"
-version = "0.4.1"
+version = "0.4.3"
 dependencies = [
  "blake3",
  "reqwest",
@@ -2871,7 +2871,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-worker"
-version = "0.4.1"
+version = "0.4.3"
 dependencies = [
  "serde_json",
  "thymos-tools",

--- a/thymos/Cargo.toml
+++ b/thymos/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 license = "Apache-2.0"
 rust-version = "1.80"

--- a/thymos/crates/thymos-runtime/src/feedback.rs
+++ b/thymos/crates/thymos-runtime/src/feedback.rs
@@ -1,0 +1,72 @@
+//! Safe routing-feedback export.
+//!
+//! A routing advisor (e.g. WisePick) improves over time from execution
+//! outcomes. THYMOS can supply that signal **without** compromising the two
+//! things it guarantees:
+//!
+//! 1. **Determinism / replay** — this is a *pull* derived from the committed
+//!    ledger after the fact. It is never read back into execution and never
+//!    touches the replay path, so it cannot make the same intent route
+//!    differently on replay. (Replay still rehydrates routing evidence from the
+//!    immutable ledger snapshot, never from a live feedback pool.)
+//! 2. **Data sovereignty** — a [`RoutingOutcome`] carries only the routing
+//!    decision id, the route that was chosen, a coarse status, and latency.
+//!    It deliberately excludes intent args, tool output, tenant identity, writ
+//!    ids, resource values, and any free-text reason — nothing that could leak
+//!    workload content or identity. And there is **no built-in network egress**:
+//!    callers obtain the records and decide whether/where to send them. Off by
+//!    default — it's a pull, not a push.
+//!
+//! The records are derived purely from the ledger (the audit source of truth),
+//! so what is exported is exactly what was committed — auditable and stable.
+
+use serde::{Deserialize, Serialize};
+
+use thymos_ledger::{Entry, EntryPayload};
+
+/// A single, non-sensitive routing outcome suitable for export to a routing
+/// advisor's feedback channel. Keyed by `decision_hash` so the advisor can join
+/// it back to the decision it made — without THYMOS revealing what was done.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RoutingOutcome {
+    /// The advisor's decision id (from `routing_evidence.decision_hash`). The
+    /// join key; reveals nothing about the workload by itself.
+    pub decision_hash: String,
+    /// The route that was selected (`provider:capability`). The advisor supplied
+    /// this, so returning it leaks nothing new.
+    pub selected: String,
+    /// Coarse outcome of the routed action. Currently `"committed"` — the route
+    /// reached execution and was recorded. (Routes rejected at the governance
+    /// boundary do not carry routing evidence on the ledger, so they are not
+    /// exported.)
+    pub status: String,
+    /// Execution latency in milliseconds, from the recorded observation.
+    pub latency_ms: u64,
+}
+
+/// Derive the safe routing-outcome records for a trajectory from its ledger
+/// entries. Pure and read-only: only committed entries that carry routing
+/// evidence produce an outcome, and only the non-sensitive fields above are
+/// emitted.
+pub fn routing_outcomes(entries: &[Entry]) -> Vec<RoutingOutcome> {
+    entries
+        .iter()
+        .filter_map(|e| match &e.payload {
+            EntryPayload::Commit(c) => {
+                let ev = c.body.routing_evidence.as_ref()?;
+                Some(RoutingOutcome {
+                    decision_hash: ev.decision_hash.clone(),
+                    selected: ev.selected.clone(),
+                    status: "committed".to_string(),
+                    latency_ms: c
+                        .body
+                        .observations
+                        .first()
+                        .map(|o| o.latency_ms)
+                        .unwrap_or(0),
+                })
+            }
+            _ => None,
+        })
+        .collect()
+}

--- a/thymos/crates/thymos-runtime/src/lib.rs
+++ b/thymos/crates/thymos-runtime/src/lib.rs
@@ -25,6 +25,9 @@ pub use agent::{
     run_agent, AgentEventCallback, AgentRunOptions, AgentRunSummary, AgentTraceEvent, Termination,
 };
 
+pub mod feedback;
+pub use feedback::{routing_outcomes, RoutingOutcome};
+
 #[cfg(feature = "async")]
 pub mod agent_async;
 #[cfg(feature = "async")]
@@ -486,6 +489,15 @@ impl<'a> Run<'a> {
             }
         }
         None
+    }
+
+    /// Safe routing-feedback for this trajectory: minimal, non-sensitive
+    /// outcome records derived from the committed ledger (see
+    /// [`crate::feedback`]). A pull, not a push — no network egress; the caller
+    /// decides whether to forward these to a routing advisor's feedback channel.
+    pub fn routing_outcomes(&self) -> Result<Vec<crate::RoutingOutcome>> {
+        let entries = self.runtime.ledger.entries(self.trajectory_id)?;
+        Ok(crate::routing_outcomes(&entries))
     }
 
     /// Submit one Intent. Runs it through the full Triad.

--- a/thymos/crates/thymos-runtime/tests/feedback.rs
+++ b/thymos/crates/thymos-runtime/tests/feedback.rs
@@ -1,0 +1,170 @@
+//! Routing-feedback export is safe: it carries only the routing decision id,
+//! the chosen route, a coarse status, and latency — never intent args, tool
+//! output, tenant, writ, or any free text — and is derived purely from the
+//! ledger (a pull, no egress).
+
+use serde_json::{json, Value};
+
+use thymos_core::{
+    commit::Observation, delta::StructuredDelta, error::Result, proposal::FallbackHint,
+    RoutingEvidence,
+};
+use thymos_ledger::Ledger;
+use thymos_policy::{PolicyEngine, WritAuthorityPolicy};
+use thymos_runtime::{
+    generate_signing_key, public_key_of, Budget, CoreIntent, DelegationBounds, EffectCeiling,
+    IntentBody, IntentKind, Runtime, Step, TimeWindow, ToolPattern, Writ, WritBody,
+};
+use thymos_tools::{
+    EffectClass, RiskClass, ToolContract, ToolContractMeta, ToolInvocation, ToolOutcome,
+    ToolRegistry,
+};
+
+struct SecretTool;
+impl ToolContract for SecretTool {
+    fn meta(&self) -> &ToolContractMeta {
+        static M: std::sync::OnceLock<ToolContractMeta> = std::sync::OnceLock::new();
+        M.get_or_init(|| ToolContractMeta {
+            name: "act".into(),
+            version: "1.0.0".into(),
+            effect_class: EffectClass::Write,
+            risk_class: RiskClass::Low,
+        })
+    }
+    fn description(&self) -> &str {
+        "noop"
+    }
+    fn input_schema(&self) -> Value {
+        json!({"type": "object"})
+    }
+    fn execute(&self, _inv: &ToolInvocation<'_>) -> Result<ToolOutcome> {
+        Ok(ToolOutcome {
+            delta: StructuredDelta(vec![]),
+            observation: Observation {
+                tool: "act".into(),
+                // A field a naive exporter might leak — must NOT appear in feedback.
+                output: json!({ "secret": "do-not-export" }),
+                latency_ms: 42,
+            },
+        })
+    }
+}
+
+fn writ() -> Writ {
+    let issuer = generate_signing_key();
+    let subject = generate_signing_key();
+    Writ::sign(
+        WritBody {
+            issuer: "root".into(),
+            issuer_pubkey: public_key_of(&issuer),
+            subject: "agent".into(),
+            subject_pubkey: public_key_of(&subject),
+            nonce: [0u8; 16],
+            parent: None,
+            tenant_id: "secret-tenant".into(),
+            tool_scopes: vec![ToolPattern::exact("act")],
+            budget: Budget {
+                tokens: 10_000,
+                tool_calls: 100,
+                wall_clock_ms: 600_000,
+                usd_millicents: 0,
+            },
+            effect_ceiling: EffectCeiling::read_write_local(),
+            time_window: TimeWindow {
+                not_before: 0,
+                expires_at: u64::MAX,
+            },
+            delegation: DelegationBounds {
+                max_depth: 1,
+                may_subdivide: false,
+            },
+        },
+        &issuer,
+    )
+    .unwrap()
+}
+
+fn evidence() -> RoutingEvidence {
+    RoutingEvidence {
+        decision_hash: "abc123".into(),
+        selected: "anthropic:claude".into(),
+        alternatives: vec!["openai:gpt".into()],
+        confidence_bps: 9000,
+        reason_codes: vec!["cost_optimal".into()],
+        latency_estimate_ms: 700,
+        cost_estimate_millicents: 1234,
+        fallback_hint: Some(FallbackHint {
+            provider: "openai".into(),
+            model: Some("gpt-4o".into()),
+            reason: "primary overloaded".into(),
+        }),
+    }
+}
+
+fn intent() -> CoreIntent {
+    CoreIntent::new(IntentBody {
+        parent_commit: None,
+        author: "test".into(),
+        kind: IntentKind::Act,
+        target: "act".into(),
+        // Sensitive args a naive exporter might leak — must NOT appear.
+        args: json!({ "password": "hunter2" }),
+        rationale: "secret rationale".into(),
+        nonce: [7; 16],
+    })
+    .unwrap()
+}
+
+#[test]
+fn routing_outcomes_export_only_safe_fields() {
+    let mut tools = ToolRegistry::new();
+    tools.register(SecretTool);
+    let runtime = Runtime::new(
+        Ledger::open_in_memory().unwrap(),
+        tools,
+        PolicyEngine::new().with(WritAuthorityPolicy),
+    );
+    let run = runtime.create_run("fb", b"fb").unwrap();
+    assert!(matches!(
+        run.submit_with_routing_evidence(intent(), &writ(), evidence()).unwrap(),
+        Step::Committed(_)
+    ));
+
+    let outcomes = run.routing_outcomes().unwrap();
+    assert_eq!(outcomes.len(), 1);
+    let o = &outcomes[0];
+    assert_eq!(o.decision_hash, "abc123");
+    assert_eq!(o.selected, "anthropic:claude");
+    assert_eq!(o.status, "committed");
+    assert_eq!(o.latency_ms, 42);
+
+    // Hard guarantee: the serialized export has EXACTLY the four safe keys, and
+    // none of the sensitive material from intent/observation/writ.
+    let serialized = serde_json::to_string(o).unwrap();
+    let v: Value = serde_json::from_str(&serialized).unwrap();
+    let keys: Vec<&str> = v.as_object().unwrap().keys().map(|s| s.as_str()).collect();
+    assert_eq!(keys.len(), 4, "exactly four fields exported: {keys:?}");
+    for leak in [
+        "password", "hunter2", "secret", "do-not-export", "secret-tenant",
+        "secret rationale", "writ", "tenant", "args", "output",
+    ] {
+        assert!(
+            !serialized.contains(leak),
+            "feedback must not leak '{leak}': {serialized}"
+        );
+    }
+}
+
+#[test]
+fn no_routing_evidence_means_no_outcomes() {
+    let mut tools = ToolRegistry::new();
+    tools.register(SecretTool);
+    let runtime = Runtime::new(
+        Ledger::open_in_memory().unwrap(),
+        tools,
+        PolicyEngine::new().with(WritAuthorityPolicy),
+    );
+    let run = runtime.create_run("fb2", b"fb2").unwrap();
+    run.submit(intent(), &writ()).unwrap();
+    assert!(run.routing_outcomes().unwrap().is_empty());
+}

--- a/thymos/crates/thymos-server/src/lib.rs
+++ b/thymos/crates/thymos-server/src/lib.rs
@@ -52,8 +52,8 @@ use thymos_ledger::{EntryPayload, Ledger};
 use thymos_policy::{PolicyEngine, WritAuthorityPolicy};
 use thymos_runtime::agent_async::ApprovalDecision;
 use thymos_runtime::{
-    AgentEventCallback, AgentRunOptions, AgentRunSummary, AgentTraceEvent, Runtime, Step,
-    Termination,
+    routing_outcomes, AgentEventCallback, AgentRunOptions, AgentRunSummary, AgentTraceEvent,
+    Runtime, Step, Termination,
 };
 use thymos_tools::{
     DelegateTool, FsPatchTool, FsReadTool, GrepTool, HttpTool, KvGetTool, KvSetTool, ListFilesTool,
@@ -462,6 +462,7 @@ pub fn app(state: Arc<AppState>) -> Router {
         .route("/writs/{writ_id}/restore", post(restore_writ_handler))
         .route("/routed-submit", post(routed_submit))
         .route("/runs/{id}/delegations", get(get_delegations))
+        .route("/runs/{id}/routing-outcomes", get(get_routing_outcomes))
         .route("/runs/{id}/branch", post(post_branch))
         .route("/usage", get(get_usage))
         .route("/audit/entries", get(audit::get_audit_entries))
@@ -635,6 +636,8 @@ fn tenant_can_access(run_tenant: &str, caller_tenant: &str) -> bool {
 }
 
 fn trajectory_from_hex(traj_hex: &str) -> Result<TrajectoryId, &'static str> {
+    // Accept both the bare 32-byte hex and the `traj:<hex>` display form.
+    let traj_hex = traj_hex.strip_prefix("traj:").unwrap_or(traj_hex);
     let bytes = hex::decode(traj_hex).map_err(|_| "invalid trajectory id")?;
     if bytes.len() != 32 {
         return Err("invalid trajectory id");
@@ -2297,6 +2300,48 @@ async fn post_branch(
 }
 
 /// GET /runs/:id/delegations — list child trajectories created via delegation.
+/// Read-only: the safe routing-feedback records for a run (decision_hash,
+/// selected route, status, latency only — never workload content). A pull, not
+/// a push: an advisor fetches these and decides what to do with them; THYMOS
+/// initiates no egress.
+async fn get_routing_outcomes(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    // Resolve to a trajectory: a known run id maps to its trajectory; otherwise
+    // the path is treated as a trajectory hex directly (e.g. the trajectory_id
+    // returned by /routed-submit, which is not tracked in the run store).
+    let traj_hex = {
+        let runs = state.runs.lock().unwrap();
+        runs.get(&id)
+            .map(|r| r.trajectory_id.clone())
+            .filter(|t| !t.is_empty())
+    }
+    .unwrap_or_else(|| id.clone());
+    let trajectory_id = match trajectory_from_hex(&traj_hex) {
+        Ok(t) => t,
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "error": e })),
+            )
+                .into_response()
+        }
+    };
+    match state.runtime.ledger.entries(trajectory_id) {
+        Ok(entries) => (
+            StatusCode::OK,
+            Json(serde_json::json!({ "outcomes": routing_outcomes(&entries) })),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": e.to_string() })),
+        )
+            .into_response(),
+    }
+}
+
 async fn get_delegations(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,

--- a/thymos/crates/thymos-server/tests/e2e.rs
+++ b/thymos/crates/thymos-server/tests/e2e.rs
@@ -653,3 +653,39 @@ async fn marketplace_requires_auth_when_jwt_configured() {
     let resp = server.get("/marketplace/packages").await;
     resp.assert_status(axum::http::StatusCode::UNAUTHORIZED);
 }
+
+#[tokio::test]
+async fn routing_outcomes_endpoint_returns_safe_records() {
+    let server = test_server(test_state());
+    // A routed action with evidence.
+    let resp = server
+        .post("/routed-submit")
+        .json(&json!({
+            "tool": "kv_set",
+            "args": { "key": "k", "value": "secret-value" },
+            "routing_evidence": {
+                "decision_hash": "deadbeef",
+                "selected": "anthropic:claude",
+                "alternatives": [],
+                "confidence_bps": 9000,
+                "reason_codes": ["cost_optimal"],
+                "latency_estimate_ms": 100,
+                "cost_estimate_millicents": 50
+            }
+        }))
+        .await;
+    resp.assert_status_ok();
+    let traj = resp.json::<Value>()["trajectory_id"].as_str().unwrap().to_string();
+
+    // Pull the safe feedback for that trajectory.
+    let resp = server.get(&format!("/runs/{traj}/routing-outcomes")).await;
+    resp.assert_status_ok();
+    let body: Value = resp.json();
+    let outcomes = body["outcomes"].as_array().unwrap();
+    assert_eq!(outcomes.len(), 1);
+    assert_eq!(outcomes[0]["decision_hash"], "deadbeef");
+    assert_eq!(outcomes[0]["selected"], "anthropic:claude");
+    // No workload content leaks through the feedback endpoint.
+    let raw = body.to_string();
+    assert!(!raw.contains("secret-value") && !raw.contains("\"k\""));
+}


### PR DESCRIPTION
A way to give a routing advisor (WisePick) execution-outcome feedback **without** compromising determinism or data sovereignty — the safe version of their "feedback pool" idea.

## Design (why it's safe for THYMOS)
- **Minimal, non-sensitive.** `RoutingOutcome { decision_hash, selected, status, latency_ms }` — keyed by `decision_hash` so the advisor joins it to its own decision; **never** intent args, tool output, tenant, writ, resource values, or free text.
- **Derived from the ledger** (audit source of truth) — the export is exactly what was committed.
- **Out of the replay path.** Post-hoc read only; never fed back into execution, so it can't make the same intent route differently on replay.
- **Pull, not push.** THYMOS initiates no network egress; the operator/advisor fetches and decides what to forward.

## Surface
- `thymos-runtime::{routing_outcomes, RoutingOutcome}` + `Run::routing_outcomes()`.
- `GET /runs/{id_or_trajectory}/routing-outcomes` (also takes the `/routed-submit` trajectory_id). Read-only, same auth.
- `docs/integrations/wisepick.md` updated.

## Tests
Export carries exactly the four safe fields and leaks **none** of the sensitive material (password arg, tool output, tenant, rationale); empty without evidence; e2e routed-submit → pull outcomes. **234 pass, 0 warnings.**

`v0.4.2 → v0.4.3`.

