### PR TITLE
chore(release): v0.5.0

### DIFF
--- a/thymos/Cargo.lock
+++ b/thymos/Cargo.lock
@@ -2699,7 +2699,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-cli"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "axum 0.8.9",
  "clap",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-client"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "axum-test",
  "reqwest",
@@ -2733,7 +2733,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-cognition"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -2747,7 +2747,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-compiler"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2758,7 +2758,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-core"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "blake3",
  "ed25519-dalek",
@@ -2771,7 +2771,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-ledger"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "blake3",
  "deadpool-postgres",
@@ -2787,7 +2787,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-marketplace"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "blake3",
  "hex",
@@ -2800,7 +2800,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-policy"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2809,7 +2809,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-runtime"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "serde",
@@ -2826,7 +2826,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-server"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2859,7 +2859,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-tools"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "blake3",
  "reqwest",
@@ -2872,7 +2872,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-worker"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "serde_json",
  "thymos-tools",

--- a/thymos/Cargo.toml
+++ b/thymos/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.4"
+version = "0.5.0"
 edition = "2021"
 license = "Apache-2.0"
 rust-version = "1.80"


### PR DESCRIPTION
Version bump `0.4.4 → 0.5.0` (workspace + lockfile). Merging this, then tagging `v0.5.0`, triggers the release workflow (multi-platform binaries + ghcr container images + GitHub Release).

### Since v0.4.4
- **feat:** real Postgres HTTP runtime backend (#28/#29)
- **feat:** drive (almost) any model via OpenAI-compatible presets (#33)
- **feat:** violet brand — 3D site hero (#32/#34) + on-brand CLI graphics (#35)
- **docs:** honest `/health` + Postgres docs alignment (#30/#31)
- **fix(ci):** correct container documentation label (#37)
- **fix(site):** mobile menu button, bigger logo, de-crammed header (#38)

Verified: `cargo test --workspace` green · `clippy` 0 warnings · builds at 0.5.0.

