### PR TITLE
docs: align /health + Postgres docs with shipped #28/#29 backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,13 +276,13 @@ cargo test --workspace
 ```
 
 Run it on a real model, on a **Postgres** ledger, or in production-shaped mode —
-see **[Getting Started](docs/getting-started.md)**. The remaining gated proofs
-(live-model cognition and `postgres_integration` against a real database) run in
-CI when their secrets are present; see [STATUS.md](STATUS.md).
-```
+see **[Getting Started](docs/getting-started.md)**. The remaining external-resource
+proofs (`live_provider` and `postgres_integration`) run when their secrets are
+present; see [STATUS.md](STATUS.md).
 
-Run it on a real model, on a **Postgres** ledger, or in production-shaped mode —
-see **[Getting Started](docs/getting-started.md)**.
+The Postgres HTTP runtime path is active only when the server is built with
+`--features postgres` *and* `THYMOS_POSTGRES_URL` is set; otherwise it falls
+back to SQLite. Confirm the live backend in `/health` via `"ledger":"postgres"`.
 
 ## Repository
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -20,14 +20,18 @@ Returns liveness plus the runtime facts an operator should not have to infer:
   "mode": "reference",
   "default_provider": "mock",
   "cognition_live": false,
+  "ledger": "sqlite",
   "shutdown": false
 }
 ```
 
 Use `cognition_live` to distinguish a real model from the deterministic mock,
-and `mode` to distinguish the `reference` runtime from `production`. The HTTP
-runtime is SQLite-backed today; see [STATUS.md](https://github.com/gryszzz/open-thymos/blob/main/STATUS.md)
-for the gated `live_provider` / `postgres_integration` proofs.
+`mode` to distinguish the `reference` runtime from `production`, and `ledger`
+to confirm which durable backend is actually live (`"sqlite"` or `"postgres"`).
+Postgres is used only when the binary is built with `--features postgres` *and*
+`THYMOS_POSTGRES_URL` is set; otherwise the runtime falls back to SQLite. See
+[STATUS.md](https://github.com/gryszzz/open-thymos/blob/main/STATUS.md) for the
+gated `live_provider` / `postgres_integration` proofs.
 
 ## Runs
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -178,6 +178,7 @@ actually resolved as its default, check `/health`:
 curl http://localhost:3001/health
 # default_provider: "mock" | "anthropic" | "openai" | ...
 # cognition_live:   false when the default provider is mock
+# ledger:           "sqlite" | "postgres" — the durable backend actually live
 ```
 
 `cognition_live` is the honest signal: when it is `false`, any run that omits


### PR DESCRIPTION
#28/#29 (b696143, 7689408) landed Postgres as a real, selectable HTTP runtime backend and added the `ledger` field to /health (lib.rs:1010), which made the prior docs (incl. #30) stale.

- api-reference.md: add `ledger` to the /health sample and document the `--features postgres` + `THYMOS_POSTGRES_URL` selection (main.rs:61-70); drop the now-false "SQLite-backed today" line.
- providers.md: add `ledger` to the /health verification hook.
- README: collapse the duplicated quick-start tail + stray code fence into one block; add the Postgres HTTP-path confirmation (`"ledger":"postgres"`).