### PR TITLE
fix(cli): add default_cognition to thymos-cli test AppState (unbreak main)

### DIFF
--- a/thymos/crates/thymos-cli/tests/e2e.rs
+++ b/thymos/crates/thymos-cli/tests/e2e.rs
@@ -28,6 +28,7 @@ fn test_state() -> Arc<AppState> {
         shutdown_tx,
         active_runs: AtomicU32::new(0),
         marketplace: Arc::new(thymos_marketplace::MarketplaceService::in_memory()),
+        default_cognition: thymos_server::CognitionConfig::default(),
     })
 }
 


### PR DESCRIPTION
Follow-up to #19. #19 was merged at the commit before the test-compile fix landed, so `main` currently fails `cargo test --workspace` to **build**:

```
error[E0063]: missing field `default_cognition` in initializer of `AppState`
  --> crates/thymos-cli/tests/e2e.rs
```

`thymos-cli`'s e2e test constructs `AppState` directly and was the one site outside `thymos-server` that the #19 commits missed. (`cargo build --workspace` passes — the missing field is in a test file — which is why only the `cargo test` step went red.)

This PR adds the single missing field. Verified locally: `cargo test --workspace` compiles and passes — 45 test groups, 0 failures.

https://claude.ai/code/session_01BTiNYcDGfvthQMJwfCgBjY

---
_Generated by [Claude Code](https://claude.ai/code/session_01BTiNYcDGfvthQMJwfCgBjY)_