### PR TITLE
revert(site): drop openthymos.js.org CNAME, stay on github.io

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,0 @@
-openthymos.js.org


### PR DESCRIPTION
js-org/js.org#11543 isn't merged yet, so openthymos.js.org has no HTTPS cert and the github.io→custom-domain redirect broke the live site on HTTPS. The Pages custom domain was cleared via API; removing the CNAME file keeps the next Pages build from re-applying it. Re-add once the js.org PR merges.