### PR TITLE
docs: honest /health + audit-first hooks (subset of #22 follow-up)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -12,7 +12,22 @@ Base URL: `http://localhost:3001`
 
 ### GET /health
 
-Returns server liveness and runtime mode.
+Returns liveness plus the runtime facts an operator should not have to infer:
+
+```json
+{
+  "status": "ok",
+  "mode": "reference",
+  "default_provider": "mock",
+  "cognition_live": false,
+  "shutdown": false
+}
+```
+
+Use `cognition_live` to distinguish a real model from the deterministic mock,
+and `mode` to distinguish the `reference` runtime from `production`. The HTTP
+runtime is SQLite-backed today; see [STATUS.md](https://github.com/gryszzz/open-thymos/blob/main/STATUS.md)
+for the gated `live_provider` / `postgres_integration` proofs.
 
 ## Runs
 

--- a/docs/demos/delegation-lineage.md
+++ b/docs/demos/delegation-lineage.md
@@ -104,5 +104,5 @@ swarms** that must stay inside their lane: you can hand a task to a sub-agent an
 *know* — structurally, and provably after the fact — that it could not exceed the
 authority you granted, touch another tenant, or silently mutate your state.
 
-See also: [Deterministic Replay](/open-thymos/demos/deterministic-replay/) ·
-[Policy Intercept & Approval](/open-thymos/demos/policy-intercept-approval/).
+See also: [Deterministic Replay]({{ '/demos/deterministic-replay' | relative_url }}) ·
+[Policy Intercept & Approval]({{ '/demos/policy-intercept-approval' | relative_url }}).

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -167,3 +167,19 @@ talk to a real model.
 
 The runtime, ledger, policy, and tool surface do not change. Only the
 proposer does.
+
+## Confirming which provider resolved
+
+A run can override the provider for that run via its own `cognition` block, so
+the configured default is not always the whole story. To see what the server
+actually resolved as its default, check `/health`:
+
+```bash
+curl http://localhost:3001/health
+# default_provider: "mock" | "anthropic" | "openai" | ...
+# cognition_live:   false when the default provider is mock
+```
+
+`cognition_live` is the honest signal: when it is `false`, any run that omits
+its own `cognition` block is answered by the deterministic mock, not a real
+model.

--- a/docs/replay.md
+++ b/docs/replay.md
@@ -121,8 +121,12 @@ under their own ledgers and writs.
 ## CLI
 
 ```bash
+thymos audit run_847
 thymos replay run_847 --verify --fold-world --policy-trace
 ```
+
+Use `audit` when a human needs the governance trail; use `replay` when a tool
+or script needs the verifier/fold result directly.
 
 Expected verifier phases:
 


### PR DESCRIPTION
Implements the **accurate** edits from the #22 follow-up comment, and deliberately drops the ones that assumed a selectable Postgres HTTP backend that has not landed.

## Landed
- **`docs/providers.md`** — `/health` live-vs-mock verification hook using the real `default_provider` / `cognition_live` fields.
- **`docs/api-reference.md`** — expanded `GET /health` into the operator truth surface (real fields only: `status`, `mode`, `default_provider`, `cognition_live`, `shutdown`).
- **`docs/replay.md`** — CLI section now leads with `thymos audit`, then `thymos replay`, plus the human-vs-tool sentence.

## Deliberately held (would reopen a claims-vs-reality gap)
- Suggestion **#1** doesn't apply — the duplicated tail / stray fence isn't in the current README.
- Suggestion **#2** and the `"ledger":"postgres"` part of **#4** describe a selectable Postgres HTTP runtime backend that does **not** exist here: the server is SQLite-only (no `postgres` feature, no `THYMOS_POSTGRES_URL`), and `/health` emits no `ledger` field. #28/#29 never landed (latest merges are #24/#25/#26).

Verified against code: [`/health` handler](thymos/crates/thymos-server/src/lib.rs#L960-L973), [SQLite-only server](thymos/crates/thymos-server/src/main.rs#L65), [`thymos audit` subcommand](thymos/crates/thymos-cli/src/main.rs#L95).

Refs #22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)