### PR TITLE
Phase III: make the Postgres ledger a real HTTP runtime backend

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,3 +36,38 @@ jobs:
           # The server can now select the Postgres backend at startup; guard that
           # wiring (Runtime<Box<dyn LedgerStore>> + BlockingPostgresLedger) too.
           cargo check -p thymos-server --features postgres
+
+  # Run the gated Postgres integration tests for real against a live database.
+  # This is the proof that the Postgres ledger backend (and the blocking facade
+  # the HTTP server uses) actually works — not just compiles. The same tests
+  # skip cleanly when THYMOS_TEST_POSTGRES_URL is unset (e.g. local `cargo test`).
+  postgres-integration:
+    name: Postgres ledger (live)
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: thymos_test
+          POSTGRES_USER: thymos
+          POSTGRES_PASSWORD: thymos
+        ports:
+          - 5432:5432
+        # Hold the job until Postgres is accepting connections.
+        options: >-
+          --health-cmd "pg_isready -U thymos -d thymos_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: thymos
+      - name: Run gated Postgres integration tests
+        env:
+          THYMOS_TEST_POSTGRES_URL: postgres://thymos:thymos@localhost:5432/thymos_test
+        run: |
+          cargo test -p thymos-ledger --features postgres \
+            --test postgres_integration -- --ignored --nocapture

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,3 +33,6 @@ jobs:
         run: |
           cargo check -p thymos-ledger --no-default-features --features postgres
           cargo test  -p thymos-ledger --features postgres --test postgres_integration --no-run
+          # The server can now select the Postgres backend at startup; guard that
+          # wiring (Runtime<Box<dyn LedgerStore>> + BlockingPostgresLedger) too.
+          cargo check -p thymos-server --features postgres

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,94 @@
+# Working on OpenThymos
+
+Guidance for any agent (or human) contributing to this repo. The goal is a
+runtime whose claims are **provable, demonstrable, and documented** — never
+vaporware.
+
+## The one rule everything serves
+
+**Cognition proposes. The runtime governs. The ledger records.**
+
+A model cannot call a tool, mutate state, spend budget, delegate authority, or
+erase history — not by convention, by runtime semantics. Effects pass through a
+typed `Intent → Proposal → Commit` pipeline bound to a signed writ, a policy
+trace, and an append-only ledger.
+
+Before any change, ask: *does this strengthen that boundary, or blur it?* If it
+blurs it (e.g. lets cognition assert authority inline, mutates projected state
+outside commit folding, or makes replay depend on a live provider), don't.
+
+## Architecture map
+
+| Crate | Role |
+|---|---|
+| `thymos-core` | Types: Intent, Proposal, Commit, Writ, World, deltas, ids (blake3 content-addressing) |
+| `thymos-ledger` | Append-only hash-chained ledger; SQLite (default) + Postgres backends; replay |
+| `thymos-compiler` | Compiles intents → proposals; enforces writ scope, effect ceiling, budget, time windows |
+| `thymos-policy` | Policy engine + traces (first-class proposal data) |
+| `thymos-tools` | Typed tool contracts; sandboxed shell/HTTP/fs fabric; `worker_entrypoint` |
+| `thymos-worker` | Thin binary = process-isolation boundary for tool execution (substance is in `thymos-tools`) |
+| `thymos-cognition` | Provider adapters (Anthropic, OpenAI, Mock) — emit intents only, no execution authority |
+| `thymos-runtime` | Drives the agent loop; owns runs, trajectories, budget projection, revocation |
+| `thymos-server` | HTTP surface (`/runs`, `/routed-submit`, `/routing-outcomes`, `/health`) |
+| `thymos-marketplace`, `thymos-cli`, `thymos-client` | Tool marketplace, CLI, Rust client |
+
+## Roadmap (what "aligned with our future" means)
+
+- **Phase I — Unified deterministic runtime.** Largely done: I→P→C, ledger as
+  truth, replay, signed writs, typed tools, policy traces.
+- **Phase II — Multi-agent coordination.** Delegation, child writs (strict
+  subsets of parent), child trajectories — implemented + tested; needs a
+  demonstrable end-to-end walkthrough.
+- **Phase III — Distributed execution ledger.** Postgres backend exists but is
+  **not yet wired into the HTTP runtime** (blocked on the runtime/ledger trait
+  refactor). This is the biggest claims-vs-reality gap; closing it is top
+  priority. See the tracking issues.
+
+Source of truth for current reality: **`STATUS.md`** (CI-proven vs gated vs
+caveats). Reconcile it every release; if it drifts from the code, the code wins.
+
+## Non-negotiable invariants (don't regress these)
+
+- No tool execution without a staged, authorized proposal.
+- No projected-state mutation outside commit folding.
+- No provider-specific execution authority; replay never calls a provider or
+  re-runs a tool.
+- Ledger entries are content-addressed (`id = blake3(canonical_json(payload))`);
+  replay verifies sequence continuity + parent linkage.
+- **No phone-home / no silent egress.** Telemetry is operator-owned (OTLP to the
+  operator's own endpoint, else stderr). This is a core value prop — never add
+  analytics or usage beacons. If usage signal is ever wanted, it must be
+  opt-in, off by default, and documented.
+
+## How we work (pro hygiene)
+
+- **Small, single-purpose PRs** with honest descriptions. State explicitly what
+  was *not* verified (e.g. "compiles + gates correctly, not run against a live
+  resource here"). Candor is a credibility signal.
+- **Gated tests** for anything needing external resources: `#[ignore]` and/or a
+  feature/env gate; skip cleanly (print `SKIP`, pass) when the resource is
+  absent. Never fake a green.
+  - Live LLM: `ANTHROPIC_API_KEY` → `thymos-runtime` test `live_provider`.
+  - Postgres: `THYMOS_TEST_POSTGRES_URL` → `thymos-ledger --features postgres`
+    test `postgres_integration`.
+- **Big/architectural changes get an RFC first** (`docs/rfcs/`, see
+  `RFC_TEMPLATE.md`) before code — especially anything touching the ledger,
+  replay, or the authority boundary.
+- **Release discipline:** tag every version `vX.Y.Z` so "pin to vX" is always
+  real. Tags trigger `.github/workflows/release.yml` (binaries + GHCR + GitHub
+  Release). Note: tag pushes require a credential that can write `refs/tags/*`.
+
+## Build / test / verify
+
+```bash
+cd thymos
+cargo build --workspace
+cargo test  --workspace                 # default: mock cognition, SQLite, governance
+cargo clippy --workspace --all-targets
+# gated proofs (need resources):
+ANTHROPIC_API_KEY=…       cargo test -p thymos-runtime --test live_provider -- --ignored --nocapture
+THYMOS_TEST_POSTGRES_URL=… cargo test -p thymos-ledger --features postgres --test postgres_integration -- --ignored
+```
+
+A change isn't "done" until: workspace tests pass, clippy is clean, `STATUS.md`
+still matches reality, and the PR description is honest about what was verified.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="./thymos/thymosG.PNG" alt="OpenThymos" width="325" />
 
-![Stars](https://img.shields.io/github/stars/gryszzz/open-thymos?style=for-the-badge) ![License](https://img.shields.io/github/license/gryszzz/open-thymos?style=for-the-badge) ![Rust](https://img.shields.io/badge/Rust-Execution_Runtime-orange?style=for-the-badge&logo=rust)
+[![Star on GitHub](https://img.shields.io/badge/⭐_Star-on_GitHub-yellow?style=for-the-badge)](https://github.com/gryszzz/open-thymos) [![License](https://img.shields.io/badge/License-Apache_2.0-blue?style=for-the-badge)](LICENSE) ![Rust](https://img.shields.io/badge/Rust-Execution_Runtime-orange?style=for-the-badge&logo=rust)
 
 # open-thymos
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,9 @@
 <div align="center">
-  
-<div align="center">
-  <img src="./thymos/thymosG.PNG" alt="OpenThymos" width="325" />
-</div>
-<div align="center">
 
-![Stars](https://img.shields.io/github/stars/gryszzz/open-thymos?style=for-the-badge)
+<img src="./thymos/thymosG.PNG" alt="OpenThymos" width="325" />
 
-![License](https://img.shields.io/github/license/gryszzz/open-thymos?style=for-the-badge)
+![Stars](https://img.shields.io/github/stars/gryszzz/open-thymos?style=for-the-badge) ![License](https://img.shields.io/github/license/gryszzz/open-thymos?style=for-the-badge) ![Rust](https://img.shields.io/badge/Rust-Execution_Runtime-orange?style=for-the-badge&logo=rust)
 
-![Rust](https://img.shields.io/badge/Rust-Execution_Runtime-orange?style=for-the-badge&logo=rust)
-
-<div align="center">
-  
 # open-thymos
 
 </div>

--- a/README.md
+++ b/README.md
@@ -166,20 +166,47 @@ The runtime is implemented as a Rust workspace under [`thymos/`](thymos):
 
 ## Quick Start
 
+**Fastest path — one command.** Builds the runtime, starts it, drives one real
+`Intent → Proposal → Commit` run end to end, prints the final world, and cleans
+up after itself:
+
+```bash
+./scripts/quickstart.sh
+# Connect a real model instead of the mock:
+ANTHROPIC_API_KEY=sk-ant-... ./scripts/quickstart.sh
+```
+
+**Manual path.** Start the runtime once, then attach from any client (CLI, web
+console, VS Code, terminal) — they all observe the same run state:
+
 ```bash
 cd thymos
-cargo test --workspace --features sqlite
+cargo run -p thymos-server          # http://localhost:3001 — mock cognition by default
 ```
 
 ```bash
-cargo run -p thymos-server
+# In another terminal: drive a run and follow it live (no API key needed)
+cd thymos
+cargo run -p thymos-cli -- run "Map the repo and summarize the runtime" --provider mock --follow
+
+# Verify + fold that run's ledger (use the run id printed above)
+cargo run -p thymos-cli -- replay <run_id> --verify
+
+# Check runtime health and which cognition provider is actually live
+cargo run -p thymos-cli -- doctor
 ```
 
+Install the `thymos` shorthand with `cargo install --path thymos/crates/thymos-cli`.
+
+**Verify everything** (default: mock cognition, SQLite, governance enforced):
+
 ```bash
-# Follow a run from terminal
-thymos run "summarize the open issues" --writ ./writs/dev.json
-thymos replay run_847 --verify
+cd thymos
+cargo test --workspace
 ```
+
+Run it on a real model, on a **Postgres** ledger, or in production-shaped mode —
+see **[Getting Started](docs/getting-started.md)**.
 
 ## Repository
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -55,8 +55,13 @@ never produces a false failure — and proves the real path when you supply it.
   auto-detected.
 - **Postgres is not yet the HTTP runtime path.** The async Postgres backend
   exists and is tested in isolation, but the HTTP server still uses the
-  synchronous SQLite path until the runtime/ledger trait refactor lands. The
-  server prints a note when `THYMOS_POSTGRES_URL` is set.
+  synchronous SQLite path. The runtime/ledger trait refactor has now landed:
+  `thymos-ledger` defines a `LedgerStore` trait and `thymos-runtime`'s `Runtime`
+  and `Run` are generic over it (`Runtime<L: LedgerStore = Ledger>`), proven by
+  a test that drives a full agent loop through a non-default backend. What
+  remains is a blocking facade that adapts the async Postgres backend to the
+  synchronous `LedgerStore` surface, plus wiring it into the server's
+  construction path. The server prints a note when `THYMOS_POSTGRES_URL` is set.
 - **`thymos-worker` is intentionally a thin binary.** It is the process-isolation
   boundary for sandboxed tool execution; the substance lives in
   `thymos_tools::worker_entrypoint` (kept in the library so it is unit-tested and

--- a/STATUS.md
+++ b/STATUS.md
@@ -53,15 +53,21 @@ never produces a false failure — and proves the real path when you supply it.
   server now logs a `WARNING` at startup in that case and `/health` reports
   `cognition_live: false`. Set a key to make it live; the provider is then
   auto-detected.
-- **Postgres is not yet the HTTP runtime path.** The async Postgres backend
-  exists and is tested in isolation, but the HTTP server still uses the
-  synchronous SQLite path. The runtime/ledger trait refactor has now landed:
-  `thymos-ledger` defines a `LedgerStore` trait and `thymos-runtime`'s `Runtime`
-  and `Run` are generic over it (`Runtime<L: LedgerStore = Ledger>`), proven by
-  a test that drives a full agent loop through a non-default backend. What
-  remains is a blocking facade that adapts the async Postgres backend to the
-  synchronous `LedgerStore` surface, plus wiring it into the server's
-  construction path. The server prints a note when `THYMOS_POSTGRES_URL` is set.
+- **Postgres is now a selectable HTTP runtime backend (feature-gated).** The
+  runtime/ledger trait refactor has landed end to end: `thymos-ledger` defines a
+  `LedgerStore` trait; `thymos-runtime`'s `Runtime`/`Run` are generic over it
+  (`Runtime<L: LedgerStore = Ledger>`); and a `BlockingPostgresLedger` facade
+  adapts the async Postgres backend to the synchronous trait by driving futures
+  on a dedicated runtime thread (so it is safe to call from the server's async
+  handlers — `block_on` would panic there). The server selects the backend at
+  startup: with the `postgres` feature built and `THYMOS_POSTGRES_URL` set, it
+  runs `Runtime<Box<dyn LedgerStore>>` over Postgres; otherwise it uses SQLite.
+  The **default build remains SQLite** (no Postgres dependency compiled). Proof
+  is gated on a live database (`THYMOS_TEST_POSTGRES_URL`): one test asserts the
+  facade yields a byte-identical content-addressed chain to SQLite from the same
+  inputs, another asserts the sync facade is safe to call from inside a tokio
+  runtime. These run in the Postgres CI job once DB secrets exist; they skip
+  cleanly (print `SKIP`, pass) otherwise.
 - **`thymos-worker` is intentionally a thin binary.** It is the process-isolation
   boundary for sandboxed tool execution; the substance lives in
   `thymos_tools::worker_entrypoint` (kept in the library so it is unit-tested and

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -256,6 +256,29 @@ Use this when you want:
 - deploy-time concurrency tuning
 - a more production-shaped runtime boundary
 
+## 8. Postgres ledger backend (optional)
+
+The durable ledger defaults to SQLite. To run it on Postgres instead, build the
+server with the `postgres` feature and point it at a database:
+
+```bash
+# Bring up a local Postgres (or use your own); from thymos/:
+docker compose --profile postgres up -d postgres
+
+THYMOS_POSTGRES_URL=postgres://thymos:thymos@localhost:5432/thymos \
+  cargo run -p thymos-server --features postgres
+```
+
+The startup log prints `ledger: postgres (synchronous blocking facade) at …`
+when it connects. Notes:
+
+- Without the `postgres` feature, `THYMOS_POSTGRES_URL` is ignored — the server
+  logs a note and stays on SQLite. The **default build compiles no Postgres
+  dependencies**.
+- Replay is byte-identical across backends: the same trajectory yields the same
+  content-addressed chain on SQLite and Postgres (this is asserted by the gated
+  `postgres_integration` tests).
+
 ## Where to go next
 
 - [Interfaces]({{ '/interfaces' | relative_url }}) — pick the surface that fits you

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -133,6 +133,11 @@ Thymos keeps the same runtime and tool model. You only swap the proposer — and
 you just set a key. **Any run that doesn't specify its own `cognition` block now
 uses the provider you configured** (instead of silently falling back to mock).
 
+The CLI cooperates: `thymos run` defaults to `--provider auto`, which sends **no**
+provider override, so your runs use whatever the server resolved. Once the server
+has a key, the same `thymos run "…"` uses the real model with no CLI change. Pass
+`--provider mock` to force the deterministic mock for a single run.
+
 ### Anthropic
 
 ```bash

--- a/docs/rfcs/runtime-ledger-trait-v1.md
+++ b/docs/rfcs/runtime-ledger-trait-v1.md
@@ -1,0 +1,141 @@
+# RFC: Runtime/Ledger trait refactor (v1)
+
+Status: Draft
+Tracking: #22 (Phase III — distributed execution ledger)
+
+## Summary
+
+Abstract the ledger behind a trait so the synchronous SQLite backend and the
+asynchronous Postgres backend are interchangeable **without changing the
+execution protocol or replay determinism**. This unblocks running the HTTP
+server on a Postgres-backed production ledger, which the roadmap promises but the
+code does not yet deliver (the server prints a note that it "still uses the
+synchronous SQLite ledger path").
+
+## Motivation
+
+- `STATUS.md` and the roadmap claim a "production-grade Postgres ledger." Today
+  `PostgresLedger` exists and is integrity-tested in isolation, but the runtime
+  is hard-wired to `thymos_ledger::Ledger` (= `SqliteLedger`). The claim is
+  aspirational until the runtime can actually use it.
+- `thymos-runtime`'s `Runtime` holds a concrete `pub ledger: Ledger;` and calls
+  it directly. Swapping backends today means a type change, not a config change.
+
+## Goals
+
+- A single trait the runtime depends on instead of a concrete `SqliteLedger`.
+- SQLite remains the default and the in-memory path for tests — zero behavior
+  change for existing users.
+- Postgres becomes a *selectable* HTTP runtime backend.
+- Replay stays byte-identical across backends.
+
+## Non-goals
+
+- Rewriting the runtime to be fully async (tracked separately; see Alternatives).
+- Distributed/multi-node ledger semantics (Phase III later work: merge entries,
+  checkpoints). This RFC only makes the backend swappable on a single node.
+
+## The trait surface (already small and stable)
+
+The runtime + server call exactly these methods today (counts = call sites):
+
+```
+entries (17)  append_commit (3)  head (3)  has_trajectory (2)
+append_rejection (2)  append_root (1)  append_pending_approval (1)
+verify_integrity (1)
+```
+
+Plus `append_delegation`, `append_branch_root`, `query_entries`, `count_entries`
+exist on both backends and belong in the trait for completeness.
+
+```rust
+pub trait LedgerStore {
+    fn append_root(&self, trajectory_id: TrajectoryId, note: &str) -> Result<Entry>;
+    fn append_commit(&self, commit: Commit) -> Result<Entry>;
+    fn append_rejection(&self, /* … */) -> Result<Entry>;
+    fn append_pending_approval(&self, /* … */) -> Result<Entry>;
+    fn append_delegation(&self, /* … */) -> Result<Entry>;
+    fn append_branch_root(&self, /* … */) -> Result<Entry>;
+    fn has_trajectory(&self, trajectory_id: TrajectoryId) -> bool;
+    fn head(&self, trajectory_id: TrajectoryId) -> Result<(ContentHash, u64)>;
+    fn entries(&self, trajectory_id: TrajectoryId) -> Result<Vec<Entry>>;
+    fn verify_integrity(&self, trajectory_id: TrajectoryId) -> Result<()>;
+    fn query_entries(&self, /* … */) -> Result<Vec<Entry>>;
+    fn count_entries(&self, /* … */) -> Result<u64>;
+}
+```
+
+**Replay is unaffected.** `replay()`, `replay_and_match()`, `project_commits()`,
+and `verify_integrity_entries()` already take `&[Entry]` — they are
+storage-independent today. The trait only governs *how entries are read/written*,
+not how the world is folded. This is the property that makes the refactor safe.
+
+## The crux: sync runtime vs async Postgres
+
+`SqliteLedger` is synchronous; `PostgresLedger` is `async`. `Runtime`/`Run` are
+synchronous and borrow `&Runtime`. There are three ways to bridge:
+
+**Option A (recommended): sync `LedgerStore` trait; Postgres gets a blocking
+facade.** Keep the runtime synchronous. Implement `LedgerStore` directly for
+SQLite. For Postgres, wrap the async pool in an adapter that drives futures to
+completion on a dedicated Tokio runtime handle (`Handle::block_on` / a current-
+thread runtime owned by the adapter). The server already calls the sync runtime
+from async handlers via the blocking path, so this composes.
+- *Pros:* smallest blast radius; runtime, compiler, replay, and every test stay
+  unchanged; ships Phase III value now.
+- *Cons:* a blocking hop per ledger op under Postgres (acceptable — ledger ops
+  are not the hot loop; cognition latency dominates). Must avoid running the
+  adapter's `block_on` *inside* an async executor thread (use a dedicated
+  runtime/thread, not the request executor).
+
+**Option B: async `LedgerStore` (via `async-trait`); async-ify the runtime.**
+Cleanest long-term, but turns `Run`/`Runtime`/agent-loop and all call sites
+async — a large, higher-risk change touching the authority boundary. Defer.
+
+**Option C: two traits (sync + async) with a bridge.** More surface area, more
+ways to drift. Rejected.
+
+Recommendation: **Option A now**, with the trait shaped so a future move to
+Option B is mechanical (method names/semantics identical).
+
+## Migration plan (small, reviewable PRs)
+
+1. Define `LedgerStore` in `thymos-ledger`; impl for `SqliteLedger`. No runtime
+   change yet. (Pure addition.)
+2. Change `Runtime` to hold `L: LedgerStore` (generic) **or** `Box<dyn
+   LedgerStore>`. Prefer a generic to avoid dynamic dispatch in the hot path;
+   fall back to `dyn` if the generic bound proves viral. Default stays SQLite —
+   all existing tests pass untouched.
+3. Implement the Postgres blocking facade + `LedgerStore` for it (feature
+   `postgres`).
+4. Server: select backend from config (`THYMOS_LEDGER_BACKEND` /
+   `THYMOS_POSTGRES_URL`); remove the "still uses SQLite" note.
+5. Backend-independence test: drive the same trajectory through both backends and
+   assert `replay()` yields an identical world projection and the same
+   content-addressed head.
+
+## Test plan
+
+- Existing workspace suite must pass unchanged after steps 1–2 (proves zero
+  behavior change for SQLite).
+- New gated test (extends `postgres_integration`): run an identical scripted
+  trajectory on SQLite and Postgres; assert equal head hash + equal replayed
+  world. Gated on `THYMOS_TEST_POSTGRES_URL`.
+- CI keeps the compile guard for `--features postgres`.
+
+## Risks
+
+- **`block_on` misuse** (Option A): calling it on an async executor thread panics
+  or deadlocks. Mitigation: the Postgres adapter owns its own runtime; document
+  and test the boundary.
+- **Generic bound virality**: `L: LedgerStore` may spread through many signatures.
+  Mitigation: if it gets noisy, use `Box<dyn LedgerStore>` (ledger ops aren't hot
+  enough for dynamic dispatch to matter).
+- **Silent semantic drift between backends**: the backend-independence test is the
+  guard; it must be part of the gated Postgres CI job once secrets exist.
+
+## Decision needed
+
+Confirm Option A (sync trait + Postgres blocking facade) before implementation,
+and whether `Runtime` should be generic over `L: LedgerStore` or hold `Box<dyn
+LedgerStore>`.

--- a/docs/rfcs/runtime-ledger-trait-v1.md
+++ b/docs/rfcs/runtime-ledger-trait-v1.md
@@ -1,7 +1,34 @@
 # RFC: Runtime/Ledger trait refactor (v1)
 
-Status: Draft
+Status: Implemented (steps 1–4; step 5 gated on a live DB)
 Tracking: #22 (Phase III — distributed execution ledger)
+
+## Implementation status
+
+All five migration steps have shipped:
+
+1. ✅ `LedgerStore` trait in `thymos-ledger`, impl for `SqliteLedger` (pure addition).
+2. ✅ `Runtime`/`Run` made generic — `Runtime<L: LedgerStore = Ledger>`. The
+   default type parameter keeps every existing concrete call site (server,
+   tests) compiling unchanged.
+3. ✅ Postgres blocking facade — `BlockingPostgresLedger` (`feature = "postgres"`).
+4. ✅ Server backend selection. The server holds `Runtime<Box<dyn LedgerStore>>`
+   (Option from the "Decision needed" section: `Box<dyn>` chosen over a viral
+   generic, since ledger ops are not the hot path) and picks SQLite or Postgres
+   from `THYMOS_POSTGRES_URL` + the `postgres` feature. The "still uses SQLite"
+   note is replaced.
+5. ✅ (gated) Backend-independence + async-safety tests, on `THYMOS_TEST_POSTGRES_URL`.
+
+**One deviation from the sketch below, forced by the `block_on` risk this RFC
+flagged:** the facade does *not* use `Handle::block_on`. The server calls sync
+ledger methods from tokio worker threads (async handlers, `run_agent_streaming`),
+where `block_on` panics ("cannot block the current thread from within a runtime").
+So the facade owns a dedicated OS thread running its own current-thread runtime +
+`LocalSet`; sync methods ship a `Send` job closure to it over a channel and block
+only on a `std::sync::mpsc` reply on the caller's thread. This is safe from any
+context. (The per-call futures are `!Send` because the Postgres query builder
+holds `!Send` params across awaits, which is why the closure — not the future —
+is what crosses the thread boundary.)
 
 ## Summary
 

--- a/thymos/crates/thymos-cli/src/main.rs
+++ b/thymos/crates/thymos-cli/src/main.rs
@@ -40,8 +40,11 @@ enum Commands {
         /// Maximum steps (default: 16).
         #[arg(long, default_value = "16")]
         max_steps: u32,
-        /// Cognition provider: anthropic, openai, local, lmstudio, huggingface, mock.
-        #[arg(long, default_value = "mock")]
+        /// Cognition provider. Default `auto` uses the server's configured
+        /// provider (which resolves THYMOS_DEFAULT_PROVIDER, then the first API
+        /// key, then mock). Pass anthropic / openai / local / lmstudio /
+        /// huggingface / mock to override it for this run.
+        #[arg(long, default_value = "auto")]
         provider: String,
         /// Model override.
         #[arg(long)]
@@ -257,8 +260,32 @@ async fn main() {
 
     if let Err(e) = result {
         eprintln!("error: {e}");
+        if is_connection_error(&e) {
+            eprintln!();
+            eprintln!("Could not reach the Thymos server at {}.", cli.url);
+            eprintln!("Is it running?  Start it with:  cargo run -p thymos-server");
+            eprintln!("Point at another server with  --url <addr>  or  THYMOS_URL=<addr>.");
+        }
         std::process::exit(1);
     }
+}
+
+/// Heuristic over the stringified transport error: did we fail because nothing
+/// was listening / reachable, rather than because the server returned an error?
+fn is_connection_error(msg: &str) -> bool {
+    let m = msg.to_ascii_lowercase();
+    // reqwest's top-level Display is just "error sending request for url (…)" —
+    // the connect/DNS cause lives in the source chain, which is dropped when the
+    // error is stringified. For a CLI a failure to even send the request means
+    // the server is unreachable (an HTTP-status error takes a different path),
+    // so this phrase is a reliable signal on its own.
+    m.contains("error sending request")
+        || m.contains("connection refused")
+        || m.contains("error trying to connect")
+        || m.contains("tcp connect error")
+        || m.contains("connection reset")
+        || m.contains("dns error")
+        || m.contains("failed to lookup")
 }
 
 fn color_enabled() -> bool {
@@ -372,12 +399,16 @@ pub(crate) async fn start_run(
     let mut body = serde_json::json!({
         "task": options.task,
         "max_steps": options.max_steps,
-        "cognition": {
-            "provider": options.provider,
-        },
     });
-    if let Some(m) = options.model {
-        body["cognition"]["model"] = serde_json::json!(m);
+    // `auto` means "don't override the server's configured provider" — so we omit
+    // the cognition block entirely and let the server's own resolution order win
+    // (THYMOS_DEFAULT_PROVIDER -> first API key -> mock). An explicit provider is
+    // sent as a per-run override; `--model` pairs with an explicit provider.
+    if !options.provider.eq_ignore_ascii_case("auto") {
+        body["cognition"] = serde_json::json!({ "provider": options.provider });
+        if let Some(m) = options.model {
+            body["cognition"]["model"] = serde_json::json!(m);
+        }
     }
     if let Some(s) = options.scopes {
         let scope_list: Vec<&str> = s.split(',').collect();
@@ -413,7 +444,11 @@ pub(crate) async fn cmd_run(
 
     println!("Run started: {run_id}");
     println!("  task: {}", options.start.task);
-    println!("  provider: {}", options.start.provider);
+    if options.start.provider.eq_ignore_ascii_case("auto") {
+        println!("  provider: auto (server default)");
+    } else {
+        println!("  provider: {}", options.start.provider);
+    }
     println!();
     if options.follow {
         println!("--- streaming ---");
@@ -717,6 +752,21 @@ pub(crate) async fn cmd_doctor(
                     status.as_u16(),
                     body["mode"].as_str().unwrap_or("unknown mode")
                 ),
+            );
+            // The single most common first-run footgun: not knowing whether the
+            // server is answering with a real model or the deterministic mock.
+            let provider = body["default_provider"].as_str().unwrap_or("unknown");
+            let live = body["cognition_live"].as_bool().unwrap_or(false);
+            status_line(
+                "cognition",
+                live,
+                if live {
+                    format!("{provider} (live model)")
+                } else {
+                    format!(
+                        "{provider} — MOCK, not a real model (set ANTHROPIC_API_KEY / OPENAI_API_KEY)"
+                    )
+                },
             );
         }
         Err(err) => status_line("runtime health", false, format!("offline: {err}")),

--- a/thymos/crates/thymos-ledger/src/lib.rs
+++ b/thymos/crates/thymos-ledger/src/lib.rs
@@ -254,6 +254,111 @@ impl Entry {
     }
 }
 
+/// The storage-and-query surface shared by every ledger backend.
+///
+/// This is the abstraction the runtime is intended to depend on, so the agent
+/// loop can be written once against `LedgerStore` and bound to a concrete
+/// backend (SQLite today; a Postgres facade under Phase III) at construction.
+///
+/// It is **purely additive**: every method mirrors an existing inherent method
+/// on the concrete backends, so introducing the trait changes no behavior. The
+/// `append_*`, `head`, `entries`, `query_entries`, and `count_entries` methods
+/// are the storage primitives each backend must provide. The derived
+/// operations — `has_trajectory`, `verify_integrity`, and `anchor` — are given
+/// as defaults in terms of those primitives, because every backend computes
+/// them identically over the same shared entry types.
+///
+/// `Send + Sync` is required because the runtime shares one ledger across
+/// concurrent tasks; the in-tree backends already satisfy it.
+pub trait LedgerStore: Send + Sync {
+    /// Append the genesis (`Root`) entry that begins a trajectory.
+    fn append_root(&self, trajectory_id: TrajectoryId, note: &str) -> Result<Entry>;
+
+    /// Append a `Commit`, enforcing seq/parent continuity against the head.
+    fn append_commit(&self, commit: Commit) -> Result<Entry>;
+
+    /// Append a `Rejection` recording why an intent was refused.
+    fn append_rejection(
+        &self,
+        trajectory_id: TrajectoryId,
+        intent_id: IntentId,
+        reason: RejectionReason,
+    ) -> Result<Entry>;
+
+    /// Append a `PendingApproval` for a suspended proposal awaiting a human.
+    fn append_pending_approval(
+        &self,
+        trajectory_id: TrajectoryId,
+        proposal: Proposal,
+        channel: String,
+        reason: String,
+    ) -> Result<Entry>;
+
+    /// Append a `Delegation` linking a parent trajectory to a child one.
+    fn append_delegation(
+        &self,
+        trajectory_id: TrajectoryId,
+        child_trajectory_id: TrajectoryId,
+        task: &str,
+        final_answer: Option<String>,
+    ) -> Result<Entry>;
+
+    /// Append the genesis `Branch` entry for a trajectory forked from another.
+    fn append_branch_root(
+        &self,
+        new_trajectory_id: TrajectoryId,
+        source_trajectory_id: TrajectoryId,
+        source_commit_id: CommitId,
+        note: &str,
+    ) -> Result<Entry>;
+
+    /// Current head `(id, seq)` for a trajectory, or an error if it has none.
+    fn head(&self, trajectory_id: TrajectoryId) -> Result<(ContentHash, u64)>;
+
+    /// All entries for a trajectory in `seq` order.
+    fn entries(&self, trajectory_id: TrajectoryId) -> Result<Vec<Entry>>;
+
+    /// Query entries across trajectories with optional filters (see the
+    /// backend method for the precise filter semantics).
+    fn query_entries(
+        &self,
+        trajectory_id: Option<TrajectoryId>,
+        kind: Option<&str>,
+        from_ts: Option<u64>,
+        to_ts: Option<u64>,
+        limit: Option<u32>,
+    ) -> Result<Vec<AuditEntry>>;
+
+    /// Count entries matching the given filters.
+    fn count_entries(
+        &self,
+        trajectory_id: Option<TrajectoryId>,
+        kind: Option<&str>,
+        from_ts: Option<u64>,
+        to_ts: Option<u64>,
+    ) -> Result<u64>;
+
+    /// Whether a trajectory has been rooted. Derived from [`head`](Self::head).
+    fn has_trajectory(&self, trajectory_id: TrajectoryId) -> bool {
+        self.head(trajectory_id).is_ok()
+    }
+
+    /// Verify the hash-chain / seq / parent integrity of a trajectory.
+    /// Derived from [`entries`](Self::entries).
+    fn verify_integrity(&self, trajectory_id: TrajectoryId) -> Result<()> {
+        verify_integrity_entries(&self.entries(trajectory_id)?)
+    }
+
+    /// Produce a publishable [`MerkleAnchor`] over a verified trajectory.
+    /// Integrity is checked first, so an anchor is only taken over a valid
+    /// chain. Derived from [`entries`](Self::entries).
+    fn anchor(&self, trajectory_id: TrajectoryId) -> Result<MerkleAnchor> {
+        let entries = self.entries(trajectory_id)?;
+        verify_integrity_entries(&entries)?;
+        Ok(compute_anchor(trajectory_id, &entries))
+    }
+}
+
 #[cfg(all(test, feature = "sqlite"))]
 mod tests {
     use super::*;
@@ -311,6 +416,47 @@ mod tests {
         assert_eq!(e.seq, 1);
 
         l.verify_integrity(traj).unwrap();
+    }
+
+    /// Phase III prep: the runtime will be generic over `LedgerStore`. This
+    /// proves `SqliteLedger` satisfies the trait and that a fully
+    /// backend-agnostic function can drive the entire append/read/verify/query
+    /// surface through the trait alone — including the derived default methods
+    /// (`has_trajectory`, `verify_integrity`, `anchor`).
+    #[test]
+    fn ledger_store_trait_drives_full_surface() {
+        fn exercise<L: LedgerStore>(l: &L) {
+            let traj = TrajectoryId::new_from_seed(b"trait-generic");
+            let root = l.append_root(traj, "via-trait").unwrap();
+            assert_eq!(root.seq, 0);
+            assert!(l.has_trajectory(traj));
+
+            let c1 = trivial_commit(traj, Some(CommitId(root.id)), 1);
+            l.append_commit(c1).unwrap();
+
+            let (_head_id, head_seq) = l.head(traj).unwrap();
+            assert_eq!(head_seq, 1);
+            assert_eq!(l.entries(traj).unwrap().len(), 2);
+
+            l.verify_integrity(traj).unwrap();
+            let _ = l.anchor(traj).unwrap();
+
+            assert_eq!(l.count_entries(Some(traj), None, None, None).unwrap(), 2);
+            assert_eq!(
+                l.count_entries(Some(traj), Some("commit"), None, None)
+                    .unwrap(),
+                1
+            );
+            assert_eq!(
+                l.query_entries(Some(traj), None, None, None, None)
+                    .unwrap()
+                    .len(),
+                2
+            );
+        }
+
+        let l = Ledger::open_in_memory().unwrap();
+        exercise(&l);
     }
 
     /// Regression: two trajectories created with the *same* note against one

--- a/thymos/crates/thymos-ledger/src/lib.rs
+++ b/thymos/crates/thymos-ledger/src/lib.rs
@@ -359,6 +359,95 @@ pub trait LedgerStore: Send + Sync {
     }
 }
 
+/// Forwarding impl so a boxed trait object is itself a `LedgerStore`. This lets
+/// a caller hold *either* backend behind one concrete type — e.g. the HTTP
+/// server selecting SQLite or Postgres at startup and running
+/// `Runtime<Box<dyn LedgerStore>>` — without making every signature generic.
+/// Every method, including the derived defaults, forwards to the inner value so
+/// a backend that overrides a default is still honored.
+impl LedgerStore for Box<dyn LedgerStore> {
+    fn append_root(&self, trajectory_id: TrajectoryId, note: &str) -> Result<Entry> {
+        (**self).append_root(trajectory_id, note)
+    }
+    fn append_commit(&self, commit: Commit) -> Result<Entry> {
+        (**self).append_commit(commit)
+    }
+    fn append_rejection(
+        &self,
+        trajectory_id: TrajectoryId,
+        intent_id: IntentId,
+        reason: RejectionReason,
+    ) -> Result<Entry> {
+        (**self).append_rejection(trajectory_id, intent_id, reason)
+    }
+    fn append_pending_approval(
+        &self,
+        trajectory_id: TrajectoryId,
+        proposal: Proposal,
+        channel: String,
+        reason: String,
+    ) -> Result<Entry> {
+        (**self).append_pending_approval(trajectory_id, proposal, channel, reason)
+    }
+    fn append_delegation(
+        &self,
+        trajectory_id: TrajectoryId,
+        child_trajectory_id: TrajectoryId,
+        task: &str,
+        final_answer: Option<String>,
+    ) -> Result<Entry> {
+        (**self).append_delegation(trajectory_id, child_trajectory_id, task, final_answer)
+    }
+    fn append_branch_root(
+        &self,
+        new_trajectory_id: TrajectoryId,
+        source_trajectory_id: TrajectoryId,
+        source_commit_id: CommitId,
+        note: &str,
+    ) -> Result<Entry> {
+        (**self).append_branch_root(
+            new_trajectory_id,
+            source_trajectory_id,
+            source_commit_id,
+            note,
+        )
+    }
+    fn head(&self, trajectory_id: TrajectoryId) -> Result<(ContentHash, u64)> {
+        (**self).head(trajectory_id)
+    }
+    fn entries(&self, trajectory_id: TrajectoryId) -> Result<Vec<Entry>> {
+        (**self).entries(trajectory_id)
+    }
+    fn query_entries(
+        &self,
+        trajectory_id: Option<TrajectoryId>,
+        kind: Option<&str>,
+        from_ts: Option<u64>,
+        to_ts: Option<u64>,
+        limit: Option<u32>,
+    ) -> Result<Vec<AuditEntry>> {
+        (**self).query_entries(trajectory_id, kind, from_ts, to_ts, limit)
+    }
+    fn count_entries(
+        &self,
+        trajectory_id: Option<TrajectoryId>,
+        kind: Option<&str>,
+        from_ts: Option<u64>,
+        to_ts: Option<u64>,
+    ) -> Result<u64> {
+        (**self).count_entries(trajectory_id, kind, from_ts, to_ts)
+    }
+    fn has_trajectory(&self, trajectory_id: TrajectoryId) -> bool {
+        (**self).has_trajectory(trajectory_id)
+    }
+    fn verify_integrity(&self, trajectory_id: TrajectoryId) -> Result<()> {
+        (**self).verify_integrity(trajectory_id)
+    }
+    fn anchor(&self, trajectory_id: TrajectoryId) -> Result<MerkleAnchor> {
+        (**self).anchor(trajectory_id)
+    }
+}
+
 #[cfg(all(test, feature = "sqlite"))]
 mod tests {
     use super::*;
@@ -457,6 +546,26 @@ mod tests {
 
         let l = Ledger::open_in_memory().unwrap();
         exercise(&l);
+    }
+
+    /// `Box<dyn LedgerStore>` is itself a `LedgerStore`, so a single boxed value
+    /// can stand in for any backend (the server's runtime-time backend choice).
+    #[test]
+    fn boxed_dyn_ledger_store_forwards() {
+        let boxed: Box<dyn LedgerStore> = Box::new(Ledger::open_in_memory().unwrap());
+        let traj = TrajectoryId::new_from_seed(b"boxed-dyn");
+        let root = boxed.append_root(traj, "via-box").unwrap();
+        assert_eq!(root.seq, 0);
+        let c1 = trivial_commit(traj, Some(CommitId(root.id)), 1);
+        boxed.append_commit(c1).unwrap();
+        assert_eq!(boxed.head(traj).unwrap().1, 1);
+        assert_eq!(boxed.entries(traj).unwrap().len(), 2);
+        boxed.verify_integrity(traj).unwrap();
+        // It can also parameterize the runtime-facing generic surface.
+        fn takes_store<L: LedgerStore>(l: &L, t: TrajectoryId) -> usize {
+            l.entries(t).unwrap().len()
+        }
+        assert_eq!(takes_store(&boxed, traj), 2);
     }
 
     /// Regression: two trajectories created with the *same* note against one

--- a/thymos/crates/thymos-ledger/src/postgres.rs
+++ b/thymos/crates/thymos-ledger/src/postgres.rs
@@ -6,6 +6,10 @@
 //! All operations are async. Callers (the runtime, server) must run them
 //! inside a tokio context.
 
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
 use deadpool_postgres::{Config, Pool, Runtime};
 use tokio_postgres::NoTls;
 
@@ -501,4 +505,214 @@ fn row_to_entry(row: &tokio_postgres::Row) -> Result<Entry> {
         kind,
         payload,
     })
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Blocking facade: a synchronous `LedgerStore` over the async `PostgresLedger`.
+//
+// The runtime and the `LedgerStore` trait are synchronous, but `PostgresLedger`
+// is async. We cannot bridge with `block_on` on the request executor: the HTTP
+// server calls sync ledger methods *from tokio worker threads* (async handlers
+// and `run_agent_streaming`), where `Runtime::block_on` / `Handle::block_on`
+// panics ("cannot block the current thread from within a runtime").
+//
+// So the facade owns a dedicated OS thread running its *own* multi-thread tokio
+// runtime plus the connection pool. Each sync call ships a future to that thread
+// over a tokio unbounded channel (whose `send` is itself synchronous) and blocks
+// on a plain `std::sync::mpsc` reply. The only blocking is a std channel `recv`
+// on the *caller's* thread — never a tokio runtime — so it is safe from any
+// context (sync or async) and cannot deadlock against the request executor.
+// This realizes RFC `runtime-ledger-trait-v1` Option A.
+
+// A job is a `Send` closure that, when run *on the worker thread*, produces the
+// actual per-call future. The future itself need not be `Send` (the Postgres
+// query builder holds `!Send` params across awaits); only the closure crosses
+// the thread boundary, and it captures only `Send` data.
+type LedgerJob = Box<dyn FnOnce() -> Pin<Box<dyn Future<Output = ()>>> + Send>;
+
+/// Synchronous [`crate::LedgerStore`] adapter over [`PostgresLedger`]. Build it
+/// with [`BlockingPostgresLedger::connect`]; drop it to stop the worker thread.
+pub struct BlockingPostgresLedger {
+    job_tx: tokio::sync::mpsc::UnboundedSender<LedgerJob>,
+    ledger: Arc<PostgresLedger>,
+    // Owned so the worker thread's lifetime is tied to this value. The thread
+    // exits once `job_tx` is dropped (channel closes) when the facade drops.
+    _worker: std::thread::JoinHandle<()>,
+}
+
+impl BlockingPostgresLedger {
+    /// Connect to Postgres on a dedicated runtime thread and bootstrap the
+    /// schema. Blocks until the connection is established (or fails).
+    pub fn connect(conn_str: &str) -> Result<Self> {
+        let conn_str = conn_str.to_string();
+        let (ready_tx, ready_rx) = std::sync::mpsc::channel::<Result<Arc<PostgresLedger>>>();
+        let (job_tx, mut job_rx) = tokio::sync::mpsc::unbounded_channel::<LedgerJob>();
+
+        let worker = std::thread::Builder::new()
+            .name("thymos-pg-ledger".into())
+            .spawn(move || {
+                let rt = match tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                {
+                    Ok(rt) => rt,
+                    Err(e) => {
+                        let _ =
+                            ready_tx.send(Err(Error::Ledger(format!("pg facade runtime: {e}"))));
+                        return;
+                    }
+                };
+                // A `LocalSet` lets us `spawn_local` the per-call futures, which
+                // need not be `Send`. Concurrency is cooperative on this single
+                // thread — fine for I/O-bound ledger ops, where overlapping
+                // awaits on the connection pool still progress.
+                let local = tokio::task::LocalSet::new();
+                local.block_on(&rt, async move {
+                    let ledger = match PostgresLedger::connect(&conn_str).await {
+                        Ok(l) => Arc::new(l),
+                        Err(e) => {
+                            let _ = ready_tx.send(Err(e));
+                            return;
+                        }
+                    };
+                    if ready_tx.send(Ok(ledger)).is_err() {
+                        return; // caller stopped waiting
+                    }
+                    // Drive jobs until every sender drops (the facade is gone).
+                    while let Some(job) = job_rx.recv().await {
+                        tokio::task::spawn_local(job());
+                    }
+                });
+            })
+            .map_err(|e| Error::Ledger(format!("pg facade thread: {e}")))?;
+
+        let ledger = ready_rx
+            .recv()
+            .map_err(|_| Error::Ledger("pg facade thread exited before ready".into()))??;
+
+        Ok(Self {
+            job_tx,
+            ledger,
+            _worker: worker,
+        })
+    }
+
+    /// Ship an async operation to the worker thread and block until it returns.
+    fn call<T, F, Fut>(&self, f: F) -> T
+    where
+        F: FnOnce(Arc<PostgresLedger>) -> Fut + Send + 'static,
+        Fut: Future<Output = T> + 'static,
+        T: Send + 'static,
+    {
+        let (reply_tx, reply_rx) = std::sync::mpsc::channel::<T>();
+        let ledger = self.ledger.clone();
+        let job: LedgerJob = Box::new(move || {
+            Box::pin(async move {
+                let out = f(ledger).await;
+                let _ = reply_tx.send(out);
+            }) as Pin<Box<dyn Future<Output = ()>>>
+        });
+        self.job_tx
+            .send(job)
+            .expect("thymos postgres ledger worker thread is not running");
+        reply_rx
+            .recv()
+            .expect("thymos postgres ledger worker dropped the reply")
+    }
+}
+
+impl crate::LedgerStore for BlockingPostgresLedger {
+    fn append_root(&self, trajectory_id: TrajectoryId, note: &str) -> Result<Entry> {
+        let note = note.to_string();
+        self.call(move |l| async move { l.append_root(trajectory_id, &note).await })
+    }
+    fn append_commit(&self, commit: Commit) -> Result<Entry> {
+        self.call(move |l| async move { l.append_commit(commit).await })
+    }
+    fn append_rejection(
+        &self,
+        trajectory_id: TrajectoryId,
+        intent_id: IntentId,
+        reason: RejectionReason,
+    ) -> Result<Entry> {
+        self.call(move |l| async move { l.append_rejection(trajectory_id, intent_id, reason).await })
+    }
+    fn append_pending_approval(
+        &self,
+        trajectory_id: TrajectoryId,
+        proposal: Proposal,
+        channel: String,
+        reason: String,
+    ) -> Result<Entry> {
+        self.call(move |l| async move {
+            l.append_pending_approval(trajectory_id, proposal, channel, reason)
+                .await
+        })
+    }
+    fn append_delegation(
+        &self,
+        trajectory_id: TrajectoryId,
+        child_trajectory_id: TrajectoryId,
+        task: &str,
+        final_answer: Option<String>,
+    ) -> Result<Entry> {
+        let task = task.to_string();
+        self.call(move |l| async move {
+            l.append_delegation(trajectory_id, child_trajectory_id, &task, final_answer)
+                .await
+        })
+    }
+    fn append_branch_root(
+        &self,
+        new_trajectory_id: TrajectoryId,
+        source_trajectory_id: TrajectoryId,
+        source_commit_id: CommitId,
+        note: &str,
+    ) -> Result<Entry> {
+        let note = note.to_string();
+        self.call(move |l| async move {
+            l.append_branch_root(new_trajectory_id, source_trajectory_id, source_commit_id, &note)
+                .await
+        })
+    }
+    fn head(&self, trajectory_id: TrajectoryId) -> Result<(ContentHash, u64)> {
+        self.call(move |l| async move { l.head(trajectory_id).await })
+    }
+    fn entries(&self, trajectory_id: TrajectoryId) -> Result<Vec<Entry>> {
+        self.call(move |l| async move { l.entries(trajectory_id).await })
+    }
+    fn query_entries(
+        &self,
+        trajectory_id: Option<TrajectoryId>,
+        kind: Option<&str>,
+        from_ts: Option<u64>,
+        to_ts: Option<u64>,
+        limit: Option<u32>,
+    ) -> Result<Vec<AuditEntry>> {
+        let kind = kind.map(|s| s.to_string());
+        self.call(move |l| async move {
+            l.query_entries(trajectory_id, kind.as_deref(), from_ts, to_ts, limit)
+                .await
+        })
+    }
+    fn count_entries(
+        &self,
+        trajectory_id: Option<TrajectoryId>,
+        kind: Option<&str>,
+        from_ts: Option<u64>,
+        to_ts: Option<u64>,
+    ) -> Result<u64> {
+        let kind = kind.map(|s| s.to_string());
+        self.call(move |l| async move {
+            l.count_entries(trajectory_id, kind.as_deref(), from_ts, to_ts)
+                .await
+        })
+    }
+    fn has_trajectory(&self, trajectory_id: TrajectoryId) -> bool {
+        self.call(move |l| async move { l.has_trajectory(trajectory_id).await })
+    }
+    fn verify_integrity(&self, trajectory_id: TrajectoryId) -> Result<()> {
+        self.call(move |l| async move { l.verify_integrity(trajectory_id).await })
+    }
+    // `anchor` uses the trait default (entries-based) — identical across backends.
 }

--- a/thymos/crates/thymos-ledger/src/sqlite.rs
+++ b/thymos/crates/thymos-ledger/src/sqlite.rs
@@ -494,6 +494,95 @@ impl SqliteLedger {
     }
 }
 
+/// `LedgerStore` for the SQLite backend. Each method delegates to the
+/// inherent method of the same name, so the trait is a pure re-exposure of the
+/// existing surface with no behavior change. `has_trajectory`,
+/// `verify_integrity`, and `anchor` use the trait defaults — identical to the
+/// inherent versions, which are themselves defined over `entries`/`head`.
+impl crate::LedgerStore for SqliteLedger {
+    fn append_root(&self, trajectory_id: TrajectoryId, note: &str) -> Result<Entry> {
+        SqliteLedger::append_root(self, trajectory_id, note)
+    }
+
+    fn append_commit(&self, commit: Commit) -> Result<Entry> {
+        SqliteLedger::append_commit(self, commit)
+    }
+
+    fn append_rejection(
+        &self,
+        trajectory_id: TrajectoryId,
+        intent_id: IntentId,
+        reason: RejectionReason,
+    ) -> Result<Entry> {
+        SqliteLedger::append_rejection(self, trajectory_id, intent_id, reason)
+    }
+
+    fn append_pending_approval(
+        &self,
+        trajectory_id: TrajectoryId,
+        proposal: Proposal,
+        channel: String,
+        reason: String,
+    ) -> Result<Entry> {
+        SqliteLedger::append_pending_approval(self, trajectory_id, proposal, channel, reason)
+    }
+
+    fn append_delegation(
+        &self,
+        trajectory_id: TrajectoryId,
+        child_trajectory_id: TrajectoryId,
+        task: &str,
+        final_answer: Option<String>,
+    ) -> Result<Entry> {
+        SqliteLedger::append_delegation(self, trajectory_id, child_trajectory_id, task, final_answer)
+    }
+
+    fn append_branch_root(
+        &self,
+        new_trajectory_id: TrajectoryId,
+        source_trajectory_id: TrajectoryId,
+        source_commit_id: CommitId,
+        note: &str,
+    ) -> Result<Entry> {
+        SqliteLedger::append_branch_root(
+            self,
+            new_trajectory_id,
+            source_trajectory_id,
+            source_commit_id,
+            note,
+        )
+    }
+
+    fn head(&self, trajectory_id: TrajectoryId) -> Result<(ContentHash, u64)> {
+        SqliteLedger::head(self, trajectory_id)
+    }
+
+    fn entries(&self, trajectory_id: TrajectoryId) -> Result<Vec<Entry>> {
+        SqliteLedger::entries(self, trajectory_id)
+    }
+
+    fn query_entries(
+        &self,
+        trajectory_id: Option<TrajectoryId>,
+        kind: Option<&str>,
+        from_ts: Option<u64>,
+        to_ts: Option<u64>,
+        limit: Option<u32>,
+    ) -> Result<Vec<AuditEntry>> {
+        SqliteLedger::query_entries(self, trajectory_id, kind, from_ts, to_ts, limit)
+    }
+
+    fn count_entries(
+        &self,
+        trajectory_id: Option<TrajectoryId>,
+        kind: Option<&str>,
+        from_ts: Option<u64>,
+        to_ts: Option<u64>,
+    ) -> Result<u64> {
+        SqliteLedger::count_entries(self, trajectory_id, kind, from_ts, to_ts)
+    }
+}
+
 fn row_to_entry(row: &rusqlite::Row<'_>) -> rusqlite::Result<Entry> {
     let id_bytes: Vec<u8> = row.get(0)?;
     let traj_bytes: Vec<u8> = row.get(1)?;

--- a/thymos/crates/thymos-ledger/tests/postgres_integration.rs
+++ b/thymos/crates/thymos-ledger/tests/postgres_integration.rs
@@ -27,7 +27,8 @@ use thymos_core::{
     proposal::{PolicyDecision, PolicyTrace},
     CommitId, ContentHash, IntentId, TrajectoryId, COMPILER_VERSION,
 };
-use thymos_ledger::postgres::PostgresLedger;
+use thymos_ledger::postgres::{BlockingPostgresLedger, PostgresLedger};
+use thymos_ledger::LedgerStore;
 
 fn trivial_commit(traj: TrajectoryId, parent: CommitId, seq: u64, key: &str, val: &str) -> Commit {
     let body = CommitBody {
@@ -115,4 +116,118 @@ async fn postgres_appends_and_verifies_hash_chain() {
     assert_eq!(head_seq, 2);
 
     eprintln!("PROOF: Postgres backend append → read-back → verify_integrity holds (traj={traj})");
+}
+
+fn skip_if_unset(test: &str) -> Option<String> {
+    match std::env::var("THYMOS_TEST_POSTGRES_URL") {
+        Ok(u) if !u.trim().is_empty() => Some(u),
+        _ => {
+            eprintln!("SKIP {test}: THYMOS_TEST_POSTGRES_URL not set.");
+            None
+        }
+    }
+}
+
+fn unique_traj(tag: &str) -> TrajectoryId {
+    let seed = format!(
+        "{tag}-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    TrajectoryId::new_from_seed(seed.as_bytes())
+}
+
+/// Drive an identical scripted trajectory through any `LedgerStore` and return
+/// the content-addressed entry id chain.
+fn drive_script<L: LedgerStore>(l: &L, traj: TrajectoryId) -> Vec<ContentHash> {
+    let root = l.append_root(traj, "backend-indep").expect("append root");
+    let e1 = l
+        .append_commit(trivial_commit(traj, CommitId(root.id), 1, "alpha", "1"))
+        .expect("commit 1");
+    let _e2 = l
+        .append_commit(trivial_commit(traj, CommitId(e1.id), 2, "beta", "2"))
+        .expect("commit 2");
+    l.verify_integrity(traj).expect("verify integrity");
+    l.entries(traj)
+        .expect("entries")
+        .into_iter()
+        .map(|e| e.id)
+        .collect()
+}
+
+/// RFC `runtime-ledger-trait-v1` step 5: the Postgres blocking facade and the
+/// SQLite backend, driven through the *same* synchronous `LedgerStore` surface
+/// with identical inputs, must produce a byte-identical (content-addressed)
+/// chain and the same head. This is the guard against silent semantic drift
+/// between backends.
+#[test]
+#[cfg(feature = "sqlite")]
+#[ignore = "live Postgres integration — set THYMOS_TEST_POSTGRES_URL and run with --ignored"]
+fn blocking_facade_matches_sqlite() {
+    let Some(url) = skip_if_unset("blocking_facade_matches_sqlite") else {
+        return;
+    };
+
+    let pg = BlockingPostgresLedger::connect(&url).expect("connect blocking facade");
+    let sqlite = thymos_ledger::Ledger::open_in_memory().expect("open sqlite");
+
+    // Distinct trajectory ids so the run is repeatable against a shared DB, but
+    // the *same* logical script, so the content-addressed payloads (and thus the
+    // ids) line up position-for-position across backends.
+    let traj_pg = unique_traj("indep-pg");
+    let traj_sq = unique_traj("indep-sq");
+
+    let pg_ids = drive_script(&pg, traj_pg);
+    let sq_ids = drive_script(&sqlite, traj_sq);
+
+    // The root payload binds the trajectory id, so the genesis ids differ by
+    // construction; every *commit* id is trajectory-independent and must match.
+    assert_eq!(pg_ids.len(), sq_ids.len(), "same number of entries");
+    assert_eq!(
+        &pg_ids[1..],
+        &sq_ids[1..],
+        "commit chain must be byte-identical across backends"
+    );
+
+    // Heads agree on seq, and each head id equals the backend's own last entry.
+    assert_eq!(pg.head(traj_pg).unwrap().1, 2);
+    assert_eq!(sqlite.head(traj_sq).unwrap().1, 2);
+    assert_eq!(pg.head(traj_pg).unwrap().0, *pg_ids.last().unwrap());
+
+    eprintln!("PROOF: Postgres blocking facade yields a chain identical to SQLite");
+}
+
+/// The critical safety property of the blocking facade: its *synchronous*
+/// `LedgerStore` methods may be called from inside a tokio runtime (the server
+/// invokes them from async handlers and `run_agent_streaming`) without panicking
+/// — `block_on` would panic there, so the facade must not use it. Here we call
+/// the sync methods directly on a tokio worker thread.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "live Postgres integration — set THYMOS_TEST_POSTGRES_URL and run with --ignored"]
+async fn blocking_facade_is_safe_from_async_context() {
+    let Some(url) = skip_if_unset("blocking_facade_is_safe_from_async_context") else {
+        return;
+    };
+
+    // Connect off the async worker to avoid blocking it during setup.
+    let pg = tokio::task::spawn_blocking(move || BlockingPostgresLedger::connect(&url))
+        .await
+        .expect("join")
+        .expect("connect blocking facade");
+
+    // Call the SYNC trait methods directly on this tokio worker thread. The
+    // facade routes them to its own runtime thread, so this blocks the worker
+    // briefly but must NOT panic with "cannot block from within a runtime".
+    let traj = unique_traj("from-async");
+    let root = pg.append_root(traj, "from async").expect("append_root on worker");
+    assert_eq!(root.seq, 0);
+    let _c = pg
+        .append_commit(trivial_commit(traj, CommitId(root.id), 1, "k", "v"))
+        .expect("append_commit on worker");
+    assert_eq!(pg.entries(traj).expect("entries on worker").len(), 2);
+    pg.verify_integrity(traj).expect("verify on worker");
+
+    eprintln!("PROOF: blocking facade sync methods are safe to call from a tokio worker thread");
 }

--- a/thymos/crates/thymos-ledger/tests/postgres_integration.rs
+++ b/thymos/crates/thymos-ledger/tests/postgres_integration.rs
@@ -173,28 +173,25 @@ fn blocking_facade_matches_sqlite() {
     let pg = BlockingPostgresLedger::connect(&url).expect("connect blocking facade");
     let sqlite = thymos_ledger::Ledger::open_in_memory().expect("open sqlite");
 
-    // Distinct trajectory ids so the run is repeatable against a shared DB, but
-    // the *same* logical script, so the content-addressed payloads (and thus the
-    // ids) line up position-for-position across backends.
-    let traj_pg = unique_traj("indep-pg");
-    let traj_sq = unique_traj("indep-sq");
+    // The *same* trajectory id through both backends: ledger entry ids are
+    // content-addressed over the trajectory id and parent links, so identical
+    // inputs must yield an identical chain. SQLite is a fresh in-memory store;
+    // the unique seed keeps the shared Postgres DB collision-free across runs.
+    let traj = unique_traj("indep");
 
-    let pg_ids = drive_script(&pg, traj_pg);
-    let sq_ids = drive_script(&sqlite, traj_sq);
+    let pg_ids = drive_script(&pg, traj);
+    let sq_ids = drive_script(&sqlite, traj);
 
-    // The root payload binds the trajectory id, so the genesis ids differ by
-    // construction; every *commit* id is trajectory-independent and must match.
-    assert_eq!(pg_ids.len(), sq_ids.len(), "same number of entries");
+    // Every entry id — root included — must match position-for-position.
     assert_eq!(
-        &pg_ids[1..],
-        &sq_ids[1..],
-        "commit chain must be byte-identical across backends"
+        pg_ids, sq_ids,
+        "the full content-addressed chain must be byte-identical across backends"
     );
 
-    // Heads agree on seq, and each head id equals the backend's own last entry.
-    assert_eq!(pg.head(traj_pg).unwrap().1, 2);
-    assert_eq!(sqlite.head(traj_sq).unwrap().1, 2);
-    assert_eq!(pg.head(traj_pg).unwrap().0, *pg_ids.last().unwrap());
+    // Heads agree, and each head id equals the backend's own last entry.
+    assert_eq!(pg.head(traj).unwrap(), sqlite.head(traj).unwrap());
+    assert_eq!(pg.head(traj).unwrap().1, 2);
+    assert_eq!(pg.head(traj).unwrap().0, *pg_ids.last().unwrap());
 
     eprintln!("PROOF: Postgres blocking facade yields a chain identical to SQLite");
 }

--- a/thymos/crates/thymos-runtime/src/agent.rs
+++ b/thymos/crates/thymos-runtime/src/agent.rs
@@ -23,7 +23,7 @@ use thymos_core::{
     writ::Writ,
     TrajectoryId,
 };
-use thymos_ledger::{Entry, EntryPayload};
+use thymos_ledger::{Entry, EntryPayload, LedgerStore};
 
 use crate::{Run, Runtime, Step};
 
@@ -165,8 +165,8 @@ pub(crate) fn emit_event(event_tx: Option<&AgentEventCallback>, event: AgentTrac
 /// Drive a Cognition to completion against the Thymos runtime.
 ///
 /// The loop is explicit: cognition proposes, runtime decides, ledger remembers.
-pub fn run_agent(
-    runtime: &Runtime,
+pub fn run_agent<L: LedgerStore>(
+    runtime: &Runtime<L>,
     cognition: &mut dyn Cognition,
     task: &str,
     writ: &Writ,
@@ -363,7 +363,10 @@ pub fn run_agent(
 
 /// Fetch the Observation from the commit that just landed. The ledger is the
 /// source of truth — we don't trust cached values.
-fn last_observation(run: &Run<'_>, commit_id: thymos_core::CommitId) -> Result<Observation> {
+fn last_observation<L: LedgerStore>(
+    run: &Run<'_, L>,
+    commit_id: thymos_core::CommitId,
+) -> Result<Observation> {
     let entries: Vec<Entry> = run.runtime().ledger.entries(run.trajectory_id())?;
     for e in entries.into_iter().rev() {
         if let EntryPayload::Commit(c) = &e.payload {

--- a/thymos/crates/thymos-runtime/src/agent_async.rs
+++ b/thymos/crates/thymos-runtime/src/agent_async.rs
@@ -17,7 +17,7 @@ use thymos_core::{
     writ::Writ,
     ProposalId,
 };
-use thymos_ledger::{Entry, EntryPayload};
+use thymos_ledger::{Entry, EntryPayload, LedgerStore};
 
 use super::agent::{
     emit_event, AgentEventCallback, AgentRunOptions, AgentRunSummary, AgentTraceEvent, Termination,
@@ -48,8 +48,8 @@ pub type ApprovalRequester = Box<
 /// `approval_requester` is called when a proposal needs human approval. If
 /// `None`, suspensions terminate the run (Phase 1 behavior).
 #[allow(clippy::too_many_arguments)]
-pub async fn run_agent_streaming(
-    runtime: &Runtime,
+pub async fn run_agent_streaming<L: LedgerStore>(
+    runtime: &Runtime<L>,
     cognition: &mut dyn StreamingCognition,
     task: &str,
     writ: &Writ,
@@ -368,7 +368,7 @@ pub async fn run_agent_streaming(
 }
 
 /// Find the ProposalId of the most recent PendingApproval entry in this run.
-fn find_last_pending_proposal(run: &Run<'_>) -> Result<ProposalId> {
+fn find_last_pending_proposal<L: LedgerStore>(run: &Run<'_, L>) -> Result<ProposalId> {
     let entries: Vec<Entry> = run.runtime().ledger.entries(run.trajectory_id())?;
     for e in entries.into_iter().rev() {
         if let EntryPayload::PendingApproval { proposal, .. } = &e.payload {
@@ -381,7 +381,10 @@ fn find_last_pending_proposal(run: &Run<'_>) -> Result<ProposalId> {
 }
 
 /// Fetch the Observation from the commit that just landed.
-fn last_observation(run: &Run<'_>, commit_id: thymos_core::CommitId) -> Result<Observation> {
+fn last_observation<L: LedgerStore>(
+    run: &Run<'_, L>,
+    commit_id: thymos_core::CommitId,
+) -> Result<Observation> {
     let entries: Vec<Entry> = run.runtime().ledger.entries(run.trajectory_id())?;
     for e in entries.into_iter().rev() {
         if let EntryPayload::Commit(c) = &e.payload {

--- a/thymos/crates/thymos-runtime/src/lib.rs
+++ b/thymos/crates/thymos-runtime/src/lib.rs
@@ -16,7 +16,7 @@ use thymos_core::{
     writ::BudgetCost,
     CommitId, TrajectoryId, COMPILER_VERSION,
 };
-use thymos_ledger::{project_commits, Entry, EntryPayload, Ledger};
+use thymos_ledger::{project_commits, Entry, EntryPayload, Ledger, LedgerStore};
 use thymos_policy::PolicyEngine;
 use thymos_tools::{EffectClass, ToolInvocation, ToolRegistry};
 
@@ -144,8 +144,8 @@ impl Clock for FixedClock {
     }
 }
 
-pub struct Runtime {
-    pub ledger: Ledger,
+pub struct Runtime<L: LedgerStore = Ledger> {
+    pub ledger: L,
     pub tools: ToolRegistry,
     pub policy: PolicyEngine,
     pub delegation_keyring: Option<DelegationKeyring>,
@@ -263,8 +263,8 @@ pub struct ApprovalProgress {
     pub satisfied: bool,
 }
 
-impl Runtime {
-    pub fn new(ledger: Ledger, tools: ToolRegistry, policy: PolicyEngine) -> Self {
+impl<L: LedgerStore> Runtime<L> {
+    pub fn new(ledger: L, tools: ToolRegistry, policy: PolicyEngine) -> Self {
         Runtime {
             ledger,
             tools,
@@ -340,7 +340,7 @@ impl Runtime {
     }
 
     /// Create a new trajectory and return a Run bound to it.
-    pub fn create_run(&self, note: &str, seed: &[u8]) -> Result<Run<'_>> {
+    pub fn create_run(&self, note: &str, seed: &[u8]) -> Result<Run<'_, L>> {
         let trajectory_id = TrajectoryId::new_from_seed(seed);
         self.ledger.append_root(trajectory_id, note)?;
         Ok(Run {
@@ -352,7 +352,7 @@ impl Runtime {
     /// Resume an existing trajectory. The Run picks up where it left off;
     /// world projection will fold every commit already in the ledger. Returns
     /// an error if the trajectory hasn't been rooted yet.
-    pub fn resume_run(&self, trajectory_id: TrajectoryId) -> Result<Run<'_>> {
+    pub fn resume_run(&self, trajectory_id: TrajectoryId) -> Result<Run<'_, L>> {
         if !self.ledger.has_trajectory(trajectory_id) {
             return Err(Error::Ledger(format!(
                 "trajectory {:?} does not exist",
@@ -366,8 +366,8 @@ impl Runtime {
     }
 }
 
-pub struct Run<'a> {
-    runtime: &'a Runtime,
+pub struct Run<'a, L: LedgerStore = Ledger> {
+    runtime: &'a Runtime<L>,
     trajectory_id: TrajectoryId,
 }
 
@@ -388,14 +388,14 @@ pub enum Step {
     },
 }
 
-impl<'a> Run<'a> {
+impl<'a, L: LedgerStore> Run<'a, L> {
     pub fn trajectory_id(&self) -> TrajectoryId {
         self.trajectory_id
     }
 
     /// Accessor for the enclosing runtime. Used by the agent loop to reach
     /// the ledger for observation lookup.
-    pub fn runtime(&self) -> &Runtime {
+    pub fn runtime(&self) -> &Runtime<L> {
         self.runtime
     }
 
@@ -440,7 +440,7 @@ impl<'a> Run<'a> {
 
     /// Create a new trajectory branched from a specific commit in this
     /// trajectory. The new Run starts with the world state as of that commit.
-    pub fn branch_from(&self, commit_id: CommitId, note: &str) -> Result<Run<'_>> {
+    pub fn branch_from(&self, commit_id: CommitId, note: &str) -> Result<Run<'_, L>> {
         let seed = format!("branch-{}-{}", self.trajectory_id, commit_id);
         let new_traj = TrajectoryId::new_from_seed(seed.as_bytes());
         self.runtime
@@ -1274,8 +1274,8 @@ impl<'a> Run<'a> {
 /// Project world state for a trajectory, optionally stopping at a specific
 /// commit (inclusive). Handles recursive ancestor chains for branched
 /// trajectories.
-fn project_world_up_to(
-    ledger: &Ledger,
+fn project_world_up_to<L: LedgerStore>(
+    ledger: &L,
     trajectory_id: TrajectoryId,
     up_to: Option<CommitId>,
 ) -> Result<World> {

--- a/thymos/crates/thymos-runtime/tests/agent_loop.rs
+++ b/thymos/crates/thymos-runtime/tests/agent_loop.rs
@@ -217,6 +217,127 @@ fn run_agent_rejects_on_budget_exhaustion() {
     assert_eq!(summary.rejections, 1);
 }
 
+/// Step 2 proof: the runtime is generic over *any* `LedgerStore`, not only the
+/// default SQLite `Ledger`. `WrapLedger` is a distinct concrete type that
+/// implements the trait by delegating to an inner `Ledger`; building a
+/// `Runtime<WrapLedger>` and driving a full agent loop through it proves the
+/// generic refactor works end-to-end with an arbitrary backend — the exact
+/// shape a Phase III Postgres facade will take.
+mod backend_agnostic {
+    use super::*;
+    use thymos_core::{
+        commit::Commit,
+        ids::IntentId,
+        proposal::{Proposal, RejectionReason},
+        CommitId, ContentHash, Result, TrajectoryId,
+    };
+    use thymos_ledger::{AuditEntry, Entry, LedgerStore};
+
+    /// A `LedgerStore` that is *not* `Ledger`, delegating to one inside.
+    struct WrapLedger(Ledger);
+
+    impl LedgerStore for WrapLedger {
+        fn append_root(&self, t: TrajectoryId, note: &str) -> Result<Entry> {
+            self.0.append_root(t, note)
+        }
+        fn append_commit(&self, c: Commit) -> Result<Entry> {
+            self.0.append_commit(c)
+        }
+        fn append_rejection(
+            &self,
+            t: TrajectoryId,
+            i: IntentId,
+            r: RejectionReason,
+        ) -> Result<Entry> {
+            self.0.append_rejection(t, i, r)
+        }
+        fn append_pending_approval(
+            &self,
+            t: TrajectoryId,
+            p: Proposal,
+            channel: String,
+            reason: String,
+        ) -> Result<Entry> {
+            self.0.append_pending_approval(t, p, channel, reason)
+        }
+        fn append_delegation(
+            &self,
+            t: TrajectoryId,
+            child: TrajectoryId,
+            task: &str,
+            final_answer: Option<String>,
+        ) -> Result<Entry> {
+            self.0.append_delegation(t, child, task, final_answer)
+        }
+        fn append_branch_root(
+            &self,
+            new_t: TrajectoryId,
+            src: TrajectoryId,
+            src_commit: CommitId,
+            note: &str,
+        ) -> Result<Entry> {
+            self.0.append_branch_root(new_t, src, src_commit, note)
+        }
+        fn head(&self, t: TrajectoryId) -> Result<(ContentHash, u64)> {
+            self.0.head(t)
+        }
+        fn entries(&self, t: TrajectoryId) -> Result<Vec<Entry>> {
+            self.0.entries(t)
+        }
+        fn query_entries(
+            &self,
+            t: Option<TrajectoryId>,
+            kind: Option<&str>,
+            from_ts: Option<u64>,
+            to_ts: Option<u64>,
+            limit: Option<u32>,
+        ) -> Result<Vec<AuditEntry>> {
+            self.0.query_entries(t, kind, from_ts, to_ts, limit)
+        }
+        fn count_entries(
+            &self,
+            t: Option<TrajectoryId>,
+            kind: Option<&str>,
+            from_ts: Option<u64>,
+            to_ts: Option<u64>,
+        ) -> Result<u64> {
+            self.0.count_entries(t, kind, from_ts, to_ts)
+        }
+    }
+
+    #[test]
+    fn runtime_drives_a_non_default_ledger_backend() {
+        let ledger = WrapLedger(Ledger::open_in_memory().unwrap());
+        let mut tools = ToolRegistry::new();
+        tools.register(KvSetTool::default());
+        tools.register(KvGetTool::default());
+        let policy = PolicyEngine::new().with(WritAuthorityPolicy);
+        // The whole point: `Runtime` parameterized by a backend that is *not*
+        // the default `Ledger`.
+        let runtime: Runtime<WrapLedger> = Runtime::new(ledger, tools, policy);
+
+        let writ = root_writ();
+        let set = mk_intent("kv_set", serde_json::json!({"key": "k", "value": "v"}), 1);
+        let get = mk_intent("kv_get", serde_json::json!({"key": "k"}), 2);
+        let mut cognition = MockCognition::new(vec![vec![set], vec![get]], Some("done".into()));
+
+        let summary = run_agent(
+            &runtime,
+            &mut cognition,
+            "drive a non-default backend",
+            &writ,
+            AgentRunOptions { max_steps: 8 },
+            None,
+        )
+        .expect("agent run on wrapped backend");
+
+        assert_eq!(summary.intents_submitted, 2);
+        assert_eq!(summary.commits, 2);
+        assert!(matches!(summary.terminated_by, Termination::CognitionDone));
+        assert_eq!(summary.final_answer.as_deref(), Some("done"));
+    }
+}
+
 #[test]
 #[ignore = "timing benchmark — run with --include-ignored --nocapture"]
 fn bench_execution_overhead_per_proposal() {

--- a/thymos/crates/thymos-server/Cargo.toml
+++ b/thymos/crates/thymos-server/Cargo.toml
@@ -4,6 +4,11 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[features]
+default = []
+# Enable the Postgres-backed ledger (via the synchronous blocking facade).
+postgres = ["thymos-ledger/postgres"]
+
 [dependencies]
 thymos-core      = { workspace = true }
 thymos-ledger    = { workspace = true }

--- a/thymos/crates/thymos-server/src/lib.rs
+++ b/thymos/crates/thymos-server/src/lib.rs
@@ -49,7 +49,7 @@ use thymos_core::{
     writ::{Budget, DelegationBounds, EffectCeiling, TimeWindow, ToolPattern, Writ, WritBody},
     TrajectoryId,
 };
-use thymos_ledger::{EntryPayload, Ledger};
+use thymos_ledger::{EntryPayload, Ledger, LedgerStore};
 use thymos_policy::{PolicyEngine, WritAuthorityPolicy};
 use thymos_runtime::agent_async::ApprovalDecision;
 use thymos_runtime::{
@@ -190,14 +190,24 @@ impl ServerConfig {
         )?;
 
         if runtime_mode == RuntimeMode::Production && ledger_path.is_none() {
-            if postgres_url.is_some() {
+            // Postgres is an acceptable durable backend only when this binary was
+            // actually built with the `postgres` feature; otherwise the URL would
+            // be silently ignored, so we reject it.
+            #[cfg(feature = "postgres")]
+            let postgres_durable = postgres_url.is_some();
+            #[cfg(not(feature = "postgres"))]
+            let postgres_durable = false;
+
+            if !postgres_durable {
+                if postgres_url.is_some() {
+                    return Err(
+                        "THYMOS_POSTGRES_URL is set but this binary was built without the `postgres` feature; rebuild with `--features postgres`, or set THYMOS_LEDGER_PATH.".into(),
+                    );
+                }
                 return Err(
-                    "THYMOS_POSTGRES_URL is configured, but the server runtime is still wired to the synchronous SQLite ledger path. For now, production mode requires THYMOS_LEDGER_PATH.".into(),
+                    "production mode requires THYMOS_LEDGER_PATH (or THYMOS_POSTGRES_URL with the `postgres` feature) so the ledger is not ephemeral".into(),
                 );
             }
-            return Err(
-                "production mode requires THYMOS_LEDGER_PATH so the ledger is not ephemeral".into(),
-            );
         }
 
         if runtime_mode == RuntimeMode::Production && tool_fabric != "worker" {
@@ -384,13 +394,20 @@ pub struct ResourceDto {
     pub value: serde_json::Value,
 }
 
+/// The server holds *either* ledger backend (SQLite or the Postgres blocking
+/// facade) behind one concrete type by boxing the `LedgerStore`. The backend is
+/// chosen once at startup; handlers stay non-generic. The single dynamic-
+/// dispatch hop per ledger op is negligible next to database I/O and cognition
+/// latency.
+pub type ServerRuntime = Runtime<Box<dyn LedgerStore>>;
+
 /// Shared application state.
 pub struct AppState {
     pub runtime_mode: RuntimeMode,
     pub cors_allowed_origins: Option<Vec<String>>,
     pub max_concurrent_runs_per_tenant: u32,
     pub max_concurrent_runs_global: u32,
-    pub runtime: Arc<Runtime>,
+    pub runtime: Arc<ServerRuntime>,
     pub runs: Mutex<HashMap<String, RunRecord>>,
     /// Ledger entry events per run.
     pub event_channels: Mutex<HashMap<String, broadcast::Sender<EntryDto>>>,
@@ -450,7 +467,7 @@ pub struct ApprovalRequest {
 }
 
 /// Build a runtime with a file-backed ledger.
-pub fn persistent_runtime(ledger_path: &str) -> Arc<Runtime> {
+pub fn persistent_runtime(ledger_path: &str) -> Arc<ServerRuntime> {
     persistent_runtime_with_capabilities(ledger_path, &[])
 }
 
@@ -458,23 +475,38 @@ pub fn persistent_runtime(ledger_path: &str) -> Arc<Runtime> {
 pub fn persistent_runtime_with_capabilities(
     ledger_path: &str,
     tool_manifest_dirs: &[String],
-) -> Arc<Runtime> {
+) -> Arc<ServerRuntime> {
     let ledger = Ledger::open(ledger_path).expect("open file-backed ledger");
-    build_runtime(ledger, tool_manifest_dirs)
+    build_runtime(Box::new(ledger), tool_manifest_dirs)
+}
+
+/// Build a runtime backed by Postgres (via the synchronous blocking facade) and
+/// manifest-backed capabilities. Available with the `postgres` feature.
+#[cfg(feature = "postgres")]
+pub fn postgres_runtime_with_capabilities(
+    conn_str: &str,
+    tool_manifest_dirs: &[String],
+) -> Arc<ServerRuntime> {
+    let ledger = thymos_ledger::postgres::BlockingPostgresLedger::connect(conn_str)
+        .expect("connect to Postgres ledger");
+    build_runtime(Box::new(ledger), tool_manifest_dirs)
 }
 
 /// Build the default runtime with an in-memory ledger (for testing).
-pub fn default_runtime() -> Arc<Runtime> {
+pub fn default_runtime() -> Arc<ServerRuntime> {
     default_runtime_with_capabilities(&[])
 }
 
 /// Build the default runtime with manifest-backed capabilities.
-pub fn default_runtime_with_capabilities(tool_manifest_dirs: &[String]) -> Arc<Runtime> {
+pub fn default_runtime_with_capabilities(tool_manifest_dirs: &[String]) -> Arc<ServerRuntime> {
     let ledger = Ledger::open_in_memory().expect("open in-memory ledger");
-    build_runtime(ledger, tool_manifest_dirs)
+    build_runtime(Box::new(ledger), tool_manifest_dirs)
 }
 
-fn build_runtime(ledger: Ledger, tool_manifest_dirs: &[String]) -> Arc<Runtime> {
+fn build_runtime(
+    ledger: Box<dyn LedgerStore>,
+    tool_manifest_dirs: &[String],
+) -> Arc<ServerRuntime> {
     let mut tools = ToolRegistry::new();
     tools.register(KvSetTool::default());
     tools.register(KvGetTool::default());

--- a/thymos/crates/thymos-server/src/main.rs
+++ b/thymos/crates/thymos-server/src/main.rs
@@ -36,11 +36,6 @@ async fn main() {
         }
     };
 
-    if let Some(url) = &config.postgres_url {
-        eprintln!(
-            "note: THYMOS_POSTGRES_URL is set to '{url}', but the HTTP runtime still uses the synchronous SQLite ledger path until the runtime/ledger trait refactor lands"
-        );
-    }
 
     // Be loud about the default cognition provider. The biggest deployment
     // footgun is running with the silent mock and assuming real cognition.
@@ -61,7 +56,28 @@ async fn main() {
         );
     }
 
-    let runtime = if let Some(path) = &config.ledger_path {
+    // Backend selection: Postgres (if configured and this binary was built with
+    // the `postgres` feature) → SQLite file → in-memory.
+    let runtime = if let Some(url) = config.postgres_url.as_deref() {
+        #[cfg(feature = "postgres")]
+        {
+            eprintln!("ledger: postgres (synchronous blocking facade) at {url}");
+            thymos_server::postgres_runtime_with_capabilities(url, &config.tool_manifest_dirs)
+        }
+        #[cfg(not(feature = "postgres"))]
+        {
+            eprintln!(
+                "note: THYMOS_POSTGRES_URL is set to '{url}', but this binary was built without the `postgres` feature; falling back to SQLite. Rebuild with `--features postgres` to use Postgres."
+            );
+            if let Some(path) = &config.ledger_path {
+                eprintln!("ledger: sqlite file-backed at {path}");
+                persistent_runtime_with_capabilities(path, &config.tool_manifest_dirs)
+            } else {
+                eprintln!("ledger: in-memory reference mode");
+                default_runtime_with_capabilities(&config.tool_manifest_dirs)
+            }
+        }
+    } else if let Some(path) = &config.ledger_path {
         eprintln!("ledger: sqlite file-backed at {path}");
         persistent_runtime_with_capabilities(path, &config.tool_manifest_dirs)
     } else {

--- a/thymos/docker-compose.yml
+++ b/thymos/docker-compose.yml
@@ -55,7 +55,17 @@ services:
     profiles:
       - local
 
-  # Optional: Postgres for production ledger backend.
+  # Optional: Postgres for the production ledger backend.
+  #
+  # Run the gated ledger integration tests against it locally:
+  #   docker compose --profile postgres up -d postgres
+  #   THYMOS_TEST_POSTGRES_URL=postgres://thymos:thymos@localhost:5432/thymos \
+  #     cargo test -p thymos-ledger --features postgres \
+  #     --test postgres_integration -- --ignored --nocapture
+  #
+  # Or run the server itself on Postgres (build with the `postgres` feature):
+  #   THYMOS_POSTGRES_URL=postgres://thymos:thymos@localhost:5432/thymos \
+  #     cargo run -p thymos-server --features postgres
   postgres:
     image: postgres:16-alpine
     environment:
@@ -66,6 +76,11 @@ services:
       - "5432:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U thymos -d thymos"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
     profiles:
       - postgres
 


### PR DESCRIPTION
## Why

Closes the biggest claims-vs-reality gap called out in `STATUS.md` and `CLAUDE.md`: the roadmap promised a "production-grade Postgres ledger," but the async `PostgresLedger` existed only in isolation — the HTTP runtime was hard-wired to synchronous SQLite. This branch makes Postgres a **selectable, proven** HTTP runtime backend, end to end, without touching the execution protocol or replay determinism.

Follows the plan in `docs/rfcs/runtime-ledger-trait-v1.md` (Option A: sync `LedgerStore` trait + Postgres blocking facade).

## What changed (in dependency order)

1. **`LedgerStore` trait** (`thymos-ledger`) — impl for `SqliteLedger`. Pure addition; replay stays storage-independent (it already operates on `&[Entry]`).
2. **`Runtime`/`Run` generic over the trait** — `Runtime<L: LedgerStore = Ledger>`. The default type parameter keeps every existing call site compiling unchanged; a gated test drives a full agent loop through a non-default backend.
3. **`BlockingPostgresLedger`** — a synchronous `LedgerStore` over the async backend. It owns a **dedicated runtime thread** (current-thread + `LocalSet`) and ships `Send` job-closures to it, blocking only on a `std` channel reply. This is safe to call from tokio worker threads — where `block_on` would panic — which is exactly the case the server hits (async handlers, `run_agent_streaming`). `impl LedgerStore for Box<dyn LedgerStore>` lets one boxed value stand in for either backend.
4. **Server wiring** — `AppState` holds `Runtime<Box<dyn LedgerStore>>`; startup selects Postgres (with the `postgres` feature + `THYMOS_POSTGRES_URL`) or SQLite. **Default build is unchanged** — SQLite only, no Postgres deps compiled. Production validation accepts Postgres only when the feature is actually built.
5. **Proof + CI** — gated integration tests (`THYMOS_TEST_POSTGRES_URL`): the facade yields a **byte-identical content-addressed chain** to SQLite from identical inputs, and the sync facade is **safe from an async context**. A new `postgres-integration` CI job runs them against a `postgres:16` service container; they skip cleanly otherwise.

This branch also carries earlier honesty/quality work already on it: a gated live-provider runtime test, provider-transparency warnings, worker-doc fixes, `CLAUDE.md`, the RFC, and README badge fixes.

## Verification

- ✅ Default `cargo build`/`cargo test --workspace` green (47 binaries, 0 failures); **zero behavior change for SQLite users**.
- ✅ Compiles with `--features postgres`, including Postgres-*without*-SQLite (`--no-default-features`).
- ✅ **Ran the gated suite against a real Postgres 16 cluster — 3/3 pass, twice (repeatable).** Doing this for real caught a genuine bug: the backend-independence test originally used different trajectory ids per backend, which (because entry ids are content-addressed over trajectory id + parent links) could never match. Fixed to use one trajectory id across both.
- ✅ Clean SKIP when `THYMOS_TEST_POSTGRES_URL` is unset; clippy clean on changes.

## Honest caveat

The live proof was on a locally-spun Postgres 16, **not** yet via the GitHub Actions service container itself — this PR's first CI run is where the Actions-specific networking (`localhost:5432`) gets its final confirmation. The job config is straightforward and the YAML parses.

https://claude.ai/code/session_01BTiNYcDGfvthQMJwfCgBjY

---
_Generated by [Claude Code](https://claude.ai/code/session_01BTiNYcDGfvthQMJwfCgBjY)_