### PR TITLE
docs(wisepick): note v0.4.4 minimum for the routing-feedback loop

### DIFF
--- a/docs/integrations/wisepick.md
+++ b/docs/integrations/wisepick.md
@@ -113,6 +113,12 @@ cached-decision mode is the canonical replay path.
 
 ## Routing feedback (safe, pull-based)
 
+> **Minimum version: `v0.4.4`.** The endpoint itself landed earlier, but v0.4.3
+> had a ledger bug where the **second** routed action for a given tool hit an
+> `entries.id` collision (the genesis entry id didn't bind the trajectory), so
+> it was dropped before commit — the feedback loop would stall after a single
+> call. v0.4.4 fixes it; pin to it before driving the loop.
+
 A routing advisor improves from execution outcomes. THYMOS can supply that
 signal without breaking determinism or data sovereignty:
 


### PR DESCRIPTION
Follow-up to #17. The routing-feedback section didn't state a version floor, but the loop only works correctly on **v0.4.4** — v0.4.3 dropped the second routed action for a given tool on an `entries.id` collision, so the feedback loop would stall after a single call. Adds a short version note telling adapters to pin v0.4.4 before driving the loop.

Docs-only; no code change.

https://claude.ai/code/session_01BTiNYcDGfvthQMJwfCgBjY

---
_Generated by [Claude Code](https://claude.ai/code/session_01BTiNYcDGfvthQMJwfCgBjY)_