### PR TITLE
feat(site): rebrand Pages to violet + logo-matched 3D hero

### DIFF
--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -1,6 +1,6 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
-<meta name="theme-color" content="#05070b" />
+<meta name="theme-color" content="#08040f" />
 <meta name="color-scheme" content="dark" />
 
 {% seo %}

--- a/docs/assets/css/site.css
+++ b/docs/assets/css/site.css
@@ -4,11 +4,11 @@
    ============================================================ */
 
 :root {
-  --bg:          #05070b;
-  --bg-2:        #0a0d13;
-  --bg-3:        #0f131b;
-  --surface:     #10141c;
-  --surface-2:   #151a24;
+  --bg:          #08040f;
+  --bg-2:        #0d0717;
+  --bg-3:        #120b20;
+  --surface:     #140e22;
+  --surface-2:   #1b1230;
   --border:      rgba(255, 255, 255, 0.08);
   --border-2:    rgba(255, 255, 255, 0.14);
   --text:        #e7ecf3;
@@ -16,12 +16,12 @@
   --text-soft:   #6d7789;
   --mute:        #4a5362;
 
-  --accent:      #ffb547;           /* amber */
-  --accent-2:    #ff9a2f;           /* darker amber */
-  --accent-3:    #ffe1a8;           /* soft amber */
+  --accent:      #a855f7;           /* violet — brand */
+  --accent-2:    #7c3aed;           /* deep violet */
+  --accent-3:    #d9bcff;           /* soft lavender */
   --violet:      #8b5cf6;
   --violet-soft: #b998ff;
-  --cyan:        #4de0c4;
+  --cyan:        #8be9ff;
   --red:         #ff6f6f;
 
   --radius:       8px;
@@ -30,7 +30,7 @@
 
   --shadow-sm:   0 1px 2px rgba(0,0,0,.35);
   --shadow-md:   0 8px 24px rgba(0,0,0,.35), 0 1px 0 rgba(255,255,255,.03) inset;
-  --shadow-glow: 0 0 0 1px rgba(255,181,71,.35), 0 12px 48px rgba(255,154,47,.15);
+  --shadow-glow: 0 0 0 1px rgba(168,85,247,.35), 0 12px 48px rgba(124,58,237,.15);
 
   --font-sans: "Inter", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
   --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -55,7 +55,7 @@ html, body {
 
 body {
   background:
-    linear-gradient(180deg, rgba(18, 24, 33, 0.62), rgba(5, 7, 11, 0.98) 36%, var(--bg)),
+    linear-gradient(180deg, rgba(30, 17, 49, 0.66), rgba(8, 4, 15, 0.98) 36%, var(--bg)),
     var(--bg);
 }
 
@@ -76,8 +76,8 @@ code, pre, kbd { font-family: var(--font-mono); }
   background-image:
     linear-gradient(to right, rgba(255,255,255,0.026) 1px, transparent 1px),
     linear-gradient(to bottom, rgba(255,255,255,0.026) 1px, transparent 1px),
-    linear-gradient(to right, rgba(255,181,71,0.05) 1px, transparent 1px),
-    linear-gradient(to bottom, rgba(255,181,71,0.05) 1px, transparent 1px);
+    linear-gradient(to right, rgba(168,85,247,0.05) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(168,85,247,0.05) 1px, transparent 1px);
   background-size: 56px 56px, 56px 56px, 224px 224px, 224px 224px;
   -webkit-mask-image: linear-gradient(180deg, #000 0%, rgba(0, 0, 0, .42) 64%, transparent 100%);
   mask-image: linear-gradient(180deg, #000 0%, rgba(0, 0, 0, .42) 64%, transparent 100%);
@@ -112,7 +112,7 @@ main, header.nav, footer.footer { position: relative; z-index: 1; }
 
 .nav-mark {
   border-radius: 6px;
-  box-shadow: 0 0 0 1px rgba(255,181,71,.35), 0 0 18px rgba(255,181,71,.18);
+  box-shadow: 0 0 0 1px rgba(168,85,247,.35), 0 0 18px rgba(168,85,247,.18);
 }
 
 .nav-wordmark { color: var(--text); }
@@ -161,13 +161,13 @@ main, header.nav, footer.footer { position: relative; z-index: 1; }
 .btn:active { transform: translateY(1px); }
 
 .btn-primary {
-  color: #111418;
-  background: linear-gradient(180deg, #ffc568, #ff9a2f);
-  box-shadow: 0 1px 0 rgba(255,255,255,.25) inset, 0 8px 20px rgba(255,154,47,.28);
+  color: #fff;
+  background: linear-gradient(180deg, #c77dff, #7c3aed);
+  box-shadow: 0 1px 0 rgba(255,255,255,.25) inset, 0 8px 20px rgba(124,58,237,.28);
 }
 .btn-primary:hover {
-  box-shadow: 0 1px 0 rgba(255,255,255,.3) inset, 0 10px 26px rgba(255,154,47,.36);
-  color: #111418;
+  box-shadow: 0 1px 0 rgba(255,255,255,.3) inset, 0 10px 26px rgba(124,58,237,.36);
+  color: #fff;
 }
 .btn-ghost {
   color: var(--text);
@@ -258,7 +258,7 @@ main.page {
   margin: 22px 0;
   padding: 14px 18px;
   border-left: 2px solid var(--accent);
-  background: rgba(255,181,71,0.05);
+  background: rgba(168,85,247,0.05);
   border-radius: 0 10px 10px 0;
   color: var(--text);
 }
@@ -398,7 +398,7 @@ main.page {
 }
 .hero h1 em {
   font-style: normal;
-  background: linear-gradient(180deg, #ffe4b8 0%, #ffb547 70%, #ff8a1a 100%);
+  background: linear-gradient(180deg, #e7d2ff 0%, #a855f7 70%, #7b2fe0 100%);
   -webkit-background-clip: text;
   background-clip: text;
   color: transparent;
@@ -454,8 +454,8 @@ main.page {
   content: "";
   position: absolute; inset: 0;
   background:
-    linear-gradient(rgba(255,181,71,.055) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(255,181,71,.055) 1px, transparent 1px);
+    linear-gradient(rgba(168,85,247,.055) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(168,85,247,.055) 1px, transparent 1px);
   background-size: 36px 36px;
   pointer-events: none;
   opacity: .7;
@@ -573,10 +573,10 @@ main.page {
   width: 34px; height: 34px;
   display: grid; place-items: center;
   border-radius: 8px;
-  background: rgba(255,181,71,.14);
+  background: rgba(168,85,247,.14);
   color: var(--accent);
   margin-bottom: 12px;
-  border: 1px solid rgba(255,181,71,.25);
+  border: 1px solid rgba(168,85,247,.25);
 }
 .fcard h3 {
   font-size: 16px; margin: 0 0 6px; color: var(--text); font-weight: 600;
@@ -622,8 +622,8 @@ main.page {
   border-radius: var(--radius-xl);
   background:
     linear-gradient(180deg, rgba(255,255,255,0.03), rgba(255,255,255,0.00)),
-    linear-gradient(rgba(255,181,71,.05) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(255,181,71,.05) 1px, transparent 1px);
+    linear-gradient(rgba(168,85,247,.05) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(168,85,247,.05) 1px, transparent 1px);
   background-size: auto, 48px 48px, 48px 48px;
   border: 1px solid var(--border-2);
   text-align: center;

--- a/docs/assets/img/og.svg
+++ b/docs/assets/img/og.svg
@@ -4,7 +4,7 @@
       <path d="M 40 0 L 0 0 0 40" fill="none" stroke="rgba(255,255,255,0.032)" stroke-width="1"/>
     </pattern>
     <pattern id="grid-lg" width="160" height="160" patternUnits="userSpaceOnUse">
-      <path d="M 160 0 L 0 0 0 160" fill="none" stroke="rgba(255,181,71,0.055)" stroke-width="1"/>
+      <path d="M 160 0 L 0 0 0 160" fill="none" stroke="rgba(168,85,247,0.055)" stroke-width="1"/>
     </pattern>
     <linearGradient id="fade-top" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0%" stop-color="#000" stop-opacity="1"/>
@@ -15,9 +15,9 @@
       <rect width="1200" height="630" fill="url(#fade-top)"/>
     </mask>
     <linearGradient id="amber-grad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#ffe4b8"/>
-      <stop offset="60%" stop-color="#ffb547"/>
-      <stop offset="100%" stop-color="#ff8a1a"/>
+      <stop offset="0%" stop-color="#e7d2ff"/>
+      <stop offset="60%" stop-color="#a855f7"/>
+      <stop offset="100%" stop-color="#7b2fe0"/>
     </linearGradient>
     <filter id="glow-amber">
       <feGaussianBlur in="SourceGraphic" stdDeviation="8" result="blur"/>
@@ -29,7 +29,7 @@
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="#05070b"/>
+  <rect width="1200" height="630" fill="#08040f"/>
 
   <!-- Grid patterns -->
   <rect width="1200" height="630" fill="url(#grid-sm)" mask="url(#grid-mask)"/>
@@ -40,8 +40,8 @@
 
   <!-- Top-left mark -->
   <g transform="translate(56, 52)">
-    <rect width="28" height="28" rx="7" fill="none" stroke="#ffb547" stroke-width="1.5" opacity="0.9"/>
-    <rect x="6" y="6" width="16" height="16" rx="3" fill="#ffb547" opacity="0.85"/>
+    <rect width="28" height="28" rx="7" fill="none" stroke="#a855f7" stroke-width="1.5" opacity="0.9"/>
+    <rect x="6" y="6" width="16" height="16" rx="3" fill="#a855f7" opacity="0.85"/>
   </g>
 
   <!-- OPENTHYMOS wordmark -->
@@ -110,7 +110,7 @@
     font-size="16"
     font-weight="500"
     letter-spacing="0.5"
-    fill="#ffb547"
+    fill="#a855f7"
     opacity="0.85"
   >Intent → Proposal → Commit</text>
 
@@ -137,11 +137,11 @@
   >Append-only · Replayable · Governed</text>
 
   <!-- Amber accent dot (top-left of tagline area) -->
-  <circle cx="56" cy="200" r="3.5" fill="#ffb547" opacity="0.6">
+  <circle cx="56" cy="200" r="3.5" fill="#a855f7" opacity="0.6">
     <animate attributeName="opacity" values="0.6;0.25;0.6" dur="2.4s" repeatCount="indefinite"/>
   </circle>
 
   <!-- Corner border accent -->
-  <path d="M 1144 56 L 1200 56" stroke="#ffb547" stroke-width="1" opacity="0.3"/>
-  <path d="M 1200 56 L 1200 112" stroke="#ffb547" stroke-width="1" opacity="0.3"/>
+  <path d="M 1144 56 L 1200 56" stroke="#a855f7" stroke-width="1" opacity="0.3"/>
+  <path d="M 1200 56 L 1200 112" stroke="#a855f7" stroke-width="1" opacity="0.3"/>
 </svg>

--- a/docs/assets/js/hero3d.js
+++ b/docs/assets/js/hero3d.js
@@ -1,7 +1,8 @@
-/* THYMOS — hero 3D execution-DAG (three.js, CDN, graceful-degrading)
-   Renders a rotating node graph (the append-only ledger) with bright
-   "commit" pulses flowing along its edges. Self-guards: does nothing if
-   the container is absent, WebGL is unavailable, or the CDN fails to load. */
+/* THYMOS — hero 3D brand scene (three.js, CDN, graceful-degrading)
+   Matches the OpenThymos logo art: a glowing violet wireframe "open box"
+   (the cube) hovering over a particle portal of orbital rings and drifting
+   stars, with bright "commit" pulses running along the cube's edges.
+   Self-guards: no container / no WebGL / CDN failure → hero text stands alone. */
 
 const MOUNT = document.getElementById('hero-canvas');
 const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
@@ -13,18 +14,20 @@ if (MOUNT) {
 }
 
 function boot(THREE) {
-  // ----- palette (mirrors site.css) -----
-  const AMBER = new THREE.Color('#ffb547');
-  const AMBER_SOFT = new THREE.Color('#ffe1a8');
-  const CYAN = new THREE.Color('#4de0c4');
-  const VIOLET = new THREE.Color('#b998ff');
-  const BG = new THREE.Color('#05070b');
+  // ----- brand palette (mirrors the logo + site.css) -----
+  const VIOLET = new THREE.Color('#a855f7');
+  const VIOLET_HI = new THREE.Color('#c77dff');
+  const LAVENDER = new THREE.Color('#e7d2ff');
+  const STAR = new THREE.Color('#8be9ff');
+  const DEEP = new THREE.Color('#7c3aed');
+  const BG = new THREE.Color('#08040f');
 
   const scene = new THREE.Scene();
-  scene.fog = new THREE.Fog(BG, 34, 78);
+  scene.fog = new THREE.Fog(BG, 40, 110);
 
-  const camera = new THREE.PerspectiveCamera(58, mountAspect(), 0.1, 200);
-  camera.position.set(0, 0, 46);
+  const camera = new THREE.PerspectiveCamera(56, mountAspect(), 0.1, 300);
+  camera.position.set(0, 6, 60);
+  camera.lookAt(0, -1, 0);
 
   let renderer;
   try {
@@ -34,157 +37,143 @@ function boot(THREE) {
   setSize();
   renderer.domElement.setAttribute('aria-hidden', 'true');
   MOUNT.appendChild(renderer.domElement);
+  const PR = renderer.getPixelRatio();
 
-  // ----- build the DAG: nodes in a flattened ellipsoid, edges by proximity -----
-  const N = 88;
-  const RX = 30, RY = 13.5, RZ = 21;
-  const nodes = [];
-  for (let i = 0; i < N; i++) {
-    // even-ish distribution on a sphere, then squash to an ellipsoid
-    const u = Math.random(), v = Math.random();
-    const theta = 2 * Math.PI * u;
-    const phi = Math.acos(2 * v - 1);
-    const r = Math.cbrt(Math.random()) * 0.5 + 0.5; // bias outward, keep core sparse
-    nodes.push(new THREE.Vector3(
-      Math.sin(phi) * Math.cos(theta) * RX * r,
-      Math.sin(phi) * Math.sin(theta) * RY * r,
-      Math.cos(phi) * RZ * r
-    ));
-  }
+  const world = new THREE.Group();
+  world.rotation.x = -0.34; // gentle isometric look-down, like the logo art
+  scene.add(world);
 
-  // proximity edges (capped), build adjacency for the pulse walk
-  const D2 = 9.2 * 9.2;
-  const edges = [];
-  const adj = Array.from({ length: N }, () => []);
-  for (let i = 0; i < N; i++) {
-    for (let j = i + 1; j < N; j++) {
-      if (nodes[i].distanceToSquared(nodes[j]) < D2) {
-        edges.push([i, j]);
-        adj[i].push(j); adj[j].push(i);
-        if (edges.length > 260) break;
-      }
-    }
-    if (edges.length > 260) break;
-  }
-
-  const group = new THREE.Group();
-  scene.add(group);
-
-  // ----- edges as additive glowing lines -----
-  const edgePos = new Float32Array(edges.length * 2 * 3);
-  edges.forEach(([a, b], k) => {
-    edgePos.set([nodes[a].x, nodes[a].y, nodes[a].z], k * 6);
-    edgePos.set([nodes[b].x, nodes[b].y, nodes[b].z], k * 6 + 3);
-  });
-  const edgeGeo = new THREE.BufferGeometry();
-  edgeGeo.setAttribute('position', new THREE.BufferAttribute(edgePos, 3));
-  const edgeMat = new THREE.LineBasicMaterial({
-    color: AMBER, transparent: true, opacity: 0.16,
-    blending: THREE.AdditiveBlending, depthWrite: false,
-  });
-  group.add(new THREE.LineSegments(edgeGeo, edgeMat));
-
-  // ----- nodes as additive points -----
-  const nodePos = new Float32Array(N * 3);
-  const nodeCol = new Float32Array(N * 3);
-  const nodeSize = new Float32Array(N);
-  nodes.forEach((p, i) => {
-    nodePos.set([p.x, p.y, p.z], i * 3);
-    const c = i % 11 === 0 ? VIOLET : i % 7 === 0 ? CYAN : AMBER;
-    nodeCol.set([c.r, c.g, c.b], i * 3);
-    nodeSize[i] = (i % 7 === 0 || i % 11 === 0) ? 2.1 : 1.3;
-  });
-  const nodeGeo = new THREE.BufferGeometry();
-  nodeGeo.setAttribute('position', new THREE.BufferAttribute(nodePos, 3));
-  nodeGeo.setAttribute('aColor', new THREE.BufferAttribute(nodeCol, 3));
-  nodeGeo.setAttribute('aSize', new THREE.BufferAttribute(nodeSize, 1));
-
-  const nodeMat = new THREE.ShaderMaterial({
+  // additive glow point material (shared shader)
+  const pointMat = (sizePx) => new THREE.ShaderMaterial({
     transparent: true, depthWrite: false, blending: THREE.AdditiveBlending,
-    uniforms: { uPixelRatio: { value: renderer.getPixelRatio() }, uTime: { value: 0 } },
+    uniforms: { uPR: { value: PR }, uTime: { value: 0 }, uSize: { value: sizePx } },
     vertexShader: `
-      attribute vec3 aColor; attribute float aSize;
-      uniform float uPixelRatio; uniform float uTime;
-      varying vec3 vColor; varying float vAlpha;
+      attribute vec3 aColor; attribute float aScale; attribute float aPhase;
+      uniform float uPR; uniform float uTime; uniform float uSize;
+      varying vec3 vColor; varying float vA;
       void main() {
         vColor = aColor;
         vec4 mv = modelViewMatrix * vec4(position, 1.0);
-        float pulse = 0.78 + 0.22 * sin(uTime * 1.6 + position.x * 0.4 + position.y * 0.6);
-        vAlpha = pulse;
-        gl_PointSize = aSize * 9.0 * uPixelRatio * pulse * (60.0 / -mv.z);
+        float tw = 0.65 + 0.35 * sin(uTime * 1.7 + aPhase);
+        vA = tw;
+        gl_PointSize = uSize * aScale * uPR * tw * (60.0 / -mv.z);
         gl_Position = projectionMatrix * mv;
       }`,
     fragmentShader: `
-      varying vec3 vColor; varying float vAlpha;
+      varying vec3 vColor; varying float vA;
       void main() {
         float d = length(gl_PointCoord - vec2(0.5));
         if (d > 0.5) discard;
         float core = smoothstep(0.5, 0.0, d);
-        gl_FragColor = vec4(vColor, core * core * vAlpha);
+        gl_FragColor = vec4(vColor, core * core * vA);
       }`,
   });
-  group.add(new THREE.Points(nodeGeo, nodeMat));
 
-  // ----- commit pulses: bright sprites walking the DAG edges -----
-  const PULSES = reduceMotion ? 0 : 7;
-  const pulseGeo = new THREE.BufferGeometry();
-  const pulsePos = new Float32Array(Math.max(PULSES, 1) * 3);
-  const pulseCol = new Float32Array(Math.max(PULSES, 1) * 3);
-  pulseGeo.setAttribute('position', new THREE.BufferAttribute(pulsePos, 3));
-  pulseGeo.setAttribute('aColor', new THREE.BufferAttribute(pulseCol, 3));
-  const pulseMat = new THREE.ShaderMaterial({
-    transparent: true, depthWrite: false, blending: THREE.AdditiveBlending,
-    uniforms: { uPixelRatio: { value: renderer.getPixelRatio() } },
-    vertexShader: `
-      attribute vec3 aColor; uniform float uPixelRatio; varying vec3 vColor;
-      void main() {
-        vColor = aColor;
-        vec4 mv = modelViewMatrix * vec4(position, 1.0);
-        gl_PointSize = 26.0 * uPixelRatio * (60.0 / -mv.z);
-        gl_Position = projectionMatrix * mv;
-      }`,
-    fragmentShader: `
-      varying vec3 vColor;
-      void main() {
-        float d = length(gl_PointCoord - vec2(0.5));
-        if (d > 0.5) discard;
-        float core = smoothstep(0.5, 0.0, d);
-        gl_FragColor = vec4(vColor, core * core);
-      }`,
+  // =========================================================
+  // 1) The cube — wireframe "open box"
+  // =========================================================
+  const H = 11; // half-size
+  const CUBE_Y = 3;
+  const corners = [
+    [-H,-H,-H],[ H,-H,-H],[ H, H,-H],[-H, H,-H],
+    [-H,-H, H],[ H,-H, H],[ H, H, H],[-H, H, H],
+  ].map((c) => new THREE.Vector3(c[0], c[1] + CUBE_Y, c[2]));
+  const cubeEdges = [
+    [0,1],[1,2],[2,3],[3,0], [4,5],[5,6],[6,7],[7,4], [0,4],[1,5],[2,6],[3,7],
+  ];
+  const cube = new THREE.Group();
+  world.add(cube);
+
+  // edges
+  const ePos = new Float32Array(cubeEdges.length * 2 * 3);
+  cubeEdges.forEach(([a, b], k) => {
+    ePos.set([corners[a].x, corners[a].y, corners[a].z], k * 6);
+    ePos.set([corners[b].x, corners[b].y, corners[b].z], k * 6 + 3);
   });
-  const pulsePoints = new THREE.Points(pulseGeo, pulseMat);
-  group.add(pulsePoints);
+  const eGeo = new THREE.BufferGeometry();
+  eGeo.setAttribute('position', new THREE.BufferAttribute(ePos, 3));
+  cube.add(new THREE.LineSegments(eGeo, new THREE.LineBasicMaterial({
+    color: VIOLET, transparent: true, opacity: 0.55, blending: THREE.AdditiveBlending, depthWrite: false,
+  })));
+  // a second, larger faint cube for a halo of depth
+  cube.add(new THREE.LineSegments(eGeo, new THREE.LineBasicMaterial({
+    color: DEEP, transparent: true, opacity: 0.18, blending: THREE.AdditiveBlending, depthWrite: false,
+  })).clone());
 
+  // bright corner nodes
+  const cn = makePoints(corners.map((p) => ({ p, color: VIOLET_HI, scale: 2.0 })), 11);
+  cube.add(cn.points);
+
+  // =========================================================
+  // 2) Commit pulses — walk the cube edges
+  // =========================================================
+  const adj = corners.map(() => []);
+  cubeEdges.forEach(([a, b]) => { adj[a].push(b); adj[b].push(a); });
+  const PULSES = reduceMotion ? 0 : 8;
+  const pulse = makePoints(
+    Array.from({ length: Math.max(PULSES, 1) }, () => ({ p: corners[0].clone(), color: LAVENDER, scale: 1.0 })),
+    30
+  );
+  cube.add(pulse.points);
   const walkers = [];
   for (let i = 0; i < PULSES; i++) {
-    const from = (Math.random() * N) | 0;
-    const to = adj[from].length ? adj[from][(Math.random() * adj[from].length) | 0] : from;
-    walkers.push({ from, to, t: Math.random(), speed: 0.18 + Math.random() * 0.22 });
+    const from = (Math.random() * 8) | 0;
+    walkers.push({ from, to: adj[from][(Math.random() * adj[from].length) | 0], t: Math.random(), speed: 0.3 + Math.random() * 0.4 });
   }
 
-  function stepWalkers(dt) {
-    for (let i = 0; i < walkers.length; i++) {
-      const w = walkers[i];
-      w.t += w.speed * dt;
-      while (w.t >= 1) {
-        w.t -= 1;
-        w.from = w.to;
-        const nbrs = adj[w.from];
-        w.to = nbrs.length ? nbrs[(Math.random() * nbrs.length) | 0] : w.from;
-      }
-      const a = nodes[w.from], b = nodes[w.to];
-      const x = a.x + (b.x - a.x) * w.t;
-      const y = a.y + (b.y - a.y) * w.t;
-      const z = a.z + (b.z - a.z) * w.t;
-      pulsePos.set([x, y, z], i * 3);
-      const c = i % 2 ? CYAN : AMBER_SOFT;
-      pulseCol.set([c.r, c.g, c.b], i * 3);
+  // =========================================================
+  // 3) Portal — concentric orbital rings on a flat plane
+  // =========================================================
+  const PORTAL_Y = -15;
+  const portal = new THREE.Group();
+  portal.position.y = PORTAL_Y;
+  portal.rotation.x = -Math.PI / 2; // lay the rings flat
+  world.add(portal);
+
+  const ringDefs = [
+    { r: 17, op: 0.5, color: VIOLET_HI },
+    { r: 25, op: 0.3, color: VIOLET },
+    { r: 34, op: 0.18, color: DEEP },
+  ];
+  ringDefs.forEach(({ r, op, color }) => {
+    const seg = 160;
+    const pos = new Float32Array((seg + 1) * 3);
+    for (let i = 0; i <= seg; i++) {
+      const a = (i / seg) * Math.PI * 2;
+      pos.set([Math.cos(a) * r, Math.sin(a) * r, 0], i * 3);
     }
-    pulseGeo.attributes.position.needsUpdate = true;
-    pulseGeo.attributes.aColor.needsUpdate = true;
-  }
+    const g = new THREE.BufferGeometry();
+    g.setAttribute('position', new THREE.BufferAttribute(pos, 3));
+    portal.add(new THREE.Line(g, new THREE.LineBasicMaterial({
+      color, transparent: true, opacity: op, blending: THREE.AdditiveBlending, depthWrite: false,
+    })));
+  });
 
-  // ----- interaction: gentle pointer parallax -----
+  // particle disc on the portal plane + ambient starfield
+  const discN = 320;
+  const discItems = [];
+  for (let i = 0; i < discN; i++) {
+    const a = Math.random() * Math.PI * 2;
+    const rad = 15 + Math.pow(Math.random(), 0.7) * 28;
+    const p = new THREE.Vector3(Math.cos(a) * rad, Math.sin(a) * rad, (Math.random() - 0.5) * 1.6);
+    const roll = Math.random();
+    discItems.push({ p, color: roll > 0.86 ? STAR : roll > 0.5 ? VIOLET_HI : VIOLET, scale: 0.5 + Math.random() * 1.1 });
+  }
+  const disc = makePoints(discItems, 8);
+  portal.add(disc.points);
+
+  const ambN = 220;
+  const ambItems = [];
+  for (let i = 0; i < ambN; i++) {
+    const p = new THREE.Vector3((Math.random() - 0.5) * 130, (Math.random() - 0.5) * 70, (Math.random() - 0.5) * 90);
+    ambItems.push({ p, color: Math.random() > 0.9 ? STAR : VIOLET, scale: 0.4 + Math.random() * 0.8 });
+  }
+  const amb = makePoints(ambItems, 7);
+  world.add(amb.points);
+
+  // =========================================================
+  // interaction + loop
+  // =========================================================
   const pointer = { x: 0, y: 0, tx: 0, ty: 0 };
   if (!reduceMotion) {
     window.addEventListener('pointermove', (e) => {
@@ -193,56 +182,80 @@ function boot(THREE) {
     }, { passive: true });
   }
 
-  // ----- run loop, paused when offscreen or tab hidden -----
-  let running = true, raf = 0, last = performance.now();
-  const clock = { t: 0 };
+  const mats = [cn.mat, pulse.mat, disc.mat, amb.mat];
+  let running = false, raf = 0, last = performance.now();
+  let t = 0;
 
   function frame(now) {
     if (!running) return;
     const dt = Math.min((now - last) / 1000, 0.05);
-    last = now;
-    clock.t += dt;
+    last = now; t += dt;
 
-    group.rotation.y += dt * 0.07;
-    group.rotation.x = Math.sin(clock.t * 0.12) * 0.12;
+    cube.rotation.y += dt * 0.18;
+    portal.rotation.z -= dt * 0.06;
+    amb.points.rotation.y += dt * 0.01;
+    world.rotation.z = Math.sin(t * 0.1) * 0.03;
 
     pointer.x += (pointer.tx - pointer.x) * 0.04;
     pointer.y += (pointer.ty - pointer.y) * 0.04;
-    camera.position.x = pointer.x * 4.5;
-    camera.position.y = -pointer.y * 3.0;
-    camera.lookAt(0, 0, 0);
+    camera.position.x = pointer.x * 6;
+    camera.position.y = 6 - pointer.y * 4;
+    camera.lookAt(0, -1, 0);
 
-    nodeMat.uniforms.uTime.value = clock.t;
+    for (const m of mats) m.uniforms.uTime.value = t;
     if (PULSES) stepWalkers(dt);
 
     renderer.render(scene, camera);
     raf = requestAnimationFrame(frame);
   }
 
-  function start() {
-    if (running && raf) return;
-    running = true; last = performance.now();
-    raf = requestAnimationFrame(frame);
+  function stepWalkers(dt) {
+    const arr = pulse.points.geometry.attributes.position.array;
+    for (let i = 0; i < walkers.length; i++) {
+      const w = walkers[i];
+      w.t += w.speed * dt;
+      while (w.t >= 1) {
+        w.t -= 1; w.from = w.to;
+        const nb = adj[w.from];
+        w.to = nb[(Math.random() * nb.length) | 0];
+      }
+      const a = corners[w.from], b = corners[w.to];
+      arr[i * 3] = a.x + (b.x - a.x) * w.t;
+      arr[i * 3 + 1] = a.y + (b.y - a.y) * w.t;
+      arr[i * 3 + 2] = a.z + (b.z - a.z) * w.t;
+    }
+    pulse.points.geometry.attributes.position.needsUpdate = true;
   }
+
+  function start() { if (running) return; running = true; last = performance.now(); raf = requestAnimationFrame(frame); }
   function stop() { running = false; if (raf) cancelAnimationFrame(raf); raf = 0; }
 
-  // pause when the hero leaves the viewport
   if ('IntersectionObserver' in window) {
-    new IntersectionObserver((entries) => {
-      entries.forEach((e) => (e.isIntersecting ? start() : stop()));
-    }, { threshold: 0.01 }).observe(MOUNT);
-  }
-  document.addEventListener('visibilitychange', () => (document.hidden ? stop() : start()));
+    new IntersectionObserver((es) => es.forEach((e) => (e.isIntersecting ? start() : stop())), { threshold: 0.01 }).observe(MOUNT);
+  } else { start(); }
+  document.addEventListener('visibilitychange', () => (document.hidden ? stop() : (!reduceMotion && start())));
   window.addEventListener('resize', onResize, { passive: true });
 
-  if (reduceMotion) {
-    // static single frame — depth and structure, no motion
-    renderer.render(scene, camera);
-  } else {
-    start();
-  }
+  if (reduceMotion) renderer.render(scene, camera); else start();
 
   // ----- helpers -----
+  function makePoints(items, sizePx) {
+    const n = items.length;
+    const pos = new Float32Array(n * 3), col = new Float32Array(n * 3);
+    const scl = new Float32Array(n), pha = new Float32Array(n);
+    items.forEach((it, i) => {
+      pos.set([it.p.x, it.p.y, it.p.z], i * 3);
+      col.set([it.color.r, it.color.g, it.color.b], i * 3);
+      scl[i] = it.scale; pha[i] = Math.random() * 6.28;
+    });
+    const g = new THREE.BufferGeometry();
+    g.setAttribute('position', new THREE.BufferAttribute(pos, 3));
+    g.setAttribute('aColor', new THREE.BufferAttribute(col, 3));
+    g.setAttribute('aScale', new THREE.BufferAttribute(scl, 1));
+    g.setAttribute('aPhase', new THREE.BufferAttribute(pha, 1));
+    const mat = pointMat(sizePx);
+    return { points: new THREE.Points(g, mat), mat };
+  }
   function mountAspect() {
     const r = MOUNT.getBoundingClientRect();
     return Math.max(r.width, 1) / Math.max(r.height, 1);
@@ -255,8 +268,6 @@ function boot(THREE) {
     camera.aspect = mountAspect();
     camera.updateProjectionMatrix();
     setSize();
-    nodeMat.uniforms.uPixelRatio.value = renderer.getPixelRatio();
-    pulseMat.uniforms.uPixelRatio.value = renderer.getPixelRatio();
     if (reduceMotion || !running) renderer.render(scene, camera);
   }
 }


### PR DESCRIPTION
Follow-up to #32. That shipped the 3D hero in the old **amber** palette; this aligns the whole Pages site to the **actual OpenThymos brand** — violet/purple, the geometric fox + glowing "open box" cube from `thymos/thymosG.PNG`.

## Palette: amber → brand violet (`site.css`, `head.html`)
- Accent `#a855f7` / `#c77dff`, soft lavender `#d9bcff`, star-cyan `#8be9ff`; background deepened to violet-black `#08040f`.
- Grid, glows, buttons, cards, icons, blockquotes re-tinted; primary button now white text on a violet gradient.
- Left semantic colors alone: code-syntax highlight tokens and the macOS terminal traffic-light dots.

## 3D hero rebuilt to the logo art (`hero3d.js`)
- A glowing violet **wireframe cube** (the "open box") slowly rotating.
- A **particle portal** beneath it — concentric orbital rings + a drifting star disc, like the `thymosG.PNG` platform.
- Ambient **starfield**, plus bright **commit-pulses** running along the cube edges (on-theme: ledger commits flowing the box).
- Unchanged safety: graceful degradation (no WebGL/CDN → hero text stands alone), `prefers-reduced-motion` static frame, pauses offscreen/when tab hidden, DPR-capped.

## Also
- `og.svg` social card recolored to violet.

`node --check` passes on the JS; CSS braces balanced. Renders live once merged to Pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)