### PR TITLE
fix(server): close execution SSE stream on terminal status (--follow hung)

### DIFF
--- a/thymos/crates/thymos-server/src/execution.rs
+++ b/thymos/crates/thymos-server/src/execution.rs
@@ -15,6 +15,17 @@ pub enum ExecutionStatus {
     Cancelled,
 }
 
+impl ExecutionStatus {
+    /// A run that has reached an end state — no further snapshots will follow,
+    /// so SSE subscribers can close the stream instead of hanging open.
+    pub fn is_terminal(&self) -> bool {
+        matches!(
+            self,
+            ExecutionStatus::Completed | ExecutionStatus::Failed | ExecutionStatus::Cancelled
+        )
+    }
+}
+
 #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum ExecutionPhase {

--- a/thymos/crates/thymos-server/src/lib.rs
+++ b/thymos/crates/thymos-server/src/lib.rs
@@ -1836,11 +1836,21 @@ async fn get_execution_stream(
     match (initial, rx) {
         (Some(initial_session), Some(mut rx)) => {
             let stream = async_stream::stream! {
+                let initial_terminal = initial_session.status.is_terminal();
                 let initial_data = serde_json::to_string(&initial_session).unwrap_or_default();
                 yield Ok::<_, std::convert::Infallible>(Event::default().event("snapshot").data(initial_data));
-                while let Ok(session) = rx.recv().await {
-                    let data = serde_json::to_string(&session).unwrap_or_default();
-                    yield Ok::<_, std::convert::Infallible>(Event::default().event("snapshot").data(data));
+                // Already finished when the client connected (e.g. reconnect): close.
+                if !initial_terminal {
+                    while let Ok(session) = rx.recv().await {
+                        let terminal = session.status.is_terminal();
+                        let data = serde_json::to_string(&session).unwrap_or_default();
+                        yield Ok::<_, std::convert::Infallible>(Event::default().event("snapshot").data(data));
+                        // End the stream once the run reaches a terminal state so
+                        // `--follow` (and any SSE client) doesn't hang open forever.
+                        if terminal {
+                            break;
+                        }
+                    }
                 }
             };
             Sse::new(stream).into_response()


### PR DESCRIPTION
**Bug found while making `run --follow` more interactive:** it hung after the run finished.

### Cause
`/runs/:id/execution/stream` looped `while let Ok(s) = rx.recv().await` with no exit. The broadcast sender lives in `execution_channels` and is never dropped, so the SSE stream stayed **open forever** after a terminal status — `thymos run --follow` (and any SSE consumer) blocked instead of returning.

### Fix
- `ExecutionStatus::is_terminal()` (Completed / Failed / Cancelled).
- The stream **ends** once a terminal snapshot is sent, and **closes immediately** if the run was already terminal when the client connected (reconnect case).

### Verified
- Server e2e incl. the execution-stream tests: green. clippy clean.
- Live: `run --follow` now returns cleanly (exit 0) with the run summary, no hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)