### PR TITLE
fix(ci): correct container documentation label URL

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
             org.opencontainers.image.description=Execution substrate for governed machine cognition. Separates cognition from execution through the typed Intent -> Proposal -> Commit protocol.
             org.opencontainers.image.vendor=Exponet Labs
             org.opencontainers.image.licenses=Apache-2.0
-            org.opencontainers.image.documentation=https://github.com/gryszzz/OpenThymos#readme
+            org.opencontainers.image.documentation=https://github.com/${{ github.repository }}#readme
       - uses: docker/build-push-action@v6
         with:
           context: thymos


### PR DESCRIPTION
Audit finding ahead of the next release.

**Bug:** `release.yml` set `org.opencontainers.image.documentation=https://github.com/gryszzz/OpenThymos#readme` — wrong repo name (the repo is `open-thymos`), so the published container image's documentation label pointed at a non-existent URL.

**Fix:** use `https://github.com/${{ github.repository }}#readme` so it resolves to the real slug and can't drift.

### Audit notes (no code changes needed)
- Full `cargo test --workspace`: **green**.
- `cargo clippy --workspace --all-targets`: **0 warnings**.
- No `TODO`/`FIXME`/`dbg!`/`unimplemented!` in shipped Rust src.
- Container image OCI labelling (Dockerfile + metadata-action) is otherwise correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)