### PR TITLE
feat: Phase II — multi-agent delegation, demonstrable end to end

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,7 @@ trust-the-prompt. Concretely:
 
 **What it is _not_ (yet):** a turnkey product. It's a reference kernel — see
 [STATUS.md](STATUS.md) for the honest line between what's enforced-and-tested and what's
-still gated (Postgres on the HTTP path, live-model CI proofs, the end-to-end delegation
-demo).
+still gated (Postgres on the HTTP path, live-model CI proofs run in CI).
 
 ## The Threat Model
 
@@ -247,7 +246,15 @@ run; `/health` reports whether cognition is live or mock.
 
 **What it does not prove yet** (see [STATUS.md](STATUS.md)): that the HTTP runtime
 is using Postgres (it uses SQLite today); that the gated `live_provider` /
-`postgres_integration` proofs have run; the Phase II parent→child delegation demo.
+`postgres_integration` proofs have run.
+
+Multi-agent delegation *is* now demonstrable — parent mints a child writ ⊆ its own
+authority, child runs on its own trajectory, the ledger shows the lineage, replay
+reconstructs both:
+
+```bash
+cargo run --example delegation_lineage -p thymos-runtime   # see docs/demos/delegation-lineage.md
+```
 
 Or work directly with the workspace and CLI:
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -36,6 +36,14 @@ services or API keys:
   each committed action, and a replay-verification verdict. Pure renderer
   unit-tested across every entry kind; live wiring e2e tested
   (`crates/thymos-cli`).
+- **Multi-agent delegation, demonstrable.** A parent mints a child writ that is a
+  verified *strict subset* of its authority, the child runs on its own
+  trajectory, and the parent→child lineage is on the ledger. Tenant boundaries
+  can't be crossed by delegation and the child can't mutate parent state; replay
+  reconstructs both trajectories. Runnable
+  (`cargo run --example delegation_lineage -p thymos-runtime`), asserted
+  property-by-property (`crates/thymos-runtime/tests/delegation.rs`), and walked
+  through in [`docs/demos/delegation-lineage.md`](docs/demos/delegation-lineage.md).
 - **WisePick routing-evidence integration**: forward path + data-sovereignty
   (no intent args / tool output / tenant / writ leak into feedback records).
 

--- a/docs/demos/delegation-lineage.md
+++ b/docs/demos/delegation-lineage.md
@@ -1,0 +1,108 @@
+---
+layout: default
+title: Multi-Agent Delegation
+eyebrow: Demo
+subtitle: A parent agent grants less than it holds; the ledger records the lineage.
+permalink: /demos/delegation-lineage/
+---
+
+# Multi-Agent Delegation
+
+Delegation is where most agent frameworks quietly lose the plot: a "sub-agent"
+is spawned with the same powers as its parent, and nothing records who actually
+did what. OpenThymos makes delegation a first-class, *bounded* operation —
+
+> **cognition proposes, the runtime governs, the ledger records** — recursively.
+
+A parent mints a **child writ that is a strict subset of its own authority**,
+the child runs on its **own trajectory**, and the parent→child edge is written
+to the ledger. This page walks the runnable example; every claim it makes is
+asserted property-by-property in
+[`tests/delegation.rs`](https://github.com/gryszzz/open-thymos/blob/main/thymos/crates/thymos-runtime/tests/delegation.rs).
+
+## Run it
+
+```bash
+cargo run --example delegation_lineage -p thymos-runtime
+```
+
+## Scenario
+
+An operations agent for tenant `acme` holds a writ that authorizes `kv_*` and
+`delegate`, with `read+write` effect ceiling and delegation depth 2. It:
+
+1. commits a write (`order = received`) on its own trajectory, then
+2. **delegates** a read-only "audit the order" sub-task, restricting the child
+   to `kv_get` only.
+
+## What the runtime does
+
+```text
+== parent writ: subject=ops-agent tenant=acme scopes=[kv_*, delegate] depth=2
+
+-> parent trajectory: traj:252795ab…
+   parent kv_set(order=received): Committed(commit(275da9a2))
+
+-> delegated 'audit the order' → child trajectory: traj:73e0172b…
+   child writ ⊆ parent? true
+   child: tenant=acme scopes=[kv_get] depth=1 can_write=false
+   cross-tenant child rejected? true
+
+-> child kv_get(order): Committed(commit(08c1c052))   (reads its OWN world)
+   child kv_set(order=shipped): Rejected(AuthorityVoid("writ does not authorize tool 'kv_set'"))
+
+== parent trajectory entries
+   seq=0 Root(delegation demo)
+   seq=1 Commit seq=1
+   seq=2 Delegation(task="audit the order" → traj:73e0172b…)
+
+== parent world: order = "received"
+== replay: parent 1 commits verified, child 1 commits verified
+```
+
+## The four guarantees
+
+**1. The child writ is a strict subset of the parent.**
+`mint_child` only signs a child whose `verify_subset_of(parent)` holds: every
+child tool scope is covered by a parent scope, budget is ≤ parent on every
+dimension (here it is halved), the effect ceiling grants nothing the parent
+forbids, the time window fits inside the parent's, and delegation depth is
+decremented. The child above keeps `kv_get` but **loses `kv_set`** — narrower
+authority by construction, not by convention.
+
+**2. Tenant boundaries cannot be crossed by delegation.**
+Every writ belongs to exactly one tenant, and a child must inherit it. A child
+body that claims a different `tenant_id` is rejected by `verify_subset_of`
+(`cross-tenant delegation forbidden`) before it can ever be signed — so a
+compromised parent cannot launder authority into another tenant.
+
+**3. The lineage is on the ledger.**
+The parent trajectory carries a `Delegation` entry pointing at the child
+trajectory id and naming the task; the child trajectory opens with a `Root`
+whose note records that it was delegated. The parent→child DAG is reconstructable
+from the ledger alone — no out-of-band bookkeeping.
+
+**4. The parent's state isn't mutated by the child.**
+State is a projection of a *trajectory's own* committed deltas. The child runs on
+a separate trajectory with its own world — it cannot even *see* the parent's
+`order = received` (the child's `kv_get` reads its own, empty world), let alone
+change it. The only thing that mutates a trajectory's world is a commit on that
+trajectory. After the child runs, the parent's world is byte-for-byte what it
+was.
+
+## Replay reconstructs the DAG
+
+Replay folds each trajectory's committed deltas independently and verifies the
+hash chain. Parent and child both replay deterministically — the delegation edge
+is part of the parent's immutable record, so "which agent did what, under whose
+authority" is a reproducible question, not a guess.
+
+## Why this matters
+
+This is the building block for **multi-tenant agent platforms** and **agent
+swarms** that must stay inside their lane: you can hand a task to a sub-agent and
+*know* — structurally, and provably after the fact — that it could not exceed the
+authority you granted, touch another tenant, or silently mutate your state.
+
+See also: [Deterministic Replay](/open-thymos/demos/deterministic-replay/) ·
+[Policy Intercept & Approval](/open-thymos/demos/policy-intercept-approval/).

--- a/thymos/crates/thymos-runtime/examples/delegation_lineage.rs
+++ b/thymos/crates/thymos-runtime/examples/delegation_lineage.rs
@@ -1,0 +1,157 @@
+//! `delegation_lineage` — multi-agent delegation you can watch.
+//!
+//! A parent agent (tenant `acme`) commits a write, then **delegates** a
+//! read-only audit sub-task to a child running under a *strict subset* of its
+//! authority. The child executes on its own trajectory; the ledger records the
+//! parent→child lineage; the child cannot exceed the authority it was granted,
+//! cannot cross the tenant boundary, and cannot mutate the parent's state.
+//!
+//! Run:
+//!     cargo run --example delegation_lineage -p thymos-runtime
+//!
+//! The same flow is asserted property-by-property in
+//! `tests/delegation.rs`.
+
+use serde_json::json;
+
+use thymos_ledger::{replay, EntryPayload, Ledger, ReplayConfig};
+use thymos_policy::{PolicyEngine, WritAuthorityPolicy};
+use thymos_runtime::{
+    generate_signing_key, public_key_of, Budget, CoreIntent, DelegationBounds, DelegationKeyring,
+    EffectCeiling, IntentBody, IntentKind, Runtime, Step, TimeWindow, ToolPattern, Writ, WritBody,
+};
+use thymos_tools::{DelegateTool, KvGetTool, KvSetTool, ToolRegistry};
+
+fn act(target: &str, args: serde_json::Value, nonce: u8) -> CoreIntent {
+    CoreIntent::new(IntentBody {
+        parent_commit: None,
+        author: "cognition".into(),
+        kind: IntentKind::Act,
+        target: target.into(),
+        args,
+        rationale: format!("act on {target}"),
+        nonce: [nonce; 16],
+    })
+    .unwrap()
+}
+
+fn main() -> anyhow::Result<()> {
+    let mut tools = ToolRegistry::new();
+    tools.register(KvSetTool::default());
+    tools.register(KvGetTool::default());
+    tools.register(DelegateTool::default());
+
+    // A keyring lets the runtime sign minted child writs. Keep a handle so we
+    // can pick up the child writ after delegating.
+    let keyring = DelegationKeyring::new();
+    let runtime = Runtime::new(
+        Ledger::open_in_memory()?,
+        tools,
+        PolicyEngine::new().with(WritAuthorityPolicy),
+    )
+    .with_delegation_keyring(keyring.clone());
+
+    // Parent writ: tenant `acme`, may use kv_* and delegate, delegation depth 2.
+    let root_key = generate_signing_key();
+    let agent_key = generate_signing_key();
+    let agent_pubkey = public_key_of(&agent_key);
+    let parent_writ = Writ::sign(
+        WritBody {
+            issuer: "root".into(),
+            issuer_pubkey: public_key_of(&root_key),
+            subject: "ops-agent".into(),
+            subject_pubkey: agent_pubkey,
+            nonce: [0u8; 16],
+            parent: None,
+            tenant_id: "acme".into(),
+            tool_scopes: vec![ToolPattern::exact("kv_*"), ToolPattern::exact("delegate")],
+            budget: Budget { tokens: 10_000, tool_calls: 100, wall_clock_ms: 600_000, usd_millicents: 0 },
+            effect_ceiling: EffectCeiling::read_write_local(),
+            time_window: TimeWindow { not_before: 0, expires_at: u64::MAX },
+            delegation: DelegationBounds { max_depth: 2, may_subdivide: true },
+        },
+        &root_key,
+    )?;
+    keyring.register(agent_key);
+    println!("== parent writ: subject=ops-agent tenant=acme scopes=[kv_*, delegate] depth=2");
+
+    // 1. Parent commits a write on its own trajectory.
+    let parent = runtime.create_run("delegation demo", b"parent-v1")?;
+    println!("\n-> parent trajectory: {}", parent.trajectory_id());
+    let s = parent.submit(act("kv_set", json!({"key":"order","value":"received"}), 1), &parent_writ)?;
+    println!("   parent kv_set(order=received): {s:?}");
+
+    // 2. Parent delegates a read-only audit, restricting the child to kv_get.
+    let delegate_intent = CoreIntent::new(IntentBody {
+        parent_commit: None,
+        author: "cognition".into(),
+        kind: IntentKind::Delegate,
+        target: "auditor".into(),
+        args: json!({ "task": "audit the order", "tool_scopes": ["kv_get"] }),
+        rationale: "hand off a read-only audit under a narrower writ".into(),
+        nonce: [2u8; 16],
+    })?;
+    let child_traj = match parent.submit(delegate_intent, &parent_writ)? {
+        Step::Delegated { child_trajectory_id, .. } => child_trajectory_id,
+        other => anyhow::bail!("expected delegation, got {other:?}"),
+    };
+    println!("\n-> delegated 'audit the order' → child trajectory: {child_traj}");
+
+    // 3. Inspect the minted child writ: a strict subset of the parent.
+    let child_writ = keyring
+        .take_pending_child_writ(child_traj)
+        .expect("a signed child writ was minted");
+    println!("   child writ ⊆ parent? {}", child_writ.body.verify_subset_of(&parent_writ.body).is_ok());
+    println!(
+        "   child: tenant={} scopes=[kv_get] depth={} can_write={}",
+        child_writ.body.tenant_id,
+        child_writ.body.delegation.max_depth,
+        child_writ.authorizes_tool("kv_set"),
+    );
+
+    // Tenant isolation is structural: a child claiming a different tenant is void.
+    let mut cross = child_writ.body.clone();
+    cross.tenant_id = "evil-corp".into();
+    println!(
+        "   cross-tenant child rejected? {}",
+        cross.verify_subset_of(&parent_writ.body).is_err()
+    );
+
+    // 4. Drive the child on its own trajectory.
+    let child = runtime.resume_run(child_traj)?;
+    let s = child.submit(act("kv_get", json!({"key":"order"}), 3), &child_writ)?;
+    println!("\n-> child kv_get(order): {s:?}  (reads its OWN world — parent state not visible)");
+    let s = child.submit(act("kv_set", json!({"key":"order","value":"shipped"}), 4), &child_writ)?;
+    println!("   child kv_set(order=shipped): {s:?}  (rejected — kv_set not in child scope)");
+
+    // 5. Lineage on the ledger.
+    let parent_entries = runtime.ledger.entries(parent.trajectory_id())?;
+    println!("\n== parent trajectory entries");
+    for e in &parent_entries {
+        let label = match &e.payload {
+            EntryPayload::Root { note, .. } => format!("Root({note})"),
+            EntryPayload::Commit(c) => format!("Commit seq={}", c.body.seq),
+            EntryPayload::Delegation { child_trajectory_id, task, .. } => {
+                format!("Delegation(task={task:?} → {child_trajectory_id})")
+            }
+            other => format!("{other:?}"),
+        };
+        println!("   seq={} {label}", e.seq);
+    }
+
+    // 6. Parent state is unchanged by the child; replay reconstructs both.
+    let parent_world = parent.project_world()?;
+    let order = parent_world.resources.iter().find(|(k, _)| k.id == "order").map(|(_, v)| &v.value);
+    println!("\n== parent world: order = {}", serde_json::to_string(&order)?);
+
+    let (_pw, pr) = replay(&parent_entries, &ReplayConfig::default())?;
+    let child_entries = runtime.ledger.entries(child_traj)?;
+    let (_cw, cr) = replay(&child_entries, &ReplayConfig::default())?;
+    println!(
+        "== replay: parent {} commits verified, child {} commits verified",
+        pr.commits_replayed, cr.commits_replayed
+    );
+
+    println!("\nthymos: a parent grants less than it holds; the ledger remembers who did what.");
+    Ok(())
+}

--- a/thymos/crates/thymos-runtime/tests/delegation.rs
+++ b/thymos/crates/thymos-runtime/tests/delegation.rs
@@ -1,0 +1,199 @@
+//! Phase II — multi-agent delegation, proven end to end.
+//!
+//! A parent agent mints a child writ that is a *strict subset* of its own
+//! authority, the child executes on its own trajectory, and the ledger records
+//! the parent→child lineage. This test asserts the four properties that make
+//! delegation safe:
+//!
+//! 1. **Child writ ⊆ parent writ** — the minted child authority is a verified
+//!    strict subset (narrower tool scope, halved budget, decremented depth).
+//! 2. **Tenant boundaries cannot be crossed by delegation** — a child claiming a
+//!    different tenant is rejected by `verify_subset_of`.
+//! 3. **Lineage is recorded** — the parent trajectory carries a `Delegation`
+//!    edge to the child trajectory, and the child's root notes the task.
+//! 4. **Parent state isn't mutated by the child** — the child runs on a separate
+//!    trajectory with its own world; the parent's committed state is neither
+//!    visible to nor changed by the child. The only thing that mutates a
+//!    trajectory's world is a commit *on that trajectory*.
+//!
+//! Finally, replay reconstructs *both* trajectories deterministically.
+
+use serde_json::json;
+
+use thymos_ledger::{replay, EntryPayload, Ledger, ReplayConfig};
+use thymos_policy::{PolicyEngine, WritAuthorityPolicy};
+use thymos_runtime::{
+    generate_signing_key, public_key_of, Budget, CoreIntent, DelegationBounds, DelegationKeyring,
+    EffectCeiling, IntentBody, IntentKind, Runtime, Step, TimeWindow, ToolPattern, Writ, WritBody,
+};
+use thymos_tools::{DelegateTool, KvGetTool, KvSetTool, ToolRegistry};
+
+const TENANT: &str = "acme";
+
+fn act(target: &str, args: serde_json::Value, nonce: u8) -> CoreIntent {
+    CoreIntent::new(IntentBody {
+        parent_commit: None,
+        author: "cognition".into(),
+        kind: IntentKind::Act,
+        target: target.into(),
+        args,
+        rationale: format!("act on {target}"),
+        nonce: [nonce; 16],
+    })
+    .unwrap()
+}
+
+#[test]
+fn delegation_mints_subset_child_records_lineage_and_isolates_state() {
+    // ── Runtime with a delegation keyring (so child writs get signed). ──
+    let mut tools = ToolRegistry::new();
+    tools.register(KvSetTool::default());
+    tools.register(KvGetTool::default());
+    tools.register(DelegateTool::default());
+
+    let keyring = DelegationKeyring::new();
+    let runtime = Runtime::new(
+        Ledger::open_in_memory().unwrap(),
+        tools,
+        PolicyEngine::new().with(WritAuthorityPolicy),
+    )
+    .with_delegation_keyring(keyring.clone());
+
+    // ── Parent writ: tenant `acme`, may use kv_* and delegate, depth 2. ──
+    let root_key = generate_signing_key();
+    let agent_key = generate_signing_key();
+    let agent_pubkey = public_key_of(&agent_key);
+    let parent_writ = Writ::sign(
+        WritBody {
+            issuer: "root".into(),
+            issuer_pubkey: public_key_of(&root_key),
+            subject: "ops-agent".into(),
+            subject_pubkey: agent_pubkey,
+            nonce: [0u8; 16],
+            parent: None,
+            tenant_id: TENANT.into(),
+            tool_scopes: vec![ToolPattern::exact("kv_*"), ToolPattern::exact("delegate")],
+            budget: Budget {
+                tokens: 10_000,
+                tool_calls: 100,
+                wall_clock_ms: 600_000,
+                usd_millicents: 0,
+            },
+            effect_ceiling: EffectCeiling::read_write_local(),
+            time_window: TimeWindow { not_before: 0, expires_at: u64::MAX },
+            delegation: DelegationBounds { max_depth: 2, may_subdivide: true },
+        },
+        &root_key,
+    )
+    .unwrap();
+    // The runtime needs the parent subject's signing key to mint signed children.
+    keyring.register(agent_key);
+
+    // ── Parent commits a write on its own trajectory. ──
+    let parent = runtime.create_run("delegation demo", b"parent-v1").unwrap();
+    let s = parent
+        .submit(act("kv_set", json!({"key":"order","value":"received"}), 1), &parent_writ)
+        .unwrap();
+    assert!(matches!(s, Step::Committed(_)), "parent write should commit");
+
+    // ── Parent delegates an audit sub-task, restricting the child to kv_get. ──
+    let delegate_intent = CoreIntent::new(IntentBody {
+        parent_commit: None,
+        author: "cognition".into(),
+        kind: IntentKind::Delegate,
+        target: "auditor".into(),
+        args: json!({ "task": "audit the order", "tool_scopes": ["kv_get"] }),
+        rationale: "hand off a read-only audit under a narrower writ".into(),
+        nonce: [2u8; 16],
+    })
+    .unwrap();
+    let child_traj = match parent.submit(delegate_intent, &parent_writ).unwrap() {
+        Step::Delegated { child_trajectory_id, .. } => child_trajectory_id,
+        other => panic!("expected delegation, got {other:?}"),
+    };
+
+    // ── (1) The minted child writ is a strict subset of the parent. ──
+    let child_writ = keyring
+        .take_pending_child_writ(child_traj)
+        .expect("a signed child writ should have been minted and stashed");
+    assert!(
+        child_writ.body.verify_subset_of(&parent_writ.body).is_ok(),
+        "child writ must be a strict subset of the parent"
+    );
+    child_writ.verify_signature().expect("child writ is validly signed");
+    assert_eq!(child_writ.body.tenant_id, TENANT, "child inherits parent tenant");
+    assert_eq!(child_writ.body.parent, Some(parent_writ.id), "child points at parent writ");
+    assert_eq!(child_writ.body.delegation.max_depth, 1, "delegation depth decremented");
+    assert!(child_writ.body.budget.tool_calls <= parent_writ.body.budget.tool_calls / 2 + 1);
+    // Narrower authority: child may read but not write.
+    assert!(child_writ.authorizes_tool("kv_get"), "child keeps the granted kv_get scope");
+    assert!(!child_writ.authorizes_tool("kv_set"), "child does NOT inherit kv_set");
+
+    // ── (2) Tenant boundaries cannot be crossed by delegation. ──
+    let mut cross_tenant = child_writ.body.clone();
+    cross_tenant.tenant_id = "evil-corp".into();
+    assert!(
+        cross_tenant.verify_subset_of(&parent_writ.body).is_err(),
+        "a child claiming a different tenant must be rejected"
+    );
+
+    // ── Drive the child on its own trajectory. ──
+    let child = runtime.resume_run(child_traj).unwrap();
+    // The child reads — allowed by its writ. Its world is its own: the parent's
+    // `order=received` is NOT visible here (trajectory-isolated state).
+    let s = child.submit(act("kv_get", json!({"key":"order"}), 3), &child_writ).unwrap();
+    assert!(matches!(s, Step::Committed(_)), "child read should commit");
+    // The child attempts a write it was not granted — rejected at the writ boundary.
+    let s = child.submit(act("kv_set", json!({"key":"order","value":"shipped"}), 4), &child_writ).unwrap();
+    assert!(matches!(s, Step::Rejected(_)), "child write must be rejected (kv_set not in child scope)");
+
+    // ── (3) Lineage is recorded on the ledger. ──
+    let parent_entries = runtime.ledger.entries(parent.trajectory_id()).unwrap();
+    let edge = parent_entries.iter().find_map(|e| match &e.payload {
+        EntryPayload::Delegation { child_trajectory_id, task, .. } => Some((*child_trajectory_id, task.clone())),
+        _ => None,
+    });
+    let (edge_child, edge_task) = edge.expect("parent trajectory records a Delegation edge");
+    assert_eq!(edge_child, child_traj, "edge points at the child trajectory");
+    assert_eq!(edge_task, "audit the order");
+
+    let child_entries = runtime.ledger.entries(child_traj).unwrap();
+    match &child_entries[0].payload {
+        EntryPayload::Root { note, trajectory_id } => {
+            assert!(note.contains("delegated"), "child root notes the delegation: {note}");
+            assert_eq!(*trajectory_id, child_traj);
+        }
+        other => panic!("child trajectory must start with a Root, got {other:?}"),
+    }
+
+    // ── (4) Parent state isn't mutated by the child. ──
+    let parent_world = parent.project_world().unwrap();
+    let order = parent_world
+        .resources
+        .iter()
+        .find(|(k, _)| k.id == "order")
+        .map(|(_, v)| v.value.clone());
+    assert_eq!(order, Some(json!("received")), "parent world unchanged by the child");
+    // The child's world never saw the parent's `order` resource.
+    let child_world = child.project_world().unwrap();
+    assert!(
+        !child_world.resources.iter().any(|(k, _)| k.id == "order"),
+        "child trajectory is state-isolated from the parent"
+    );
+    // No child commit leaked onto the parent trajectory.
+    assert!(
+        !parent_entries.iter().any(|e| e.trajectory_id == child_traj),
+        "child commits stay on the child trajectory"
+    );
+
+    // ── Replay reconstructs BOTH trajectories deterministically. ──
+    let (pworld, preport) = replay(&parent_entries, &ReplayConfig::default()).unwrap();
+    assert!(preport.commits_replayed >= 1);
+    assert_eq!(
+        pworld.resources.iter().find(|(k, _)| k.id == "order").map(|(_, v)| v.value.clone()),
+        Some(json!("received")),
+        "parent replay folds back to the same world"
+    );
+    let (_cworld, creport) = replay(&child_entries, &ReplayConfig::default()).unwrap();
+    assert_eq!(creport.commits_replayed, 1, "child replay verifies its single committed read");
+}


### PR DESCRIPTION
Closes the Phase II gap in #22: delegation was *implemented* but not *showable*. Now it's runnable, asserted, and documented.

## What you can run
```bash
cargo run --example delegation_lineage -p thymos-runtime
```
```text
== parent writ: subject=ops-agent tenant=acme scopes=[kv_*, delegate] depth=2
   parent kv_set(order=received): Committed(commit(275da9a2))
-> delegated 'audit the order' → child trajectory: traj:73e0172b…
   child writ ⊆ parent? true
   child: tenant=acme scopes=[kv_get] depth=1 can_write=false
   cross-tenant child rejected? true
   child kv_get(order): Committed   (reads its OWN world — parent state not visible)
   child kv_set(order=shipped): Rejected(AuthorityVoid("writ does not authorize tool 'kv_set'"))
== parent trajectory: Root → Commit → Delegation(→ child)
== parent world: order = "received"
== replay: parent 1 commits verified, child 1 commits verified
```

## The four guarantees (asserted in `tests/delegation.rs`)
1. **Child writ ⊆ parent** — verified strict subset: narrower tool scope (loses `kv_set`), halved budget, decremented delegation depth, inherited tenant.
2. **Tenant boundaries can't be crossed by delegation** — a child claiming a different tenant is rejected by `verify_subset_of` before it can be signed.
3. **Lineage is on the ledger** — the parent trajectory carries a `Delegation` edge to the child trajectory; the child root notes the task. The DAG is reconstructable from the ledger alone.
4. **Parent state isn't mutated by the child** — the child runs on a separate, state-isolated trajectory; it can't even see the parent's `order`, and no child commit leaks onto the parent. Replay reconstructs both.

## Files
- `examples/delegation_lineage.rs` — runnable narration.
- `tests/delegation.rs` — property-by-property proof.
- `docs/demos/delegation-lineage.md` — site walkthrough.
- STATUS.md / README.md reconciled (delegation moves from "not yet" to "real").

Full `thymos-runtime` suite green, delegation test + example compile included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)