### PR TITLE
feat(server): default cognition provider from env + onboarding quickstart

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -129,7 +129,9 @@ What you should see:
 
 ## 4. Switch to a real model
 
-Thymos keeps the same runtime and tool model. You only swap the proposer.
+Thymos keeps the same runtime and tool model. You only swap the proposer — and
+you just set a key. **Any run that doesn't specify its own `cognition` block now
+uses the provider you configured** (instead of silently falling back to mock).
 
 ### Anthropic
 
@@ -149,7 +151,24 @@ OPENAI_API_KEY=... cargo run -p thymos-server
 OPENAI_BASE_URL=http://localhost:1234/v1 OPENAI_API_KEY=local cargo run -p thymos-server
 ```
 
-Then create runs with the provider you want from the web app, CLI, or API.
+Confirm which provider is active (no more guessing whether you're on mock):
+
+```bash
+curl http://localhost:3001/health
+# { "status": "ok", "mode": "reference", "default_provider": "anthropic", ... }
+```
+
+Resolution order for the default provider:
+
+1. `THYMOS_DEFAULT_PROVIDER` (`anthropic` | `openai` | `local` | `lmstudio` |
+   `huggingface` | `mock`), with optional `THYMOS_DEFAULT_MODEL`.
+2. Otherwise the first key found — `ANTHROPIC_API_KEY`, then `OPENAI_API_KEY`.
+3. Otherwise `mock`.
+
+A run can still override per-request by sending a `cognition` block to
+`POST /runs` or `--provider` on the CLI. See
+[`thymos/.env.example`](https://github.com/gryszzz/open-thymos/blob/main/thymos/.env.example)
+for the full set of runtime variables.
 
 ## 5. Load programmable capabilities
 

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+#
+# OpenThymos quickstart: build the runtime, start it, and drive one real run
+# end-to-end — Intent -> Proposal -> Commit — then shut it down.
+#
+#   ./scripts/quickstart.sh
+#   ./scripts/quickstart.sh "Map the repo and summarize the runtime"
+#
+# Connect an AI by exporting a key first (otherwise it runs the mock provider):
+#   ANTHROPIC_API_KEY=sk-ant-... ./scripts/quickstart.sh
+#   OPENAI_API_KEY=sk-...        ./scripts/quickstart.sh
+# Force a provider/model: THYMOS_DEFAULT_PROVIDER=openai THYMOS_DEFAULT_MODEL=gpt-4o-mini
+set -euo pipefail
+
+TASK="${1:-Map the repo and summarize the execution runtime}"
+PORT="${THYMOS_PORT:-3001}"
+BASE="http://localhost:${PORT}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT/thymos"
+
+echo "==> Building thymos-server (first build can take a minute)…"
+cargo build -p thymos-server
+
+echo "==> Starting server on :${PORT} …"
+# Ephemeral state in a temp dir so the quickstart leaves nothing behind.
+TMP="$(mktemp -d)"
+THYMOS_BIND_ADDR="0.0.0.0:${PORT}" \
+THYMOS_DB_PATH="$TMP/runs.db" \
+THYMOS_GATEWAY_DB_PATH="$TMP/gw.db" \
+THYMOS_MARKETPLACE_DB_PATH="$TMP/market.db" \
+  ./target/debug/thymos-server >"$TMP/server.log" 2>&1 &
+SERVER_PID=$!
+cleanup() { kill "$SERVER_PID" 2>/dev/null || true; rm -rf "$TMP"; }
+trap cleanup EXIT
+
+echo -n "==> Waiting for /health "
+for _ in $(seq 1 30); do
+  if curl -sf "${BASE}/health" >/dev/null 2>&1; then break; fi
+  echo -n "."; sleep 1
+done
+echo
+
+HEALTH="$(curl -s "${BASE}/health")"
+PROVIDER="$(printf '%s' "$HEALTH" | sed -n 's/.*"default_provider":"\([^"]*\)".*/\1/p')"
+echo "==> Active provider: ${PROVIDER:-unknown}"
+if [ "${PROVIDER:-mock}" = "mock" ]; then
+  echo "    (mock — export ANTHROPIC_API_KEY or OPENAI_API_KEY for a real model)"
+fi
+
+echo "==> Submitting task: \"${TASK}\""
+RESP="$(curl -s -X POST "${BASE}/runs" \
+  -H 'content-type: application/json' \
+  -d "$(printf '{"task": %s, "max_steps": 8}' "$(printf '%s' "$TASK" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')")")"
+RUN_ID="$(printf '%s' "$RESP" | sed -n 's/.*"run_id":"\([^"]*\)".*/\1/p')"
+if [ -z "$RUN_ID" ]; then
+  echo "!! Could not start run. Response: $RESP"; exit 1
+fi
+echo "==> Run started: ${RUN_ID}"
+
+echo "==> Running (Intent -> Proposal -> Commit). Live tokens: ${BASE}/runs/${RUN_ID}/execution/stream"
+STATUS="running"
+for _ in $(seq 1 60); do
+  SNAP="$(curl -s "${BASE}/runs/${RUN_ID}" || true)"
+  STATUS="$(printf '%s' "$SNAP" | sed -n 's/.*"status":"\([a-z_]*\)".*/\1/p' | head -1)"
+  case "$STATUS" in completed|failed) break ;; esac
+  echo -n "."; sleep 1
+done
+echo
+echo "==> Run status: ${STATUS:-unknown}"
+
+echo "==> Final world projection:"
+curl -s "${BASE}/runs/${RUN_ID}/world" || true
+echo
+echo "==> Done. (ephemeral state removed on exit)"

--- a/thymos/.env.example
+++ b/thymos/.env.example
@@ -2,11 +2,18 @@
 # Copy this to .env and fill in your values.
 
 # ── Cognition Providers ───────────────────────────────────────────────────────
-# Set at least one to enable LLM-driven cognition (otherwise mock is used).
+# Set at least one key and runs that don't specify their own `cognition` block
+# use that provider automatically (Anthropic preferred, then OpenAI). Confirm
+# which one is active at GET /health -> "default_provider". Otherwise: mock.
 # ANTHROPIC_API_KEY=sk-ant-...
 # OPENAI_API_KEY=sk-...
 # OPENAI_MODEL=gpt-4o
 # OPENAI_BASE_URL=https://api.openai.com/v1
+
+# Override the auto-detected default provider / model for runs that omit them:
+#   THYMOS_DEFAULT_PROVIDER one of: anthropic | openai | local | lmstudio | huggingface | mock
+# THYMOS_DEFAULT_PROVIDER=anthropic
+# THYMOS_DEFAULT_MODEL=sonnet
 
 # LM Studio (local OpenAI-compatible server — no auth needed)
 # LMSTUDIO_BASE_URL=http://localhost:1234/v1
@@ -31,6 +38,8 @@
 # THYMOS_MARKETPLACE_DB_PATH=thymos-marketplace.db
 # THYMOS_TOOL_FABRIC=in_process
 # THYMOS_WORKER_BIN=/absolute/path/to/target/debug/thymos-worker
+# Comma-separated dirs of JSON tool manifests loaded at startup:
+# THYMOS_TOOL_MANIFEST_DIRS=../tools
 # THYMOS_MAX_CONCURRENT_RUNS_GLOBAL=100
 # THYMOS_MAX_CONCURRENT_RUNS_PER_TENANT=20
 

--- a/thymos/crates/thymos-server/src/lib.rs
+++ b/thymos/crates/thymos-server/src/lib.rs
@@ -39,7 +39,8 @@ use tokio::sync::{broadcast, oneshot, watch};
 use tower_http::cors::{Any, CorsLayer};
 
 use execution::ExecutionSession;
-use thymos_cognition::{build_cognition, CognitionConfig, CognitionEvent, NonStreamingAdapter};
+use thymos_cognition::{build_cognition, CognitionEvent, NonStreamingAdapter};
+pub use thymos_cognition::{CognitionConfig, CognitionProvider};
 use thymos_core::{
     content_hash,
     crypto::{generate_signing_key, public_key_of},
@@ -80,6 +81,70 @@ impl RuntimeMode {
     }
 }
 
+/// Human-readable name for a cognition provider (for logs and `/health`).
+pub fn provider_label(p: &CognitionProvider) -> &'static str {
+    match p {
+        CognitionProvider::Anthropic => "anthropic",
+        CognitionProvider::Openai => "openai",
+        CognitionProvider::Local => "local",
+        CognitionProvider::Lmstudio => "lmstudio",
+        CognitionProvider::Huggingface => "huggingface",
+        CognitionProvider::Mock => "mock",
+    }
+}
+
+/// Resolve the cognition provider used for runs that don't specify their own
+/// `cognition` block. Resolution order:
+///   1. `THYMOS_DEFAULT_PROVIDER` (anthropic | openai | local | lmstudio |
+///      huggingface | mock), optionally with `THYMOS_DEFAULT_MODEL`.
+///   2. Auto-detect a configured API key: `ANTHROPIC_API_KEY`, then
+///      `OPENAI_API_KEY`.
+///   3. Fall back to `mock`.
+///
+/// This removes the "I exported my key but every run is silently mock" footgun:
+/// export a key (or set the provider var) and runs that omit `cognition` use it.
+pub fn resolve_default_cognition() -> CognitionConfig {
+    let model = std::env::var("THYMOS_DEFAULT_MODEL")
+        .ok()
+        .filter(|s| !s.trim().is_empty());
+
+    let provider = match std::env::var("THYMOS_DEFAULT_PROVIDER")
+        .ok()
+        .map(|s| s.trim().to_lowercase())
+        .filter(|s| !s.is_empty())
+    {
+        Some(p) => match p.as_str() {
+            "anthropic" => CognitionProvider::Anthropic,
+            "openai" => CognitionProvider::Openai,
+            "local" => CognitionProvider::Local,
+            "lmstudio" => CognitionProvider::Lmstudio,
+            "huggingface" => CognitionProvider::Huggingface,
+            "mock" => CognitionProvider::Mock,
+            other => {
+                eprintln!(
+                    "warn: unknown THYMOS_DEFAULT_PROVIDER '{other}', defaulting to mock"
+                );
+                CognitionProvider::Mock
+            }
+        },
+        None => {
+            if std::env::var("ANTHROPIC_API_KEY").is_ok() {
+                CognitionProvider::Anthropic
+            } else if std::env::var("OPENAI_API_KEY").is_ok() {
+                CognitionProvider::Openai
+            } else {
+                CognitionProvider::Mock
+            }
+        }
+    };
+
+    CognitionConfig {
+        provider,
+        model,
+        ..CognitionConfig::default()
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct ServerConfig {
     pub runtime_mode: RuntimeMode,
@@ -93,6 +158,8 @@ pub struct ServerConfig {
     pub max_concurrent_runs_per_tenant: u32,
     pub max_concurrent_runs_global: u32,
     pub tool_manifest_dirs: Vec<String>,
+    /// Provider used for runs that omit their own `cognition` block.
+    pub default_cognition: CognitionConfig,
 }
 
 impl ServerConfig {
@@ -178,6 +245,7 @@ impl ServerConfig {
             max_concurrent_runs_per_tenant,
             max_concurrent_runs_global,
             tool_manifest_dirs,
+            default_cognition: resolve_default_cognition(),
         })
     }
 }
@@ -348,6 +416,9 @@ pub struct AppState {
     pub active_runs: AtomicU32,
     /// Tool marketplace.
     pub marketplace: marketplace_api::MarketplaceState,
+    /// Provider used for runs that omit their own `cognition` block. Resolved
+    /// from env at startup (see [`resolve_default_cognition`]).
+    pub default_cognition: CognitionConfig,
 }
 
 #[derive(Deserialize)]
@@ -893,6 +964,7 @@ async fn health(State(state): State<Arc<AppState>>) -> impl IntoResponse {
             RuntimeMode::Reference => "reference",
             RuntimeMode::Production => "production",
         },
+        "default_provider": provider_label(&state.default_cognition.provider),
         "shutdown": *state.shutdown_tx.borrow(),
     }))
 }
@@ -913,6 +985,7 @@ async fn ready(State(state): State<Arc<AppState>>) -> impl IntoResponse {
             RuntimeMode::Reference => "reference",
             RuntimeMode::Production => "production",
         },
+        "default_provider": provider_label(&state.default_cognition.provider),
         "shutdown": shutting_down,
         "checks": {
             "run_store": run_store_ready,
@@ -1048,7 +1121,10 @@ async fn resume_run(
     let task = req.task.clone();
 
     tokio::spawn(async move {
-        let config = req.cognition.unwrap_or_default();
+        let config = req
+            .cognition
+            .clone()
+            .unwrap_or_else(|| state2.default_cognition.clone());
         // `build_cognition` may call `reqwest::blocking::ClientBuilder::build()`,
         // which internally creates and drops a current-thread tokio runtime.
         // Dropping a runtime from inside an async context panics, so construct
@@ -1397,8 +1473,12 @@ async fn create_run(
     let task2 = task.clone();
 
     tokio::spawn(async move {
-        // Build cognition from per-run config (or default to mock).
-        let config = req.cognition.unwrap_or_default();
+        // Build cognition from per-run config, or the server's configured
+        // default provider (env-resolved) instead of silently using mock.
+        let config = req
+            .cognition
+            .clone()
+            .unwrap_or_else(|| state2.default_cognition.clone());
         // `build_cognition` may call `reqwest::blocking::ClientBuilder::build()`,
         // which internally creates and drops a current-thread tokio runtime.
         // Dropping a runtime from inside an async context panics, so construct
@@ -2482,5 +2562,51 @@ fn entry_to_dto(e: &thymos_ledger::Entry) -> EntryDto {
         id: e.id.short().to_string(),
         detail,
         commit_id,
+    }
+}
+
+#[cfg(test)]
+mod onboarding_tests {
+    use super::*;
+
+    #[test]
+    fn provider_labels_are_stable() {
+        assert_eq!(provider_label(&CognitionProvider::Anthropic), "anthropic");
+        assert_eq!(provider_label(&CognitionProvider::Openai), "openai");
+        assert_eq!(provider_label(&CognitionProvider::Local), "local");
+        assert_eq!(provider_label(&CognitionProvider::Lmstudio), "lmstudio");
+        assert_eq!(provider_label(&CognitionProvider::Huggingface), "huggingface");
+        assert_eq!(provider_label(&CognitionProvider::Mock), "mock");
+    }
+
+    #[test]
+    fn explicit_default_provider_env_wins_and_is_case_insensitive() {
+        // An explicit THYMOS_DEFAULT_PROVIDER short-circuits key auto-detection,
+        // so this is deterministic regardless of any API keys in the env.
+        let prev = std::env::var("THYMOS_DEFAULT_PROVIDER").ok();
+        let prev_model = std::env::var("THYMOS_DEFAULT_MODEL").ok();
+
+        std::env::set_var("THYMOS_DEFAULT_PROVIDER", "  OpenAI ");
+        std::env::set_var("THYMOS_DEFAULT_MODEL", "gpt-4o-mini");
+        let cfg = resolve_default_cognition();
+        assert_eq!(cfg.provider, CognitionProvider::Openai);
+        assert_eq!(cfg.model.as_deref(), Some("gpt-4o-mini"));
+
+        std::env::set_var("THYMOS_DEFAULT_PROVIDER", "definitely-not-a-provider");
+        assert_eq!(
+            resolve_default_cognition().provider,
+            CognitionProvider::Mock,
+            "unknown provider falls back to mock"
+        );
+
+        // Restore prior env so we don't perturb other tests.
+        match prev {
+            Some(v) => std::env::set_var("THYMOS_DEFAULT_PROVIDER", v),
+            None => std::env::remove_var("THYMOS_DEFAULT_PROVIDER"),
+        }
+        match prev_model {
+            Some(v) => std::env::set_var("THYMOS_DEFAULT_MODEL", v),
+            None => std::env::remove_var("THYMOS_DEFAULT_MODEL"),
+        }
     }
 }

--- a/thymos/crates/thymos-server/src/main.rs
+++ b/thymos/crates/thymos-server/src/main.rs
@@ -189,7 +189,13 @@ async fn main() {
         shutdown_tx,
         active_runs: AtomicU32::new(0),
         marketplace,
+        default_cognition: config.default_cognition.clone(),
     });
+
+    eprintln!(
+        "default cognition provider: {} (runs without a `cognition` block use this)",
+        thymos_server::provider_label(&config.default_cognition.provider)
+    );
 
     let app = app(state.clone());
     eprintln!(

--- a/thymos/crates/thymos-server/tests/auth_e2e.rs
+++ b/thymos/crates/thymos-server/tests/auth_e2e.rs
@@ -49,6 +49,7 @@ fn test_state_with_jwt(jwt: Option<Arc<auth::JwtConfig>>) -> Arc<AppState> {
         shutdown_tx,
         active_runs: AtomicU32::new(0),
         marketplace: Arc::new(thymos_marketplace::MarketplaceService::in_memory()),
+        default_cognition: thymos_server::CognitionConfig::default(),
     })
 }
 

--- a/thymos/crates/thymos-server/tests/e2e.rs
+++ b/thymos/crates/thymos-server/tests/e2e.rs
@@ -33,6 +33,7 @@ fn test_state() -> Arc<AppState> {
         shutdown_tx,
         active_runs: AtomicU32::new(0),
         marketplace: Arc::new(thymos_marketplace::MarketplaceService::in_memory()),
+        default_cognition: thymos_server::CognitionConfig::default(),
     })
 }
 
@@ -448,6 +449,7 @@ fn jwt_test_state() -> Arc<AppState> {
         shutdown_tx,
         active_runs: AtomicU32::new(0),
         marketplace: Arc::new(thymos_marketplace::MarketplaceService::in_memory()),
+        default_cognition: thymos_server::CognitionConfig::default(),
     })
 }
 
@@ -480,6 +482,7 @@ fn gateway_test_state() -> Arc<AppState> {
         shutdown_tx,
         active_runs: AtomicU32::new(0),
         marketplace: Arc::new(thymos_marketplace::MarketplaceService::in_memory()),
+        default_cognition: thymos_server::CognitionConfig::default(),
     })
 }
 


### PR DESCRIPTION
## What

Make THYMOS easier to **start** and to **connect an AI** to. Today a run that omits its `cognition` block silently falls back to `mock`, so exporting `ANTHROPIC_API_KEY` does nothing unless every `POST /runs` (or CLI call) names the provider explicitly — a quiet "why is nothing happening" footgun.

## Changes

- **Default provider from env.** The server resolves a default cognition provider at startup:
  1. `THYMOS_DEFAULT_PROVIDER` (`anthropic` | `openai` | `local` | `lmstudio` | `huggingface` | `mock`), optional `THYMOS_DEFAULT_MODEL`;
  2. else auto-detect a present `ANTHROPIC_API_KEY`, then `OPENAI_API_KEY`;
  3. else `mock`.
  Runs without a `cognition` block use it instead of always mock. Per-request override still works.
- **Visibility.** `/health` and `/ready` now report `default_provider`, and the server logs it at startup — mock-vs-live is no longer invisible.
- **One-command quickstart.** `scripts/quickstart.sh` builds, starts the server, fires a real run end-to-end (polls to completion, prints the world projection), and cleans up ephemeral state. Provider-aware; warns when on mock.
- **Docs.** `thymos/.env.example` documents the new vars (+ `THYMOS_TOOL_MANIFEST_DIRS`); `docs/getting-started.md` step 4 reflects the "just set a key" path and the `/health` check.

## Trust boundary

Unchanged. Cognition is still untrusted input — this only changes **defaults and discoverability**, not authority, policy, or execution.

## Verification

- Unit tests: resolver precedence (explicit provider wins, case-insensitive, unknown → mock) + provider labels.
- Live: no key → `mock`; `THYMOS_DEFAULT_PROVIDER=openai` → `openai`; `ANTHROPIC_API_KEY` set → `anthropic` (all visible in `/health`). `scripts/quickstart.sh` runs a mock task to completion and exits clean.
- `cargo test -p thymos-server`: 0 failures.

https://claude.ai/code/session_01BTiNYcDGfvthQMJwfCgBjY

---
_Generated by [Claude Code](https://claude.ai/code/session_01BTiNYcDGfvthQMJwfCgBjY)_