### PR TITLE
fix(runtime): seed trajectory from writ id, not task text (ledger collision)

### DIFF
--- a/thymos/crates/thymos-runtime/src/agent.rs
+++ b/thymos/crates/thymos-runtime/src/agent.rs
@@ -173,7 +173,11 @@ pub fn run_agent<L: LedgerStore>(
     opts: AgentRunOptions,
     event_tx: Option<AgentEventCallback>,
 ) -> Result<AgentRunSummary> {
-    let run = runtime.create_run(task, task.as_bytes())?;
+    // Seed the trajectory from the writ id (unique per run via the writ's
+    // random nonce), NOT the task text — otherwise re-running the same task
+    // string derives the same trajectory and collides on the append-only
+    // ledger's (trajectory_id, seq) ROOT entry.
+    let run = runtime.create_run(task, writ.id.0.as_bytes())?;
     let trajectory_id = run.trajectory_id();
     emit_event(
         event_tx.as_ref(),

--- a/thymos/crates/thymos-runtime/src/agent_async.rs
+++ b/thymos/crates/thymos-runtime/src/agent_async.rs
@@ -58,7 +58,11 @@ pub async fn run_agent_streaming<L: LedgerStore>(
     approval_requester: Option<ApprovalRequester>,
     trace_tx: Option<AgentEventCallback>,
 ) -> Result<AgentRunSummary> {
-    let run = runtime.create_run(task, task.as_bytes())?;
+    // Seed the trajectory from the writ id (unique per run via the writ's
+    // random nonce), NOT the task text — otherwise re-running the same task
+    // string derives the same trajectory and collides on the append-only
+    // ledger's (trajectory_id, seq) ROOT entry.
+    let run = runtime.create_run(task, writ.id.0.as_bytes())?;
     let trajectory_id = run.trajectory_id();
     emit_event(
         trace_tx.as_ref(),

--- a/thymos/crates/thymos-runtime/tests/agent_loop.rs
+++ b/thymos/crates/thymos-runtime/tests/agent_loop.rs
@@ -21,6 +21,10 @@ fn build_runtime() -> Runtime {
 }
 
 fn root_writ() -> Writ {
+    root_writ_with_nonce([0u8; 16])
+}
+
+fn root_writ_with_nonce(nonce: [u8; 16]) -> Writ {
     let root_key = generate_signing_key();
     let agent_key = generate_signing_key();
     Writ::sign(
@@ -29,7 +33,7 @@ fn root_writ() -> Writ {
             issuer_pubkey: public_key_of(&root_key),
             subject: "test-agent".into(),
             subject_pubkey: public_key_of(&agent_key),
-            nonce: [0u8; 16],
+            nonce,
             parent: None,
             tenant_id: String::new(),
             tool_scopes: vec![ToolPattern::exact("kv_*")],
@@ -65,6 +69,44 @@ fn mk_intent(target: &str, args: serde_json::Value, nonce: u8) -> CoreIntent {
         nonce: [nonce; 16],
     })
     .unwrap()
+}
+
+#[test]
+fn same_task_text_distinct_writs_do_not_collide() {
+    // Regression: the trajectory must be seeded from the writ (unique per run
+    // via its nonce), NOT the task text. Two runs of the *same task string*
+    // (each with its own writ, as the server mints them) must get distinct
+    // trajectories and both succeed — otherwise the second collides on the
+    // append-only ledger's (trajectory_id, seq) ROOT.
+    let runtime = build_runtime();
+    let task = "Set greeting to hello, then read it back";
+
+    let go = |writ: &Writ| {
+        let set = mk_intent("kv_set", serde_json::json!({"key": "k", "value": "v"}), 1);
+        let mut cognition = MockCognition::new(vec![vec![set]], Some("done".into()));
+        run_agent(
+            &runtime,
+            &mut cognition,
+            task,
+            writ,
+            AgentRunOptions { max_steps: 4 },
+            None,
+        )
+    };
+
+    let writ_a = root_writ_with_nonce([1u8; 16]);
+    let writ_b = root_writ_with_nonce([2u8; 16]);
+    assert_ne!(writ_a.id, writ_b.id, "distinct nonces → distinct writ ids");
+
+    let a = go(&writ_a).expect("first run of the task");
+    let b = go(&writ_b).expect("second run of the SAME task must not collide");
+
+    assert_ne!(
+        a.trajectory_id, b.trajectory_id,
+        "same task + distinct writs must yield distinct trajectories"
+    );
+    assert_eq!(a.commits, 1);
+    assert_eq!(b.commits, 1);
 }
 
 #[test]


### PR DESCRIPTION
### The bug (found by driving the CLI)
Re-running the **same task string** randomly failed with:
```
error: ledger error: UNIQUE constraint failed: entries.trajectory_id, entries.seq
```

### Root cause
Both agent entry points seeded the trajectory from the task text:
```rust
// agent.rs / agent_async.rs
let run = runtime.create_run(task, task.as_bytes())?;   // TrajectoryId = blake3(task)
```
So two runs of the same task derived the **same trajectory**, and the second collided on the append-only ledger's `(trajectory_id, seq)` ROOT entry. (The routed-submit path was already seeded uniquely — these two were missed.)

### Fix
Seed from `writ.id` instead — every run mints a fresh writ with a random nonce, so trajectories are unique per run while staying deterministic given the writ:
```rust
let run = runtime.create_run(task, writ.id.0.as_bytes())?;
```

### Verification
- **Regression test** `same_task_text_distinct_writs_do_not_collide` — fails on the old code with the exact `UNIQUE constraint` error, passes now. Full `thymos-runtime` suite green; clippy clean.
- **Live:** rebuilt the server and ran one identical task **5×** → 5 distinct trajectories, all `completed` (previously every repeat after the first failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)