### PR TITLE
chore(site): CNAME for openthymos.js.org (merge after js.org PR)

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+openthymos.js.org


### PR DESCRIPTION
Adds `docs/CNAME` = `openthymos.js.org` for the custom domain (js.org PR: js-org/js.org#11543).

⚠️ **Do not merge until** the js.org PR is approved/merged AND the custom domain is set in **Settings → Pages**. Because this site deploys via Actions (`pages.yml`), the CNAME file alone does not configure the domain — it's belt-and-suspenders. Merging early (before DNS is live) would point the site at a not-yet-resolving domain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)