### PR TITLE
docs: refresh README + roadmap to v0.4.4 reality

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,12 +114,32 @@ the runtime today and covered by tests:
 - **Drift detection on replay.** Replay can pin the compiler version, the
   policy-set hash, and commit signatures — flagging compiler, policy, or
   identity drift long after a run.
+- **Writ revocation + anti-replay.** A capability can be pulled at runtime (the
+  compiler rejects it, with a one-level child cascade); every writ carries a
+  nonce so it is individually identifiable.
+- **Idempotency.** An `External` / `Irreversible` tool executes at most once per
+  content-addressed proposal — retries and re-approvals return the prior commit.
+- **Multi-party approval.** A suspended proposal can require M-of-N distinct
+  approvers; any explicit denial vetoes. Irreversible, non-compensable tools can
+  be gated to *require* approval.
+- **Compensation / saga rollback.** Compensable tools are undone newest-first —
+  including across delegated child trajectories — and each rollback is itself a
+  recorded, replayable commit.
+- **External anchoring.** A Merkle root over a trajectory's entries gives
+  third-party tamper-evidence on top of the internal hash chain.
+- **Pluggable clock.** Time-window checks read an injectable clock (an attested
+  source, or a fixed clock in tests), not the bare host wall clock.
+- **Declarative policy.** Signed JSON policy bundles loadable at runtime
+  (`eq/ne/gt/lt/in/contains` + `all/any/not` over intent / writ / world), in
+  addition to in-process Rust policies.
+- **Routing evidence (advisor integration).** Optional provider routing metadata
+  is recorded immutably in the ledger (excluded from `ProposalId`) and never read
+  for authority — plus a safe, pull-based `/routing-outcomes` feedback export
+  that leaks no workload content. See [WisePick integration](docs/integrations/wisepick.md).
 
-**Not yet — tracked on the [roadmap](docs/roadmap.md):** idempotency and
-compensation for irreversible tools, writ revocation and anti-replay, multi-party
-(quorum) approval, external Merkle anchoring of the ledger, host-clock
-attestation, and a declarative policy language ([RFC draft](docs/rfcs/policy-language-v1.md)).
-Replay verifies and folds the ledger — it does not re-execute cognition or tools.
+For the precise, adversarially-written line between *proven*, *gated*, and *not
+built*, see **[STATUS.md](STATUS.md)**. Replay verifies and folds the ledger — it
+does not (and for an LLM cannot) re-execute cognition or tools.
 
 ## Capability Writs
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -34,6 +34,13 @@ Runtime capabilities:
 - model-spend budgeting (cognition token/USD usage debited against the writ budget)
 - fork-proof append (unique `(trajectory, seq)` invariant under an immediate transaction)
 - replay drift detection (compiler version, policy-set hash, commit signatures)
+- writ revocation (compiler stage, one-level child cascade) + anti-replay nonce
+- idempotency (exactly-once execution for External/Irreversible tools per proposal)
+- multi-party (M-of-N) approval quorum + irreversible/non-compensable approval gate
+- compensation / saga rollback (incl. cross-trajectory) with recorded compensations
+- external Merkle anchoring of the ledger; pluggable (attestable) clock
+- declarative signed JSON policy bundles ([policy-language-v1](rfcs/policy-language-v1.md), implemented)
+- routing-evidence (Proposal Contract v1, Option 2) + safe pull-based feedback export
 
 Execution guarantee: no tool execution without a staged or approved proposal,
 and no effect beyond the writ's effect ceiling.
@@ -41,10 +48,13 @@ and no effect beyond the writ's effect ceiling.
 Scaling implication: correctness remains local and inspectable before
 distributed concerns are introduced.
 
-Not yet in Phase I (tracked for later phases): idempotency and compensation for
-irreversible tools, writ revocation and anti-replay, multi-party (quorum)
-approval, external Merkle anchoring of the ledger, host-clock attestation, and a
-declarative policy language ([policy-language-v1 RFC draft](rfcs/policy-language-v1.md)).
+Most of the original Phase I "later" list has shipped (above). What remains
+(see [STATUS.md](../STATUS.md) for the precise, adversarial line):
+- Postgres as the *HTTP runtime* path — the async backend is implemented and
+  tested in isolation, but the server still uses the synchronous SQLite path
+  until the runtime/ledger trait refactor lands.
+- `routing_evidence` is recorded verbatim (not redacted) — provider metadata,
+  never read for authority; a redaction pass over it is an optional follow-up.
 
 ## Phase II - Multi-Agent Coordination
 


### PR DESCRIPTION
The README "Not yet" list and the roadmap Phase I "later" list still named features that shipped long ago (revocation, idempotency, quorum, compensation, anchoring, policy language). This updates both to match v0.4.4 + STATUS.md, and adds the routing-evidence/feedback surface to the README. Docs only.
