### PR TITLE
Desktop app scaffold, easy-download path, and agent-control audit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,3 +130,122 @@ jobs:
 
             Binaries attached for linux/x86_64, darwin/arm64, darwin/x86_64, windows/x86_64.
             See [README.md](https://github.com/${{ github.repository }}/blob/main/README.md) for setup.
+
+  # ---------------------------------------------------------------------------
+  # Desktop installers (.dmg / .msi / .AppImage) for OpenThymos Desktop.
+  # UNTESTED in CI to date — the Tauri app is a scaffold (docs/rfcs/desktop-app.md).
+  # Safe by construction: continue-on-error + APPENDS bundles to the existing
+  # release, so a desktop build failure can never break the binary/container
+  # release above. Bundles are currently UNSIGNED (Gatekeeper/SmartScreen will
+  # warn); add Apple Developer ID + Windows certs as secrets to notarize/sign.
+  # ---------------------------------------------------------------------------
+  desktop:
+    name: Desktop installer (${{ matrix.os }})
+    needs: [release]
+    if: startsWith(github.ref, 'refs/tags/v')
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Linux webview deps
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+      - name: Install app deps + icons
+        working-directory: thymos/clients/desktop
+        run: |
+          npm install
+          npm run icon
+      - name: Build bundles
+        uses: tauri-apps/tauri-action@v0
+        with:
+          projectPath: thymos/clients/desktop
+      - name: Append installers to the release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            thymos/clients/desktop/src-tauri/target/release/bundle/**/*.dmg
+            thymos/clients/desktop/src-tauri/target/release/bundle/**/*.msi
+            thymos/clients/desktop/src-tauri/target/release/bundle/**/*.AppImage
+
+  # ---------------------------------------------------------------------------
+  # Homebrew tap update: `brew install <owner>/tap/thymos`.
+  # GUARDED — cleanly skips (a green no-op) until you create an
+  # `<owner>/homebrew-tap` repo and add a HOMEBREW_TAP_TOKEN secret (a PAT with
+  # write access to that tap repo). Then this regenerates the formula from the
+  # published release tarballs on every tag.
+  # ---------------------------------------------------------------------------
+  homebrew:
+    name: Update Homebrew tap
+    needs: [release]
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Gate on tap token
+        id: gate
+        env:
+          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          if [ -n "$TAP_TOKEN" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::HOMEBREW_TAP_TOKEN not set — skipping Homebrew tap update (expected until the tap is configured)."
+          fi
+      - name: Render formula and push to tap
+        if: steps.gate.outputs.enabled == 'true'
+        env:
+          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          VER: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          base="https://github.com/$OWNER/open-thymos/releases/download/$VER"
+          sha() { curl -fsSL "$base/$1" | sha256sum | cut -d' ' -f1; }
+          ARM=$(sha "thymos-$VER-aarch64-apple-darwin.tar.gz")
+          INTEL=$(sha "thymos-$VER-x86_64-apple-darwin.tar.gz")
+          LINUX=$(sha "thymos-$VER-x86_64-unknown-linux-gnu.tar.gz")
+          git clone "https://x-access-token:$TAP_TOKEN@github.com/$OWNER/homebrew-tap.git" tap
+          mkdir -p tap/Formula
+          cat > tap/Formula/thymos.rb <<RB
+          class Thymos < Formula
+            desc "Governed-cognition runtime — Intent → Proposal → Commit"
+            homepage "https://github.com/$OWNER/open-thymos"
+            version "${VER#v}"
+            on_macos do
+              on_arm do
+                url "$base/thymos-$VER-aarch64-apple-darwin.tar.gz"
+                sha256 "$ARM"
+              end
+              on_intel do
+                url "$base/thymos-$VER-x86_64-apple-darwin.tar.gz"
+                sha256 "$INTEL"
+              end
+            end
+            on_linux do
+              url "$base/thymos-$VER-x86_64-unknown-linux-gnu.tar.gz"
+              sha256 "$LINUX"
+            end
+            def install
+              bin.install "thymos", "thymos-server"
+            end
+            test do
+              system "#{bin}/thymos", "--help"
+            end
+          end
+          RB
+          cd tap
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/thymos.rb
+          git commit -m "thymos $VER" || { echo "no change"; exit 0; }
+          git push

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="./thymos/thymosG.PNG" alt="OpenThymos" width="325" />
 
-[![Star on GitHub](https://img.shields.io/badge/⭐_Star-on_GitHub-yellow?style=for-the-badge)](https://github.com/gryszzz/open-thymos) [![License](https://img.shields.io/badge/License-Apache_2.0-blue?style=for-the-badge)](LICENSE) ![Rust](https://img.shields.io/badge/Rust-Execution_Runtime-orange?style=for-the-badge&logo=rust)
+[![Download](https://img.shields.io/github/v/release/gryszzz/open-thymos?style=for-the-badge&label=⬇%20Download&color=7c5cff)](https://github.com/gryszzz/open-thymos/releases/latest) [![Star on GitHub](https://img.shields.io/badge/⭐_Star-on_GitHub-yellow?style=for-the-badge)](https://github.com/gryszzz/open-thymos) [![License](https://img.shields.io/badge/License-Apache_2.0-blue?style=for-the-badge)](LICENSE) ![Rust](https://img.shields.io/badge/Rust-Execution_Runtime-orange?style=for-the-badge&logo=rust)
 
 # open-thymos
 
@@ -260,6 +260,48 @@ cargo run -p thymos-cli -- doctor
 ```
 
 Install the `thymos` shorthand with `cargo install --path thymos/crates/thymos-cli`.
+
+### Download — prebuilt binaries (no toolchain)
+
+<div align="center">
+
+[![Download the latest release](https://img.shields.io/github/v/release/gryszzz/open-thymos?style=for-the-badge&label=⬇%20Download%20OpenThymos&color=7c5cff)](https://github.com/gryszzz/open-thymos/releases/latest)
+
+</div>
+
+Prebuilt `thymos` (CLI) + `thymos-server` (runtime) for macOS, Linux, and
+Windows ship on every tagged [release](https://github.com/gryszzz/open-thymos/releases/latest).
+No Rust, no clone, no compile.
+
+**One line (macOS / Linux):**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/gryszzz/open-thymos/main/scripts/get.sh | sh
+# installs to ~/.local/bin · pin a version with THYMOS_VERSION=v0.5.0
+# privacy: fetches only from github.com — no telemetry, no phone-home
+```
+
+**Or grab a binary directly** from the
+[latest release](https://github.com/gryszzz/open-thymos/releases/latest):
+macOS (Apple Silicon / Intel), Linux (x86_64), Windows (x86_64). Unpack and run
+`thymos-server`, then `thymos shell`.
+
+**Docker:**
+
+```bash
+docker run --rm -p 3001:3001 ghcr.io/gryszzz/openthymos-runtime:latest
+```
+
+### Desktop app — in progress
+
+A double-click **OpenThymos Desktop** (one install: provider setup, chat
+sessions, tools, logs, audit, backups) is being built as a Tauri app that
+supervises the runtime locally — *your keys never leave your machine, no
+phone-home*. It's a **client** of the same governed API as every other surface,
+so it can't bypass the `Intent → Proposal → Commit` boundary. Scope and honest
+feature-by-feature status: **[docs/rfcs/desktop-app.md](docs/rfcs/desktop-app.md)**.
+The Download button above is the terminal runtime today; the desktop GUI installer
+(`.dmg` / `.msi` / `.AppImage`) lands here once it's signed and released.
 
 **Multi-agent delegation is demonstrable** — a parent mints a child writ ⊆ its own
 authority, the child runs on its own trajectory, the ledger shows the lineage, and

--- a/docs/audits/agent-control-audit.md
+++ b/docs/audits/agent-control-audit.md
@@ -1,0 +1,170 @@
+# Audit: is the agent really under control?
+
+Date: 2026-06-06 · Scope: the cognition → runtime authority boundary. Verified
+by reading the enforcement code paths and running the governance test suite +
+`thymos audit` against a live runtime. This note captures the finding so it
+isn't only in a chat log.
+
+**Verdict:** Yes — control is enforced in code (a pure compiler + a single
+execution chokepoint), not by prompt convention, and it is regression-tested
+adversarially. The residual trust sits in **tool honesty, writ-key custody, and
+your policy/approval configuration** — which is the correct place for it. See
+[§ Honest trust boundaries](#honest-trust-boundaries).
+
+---
+
+## How the agent works
+
+The loop ([`agent.rs`](../../thymos/crates/thymos-runtime/src/agent.rs)) is
+deliberately minimal. Each step it:
+
+1. projects the world from the ledger,
+2. asks cognition for a batch of **intents** (`cognition.step(ctx)`),
+3. routes each intent through `submit` → the compiler,
+4. records the typed outcome and feeds it back next step.
+
+**Cognition's authority is bounded by the type system, not by convention.** The
+`Cognition` trait
+([`cognition/lib.rs:99`](../../thymos/crates/thymos-cognition/src/lib.rs#L99))
+exposes exactly one method, `step() -> CognitionStep`, and `CognitionStep`
+carries only `{ intents, final_answer, usage }`. There is no method to execute a
+tool, write the ledger, or mutate state — the model *cannot* do those things
+because nothing hands it the capability. A model may *propose* anything;
+proposing is harmless.
+
+## Where control is enforced
+
+Every intent passes through `compile_with_context`
+([`compiler/lib.rs:115`](../../thymos/crates/thymos-compiler/src/lib.rs#L115)) —
+a **pure function** that runs gates in a fixed order and returns either a
+`Staged` proposal, a typed `Rejected`, or `Suspended` (needs approval):
+
+| # | Gate | Reject reason |
+|---|------|---------------|
+| 1 | intent kind supported | `TypeMismatch` |
+| 2 | writ signature valid | `AuthorityVoid` |
+| 2b | writ (and parent) not revoked | `AuthorityVoid` |
+| 3 | now ∈ writ time window | `AuthorityVoid` |
+| 4 | tool ∈ writ scope | `AuthorityVoid` |
+| 5 | tool exists | `UnknownTool` |
+| 5b | **tool effect class ≤ writ effect ceiling** (Read ≤ Write ≤ External ≤ Irreversible) | `AuthorityVoid` |
+| 6 | projected cost ≤ writ budget | `BudgetExhausted` |
+| 7 | args typecheck | `TypeMismatch` |
+| 8 | preconditions hold | `PreconditionFailed` |
+| 9 | policy verdict | `PolicyDenied` / `RequireApproval` |
+| 9b | irreversible & uncompensable ⇒ force human approval | suspends |
+
+The single chokepoint that matters: in `submit`
+([`runtime/lib.rs:600`](../../thymos/crates/thymos-runtime/src/lib.rs#L600)),
+`tool.execute(&inv)` is reachable **only** inside the `Compiled::Staged` arm
+([`runtime/lib.rs:645`](../../thymos/crates/thymos-runtime/src/lib.rs#L645)).
+`Rejected` appends a rejection and returns; `Suspended` parks a pending approval
+and returns. **There is no other path to execution.**
+
+## Proof — gate tests (run 2026-06-06)
+
+The control tests don't merely assert "an error came back." They register a
+`PoisonTool` whose `execute()` increments a counter, then assert the counter
+stayed **0** — i.e. a denied intent *provably never reached the tool*
+([`compiler_rejection.rs`](../../thymos/crates/thymos-runtime/tests/compiler_rejection.rs),
+`assert_never_executed`).
+
+```
+$ cargo test -p thymos-runtime --test compiler_rejection \
+      --test cognition_budget --test revocation --test redaction \
+      --test replay_safety --test quorum --test agent_loop
+
+compiler_rejection ... 10 passed   (one per gate; all "rejects_before_execute_when_*")
+  signature_invalid · time_window_expired · tool_outside_writ_scope · tool_unknown
+  effect_exceeds_ceiling · budget_exhausted · args_fail_validation
+  precondition_fails · policy_denies · poison_tool_unused_in_clean_run
+cognition_budget   ...  2 passed   (model token/USD spend halts the run)
+revocation         ...  3 passed   (revoked & parent-revoked writ rejected before execution)
+redaction          ...  2 passed   (secrets scrubbed before hitting the ledger)
+replay_safety      ...  4 passed   (replay never calls a provider or re-runs a tool)
+quorum             ...  2 passed   (M-of-N approval; a single denial vetoes)
+agent_loop         ...  6 passed   (end-to-end loop; rejections don't stop progress)
+```
+
+## Proof — `thymos audit` on a live runtime (run 2026-06-06)
+
+A runtime was started on an isolated ledger (`THYMOS_LEDGER_PATH`), a run was
+driven through the HTTP API, and audited:
+
+```
+$ thymos audit c4655c04-031e-41b5-8959-42e2dd361ea8
+
+OpenThymos audit
+run:              c4655c04-031e-41b5-8959-42e2dd361ea8
+trajectory:       c085755abb491f3a388b385e0339779455e20c22847ec29ffd6400cf23db82e1
+
+ledger (1 entries)
+  #0   ROOT        trajectory bound  "Map the repo and summarize the runtime"
+
+replay
+  [integrity] verified
+  commits replayed:   0
+  rejected proposals: 0
+  head sequence:      0
+  final world hash:   f4cfe8821990755fea8de29b9ce6d107875717dea5f2886aa59f779d651544a8
+
+result: 0 commits, 0 rejections — replay verified
+```
+
+This proves the audit + replay machinery works end to end on a real append-only
+ledger: the trajectory is content-addressed, the chain integrity is verified,
+and a world hash is reproduced by folding.
+
+**Why the trail is short (honest caveat):** no provider key was set, so
+`/health` reported `cognition_live: false` and the bundled cognition is the
+deterministic mock. The server's mock is constructed with an **empty intent
+script**
+([`cognition/lib.rs:335`](../../thymos/crates/thymos-cognition/src/lib.rs#L335)),
+so it proposes nothing and the run commits nothing — hence ROOT-only. A
+commit-bearing, gate-firing trail (commits + a rejection + an irreversible
+approval suspension) requires a real model: run the gated live path
+(`ANTHROPIC_API_KEY=… cargo test -p thymos-runtime --test live_provider --
+--ignored --nocapture`) or drive `thymos run` with a key set.
+
+## Honest trust boundaries
+
+Control means *no action without a signed, scoped, policy-checked grant* — proven
+above. It does **not** mean the following are guaranteed; these are the residual
+trust assumptions:
+
+- **A tool self-declares its `effect_class`.** The ceiling check (gate 5b) trusts
+  that an `Irreversible` tool isn't mislabeled `Read`. A malicious/buggy tool
+  that lies about its effect class would slip under the ceiling. The root of
+  trust for tool honesty is **signed manifests + the marketplace**, not the
+  compiler.
+- **Whoever holds the writ signing key holds the authority.** Key custody is the
+  operator's responsibility.
+- **Policy is only as strong as the loaded policy set**, and approval gates are
+  only as strong as the humans clearing them.
+- **Default cognition is the mock** unless a key is set — "it responded" locally
+  may be the deterministic mock, not a real model (`/health` →
+  `cognition_live`).
+- **Replay verifies the *record* is intact and consistent; it does not
+  re-execute tools.** It trusts the observation committed at run time. Tampering
+  and drift are caught; a tool that did something unexpected *at execution time*
+  is caught only to the extent its postconditions / effect class describe it.
+
+## How to reproduce
+
+```bash
+cd thymos
+# Enforcement (no secrets):
+cargo test -p thymos-runtime --test compiler_rejection --test revocation \
+  --test cognition_budget --test redaction --test replay_safety --test quorum
+
+# Live audit tooling (no secrets; ROOT-only trail under the mock):
+THYMOS_LEDGER_PATH=/tmp/thymos-audit-demo.db ./target/debug/thymos-server &
+./target/debug/thymos run "Map the repo and summarize the runtime" --follow
+./target/debug/thymos runs ls                 # copy the full run id
+./target/debug/thymos audit <run-id>
+
+# Commit-bearing trail (needs a key):
+ANTHROPIC_API_KEY=sk-ant-… ./target/debug/thymos-server &
+ANTHROPIC_API_KEY=sk-ant-… ./target/debug/thymos run "…" --follow
+./target/debug/thymos audit <run-id>
+```

--- a/docs/rfcs/desktop-app.md
+++ b/docs/rfcs/desktop-app.md
@@ -1,0 +1,211 @@
+# Design: OpenThymos Desktop
+
+Status: **Draft / design** · Scope: a downloadable, consumer-installable desktop
+app — "one place to install OpenThymos" for people who will never open a
+terminal. Like every surface in
+[UI Surfaces & Programmability](ui-surfaces-and-programmability.md), the desktop
+app is a **client**: it observes the ledger and *proposes* runs through the
+existing HTTP/SSE API. It changes **nothing** in the runtime. The runtime stays
+the single source of truth; the app only starts work, watches verdicts, and
+clears gates.
+
+This RFC follows the design style of the UI-surfaces RFC rather than the
+protocol template, because there are **no ledger, replay, writ, or policy
+changes** here — it is packaging and a GUI over surfaces that already exist.
+
+---
+
+## 0. The one rule the GUI must not break
+
+> **Cognition proposes. The runtime governs. The ledger records.**
+
+A pretty desktop app is the easiest place to accidentally blur that line — to
+let a button "just do the thing" outside the `Intent → Proposal → Commit`
+pipeline. It must not. Concretely:
+
+- The app **never** executes a tool, mutates world state, or spends budget
+  itself. It only calls `POST /runs`, streams `/execution/stream`, and clears
+  gates via `POST /runs/:id/approvals/:channel`.
+- Every screen that shows an action shows its **verdict** (`permit` / `deny` /
+  `require-approval`), its **writ**, and a path to the **ledger** + **replay ✓**.
+  If a screen hides the boundary, it is off-brand and wrong.
+- **No phone-home.** The app ships with zero analytics/telemetry beacons
+  (CLAUDE.md core value). The only network egress is (a) to the local runtime it
+  manages, and (b) to the LLM provider the *user* configured, with the *user's*
+  key, read server-side.
+
+---
+
+## 1. Why a desktop app at all (and why Tauri)
+
+The CLI, TUI, and VS Code surfaces all assume a developer. "Normal people" — an
+auditor, a compliance reviewer, a solo operator, someone evaluating the project
+— need **install → open → it works**, with no `cargo`, no `$ANTHROPIC_API_KEY`,
+no `docker run`.
+
+**Tauri** (chosen): a Rust host process + a system-webview UI.
+
+- The Rust side **embeds or supervises `thymos-server`** in-process / as a child,
+  so the app *is* the runtime — no separate install step. (`thymos-client` and
+  `thymos-server` are already libraries; the app links them.)
+- Tiny native installers (`.dmg` / `.msi` / `.AppImage`, ~10MB) → a **real
+  download**, signable and notarizable.
+- The webview reuses the same render model as the VS Code audit webview and the
+  planned web operator surface — one UI codebase across three surfaces.
+- Matches the project's Rust + governance ethos; no 100MB Electron runtime.
+
+Rejected: **Electron** (shares more TS with the web surface but ~100MB bundles,
+HTTP-only to the runtime, heavier egress surface); **a hosted web app only**
+(no "install once, runs locally, your keys never leave your box" story, which is
+the whole point for the privacy-conscious audience).
+
+---
+
+## 2. Feature map — what's real now vs. what needs a backend
+
+The request named eleven things. **Honesty is the credibility signal** (CLAUDE.md):
+some are wired today; several are *not built in the runtime at all* and must not
+ship as buttons-over-nothing. This table is the contract.
+
+| Requested feature | Backend reality today | Verdict for v1 |
+|---|---|---|
+| **One place to install** | `thymos-server` + `thymos-client` are libs; release.yml builds per-OS binaries | **v1** — Tauri bundles + supervises the server |
+| **Provider setup** | Real: preset registry (`thymos_cognition::presets`, ~20 providers), key auto-detect, `GET /health` → `cognition_live`, `thymos providers` | **v1** — GUI key entry + provider picker → server env |
+| **Chat sessions** | Real: `POST /runs`, `GET /runs/:id/execution/stream` (SSE), `GET /runs`, `cancel`/`resume`. A "session" = a run/trajectory | **v1** — chat = a governed run, streamed |
+| **Tools** | Real: typed tool contracts, sandboxed `shell`/`http`/`fs_*`/`test_run`/`mcp_bridge`, marketplace API (`/marketplace/*`) | **v1 (read/browse + scope picker)**; install-from-marketplace **v1.1** |
+| **Logs** | Real: `/runs/:id/events`, `/audit/entries`, `/replay`, world projection | **v1** — event log + audit trail + replay badge |
+| **Backups** | Partial: ledger is a SQLite file; `verify_integrity` exists. No export command/UI | **v1 (thin)** — copy DB + run integrity check; restore = point at a file |
+| **Profile switching** | **Not a backend concept.** Tenant scoping exists on writs; no "profile" object | **v1 (local-only)**; durable profiles need backend → §4 |
+| **Scheduling** | **Not built.** No scheduler; runs are one-shot | **Deferred** → needs `thymos-schedule` (§4). Stub UI must say "not yet". |
+| **Message gateways** | **Partial/ambiguous.** There is an *API-key gateway* (`/usage`, `thymos-gateway.db`); inbound chat gateways (Slack/Telegram/email) are **not built** | **Deferred** → §4. Do **not** imply Slack/email works. |
+| **Memory management** | **Not built.** Per-run world projection exists; no cross-session memory store | **Deferred** → needs `thymos-memory` (§4) |
+| **Skills** | **Not built** as a runtime concept (distinct from tools/marketplace packages) | **Deferred** → needs a definition + backend (§4) |
+
+**The rule:** a feature is in the v1 UI **only** if it maps to a real endpoint
+above. Deferred features get a single honest "Coming soon — tracked in
+`desktop-app.md` §4" placeholder, never a dead button that pretends to work.
+
+---
+
+## 3. v1 — what ships first (all real today)
+
+A five-tab app, every tab a thin client of an existing endpoint:
+
+```
+┌ OPEN THYMOS ─────────────────────────── ●live  anthropic  ledger:sqlite ┐
+│ ◆ Chat   ▸ Runs   ⚙ Providers   🧰 Tools   📜 Audit                       │
+├──────────────────────────────────────────────────────────────────────────┤
+│  you ▸ "summarize the repo and open a PR"                                  │
+│  ◆ intent   grep "fn main"                                                 │
+│  ▸ permit   [WritAuthority]  writ ab12…   budget 12k/100k ▓▓░░░            │
+│  ✓ commit   grep → world c9f2…   14ms                                      │
+│  ⏸ approval "irreversible: git push"        [ Approve ]  [ Deny ]          │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+1. **First-run setup** — pick a provider, paste a key (or "use mock — no key,
+   deterministic"). Writes to the supervised server's env; `GET /health` confirms
+   `cognition_live`. This is "provider setup," done once.
+2. **Chat** — a message starts a run (`POST /runs`); the reply *is* the streamed
+   governance feed (intents, verdicts, commits). Suspended `⏸` proposals render
+   inline **Approve/Deny** (`POST .../approvals/:channel`). This is the product:
+   you watch authority being spent, and you authorize the risky steps.
+3. **Runs** — history (`GET /runs`), status glyphs, cancel/resume, open in Audit.
+4. **Providers** — the preset list + which key is set + live/mock badge.
+5. **Tools** — browse governed tool contracts + the marketplace catalog
+   (read-only v1); show each tool's effect class so the writ scope picker is
+   honest.
+6. **Audit** — the existing audit render (commit chain, rejections, delegations,
+   policy decision per commit) + **replay verdict badge**. Reuses the VS Code
+   webview render model.
+7. **Backups (thin)** — "Back up ledger" copies the SQLite file to a chosen
+   location and runs `verify_integrity`, reporting the chain head + entry count;
+   "Restore" points the runtime at a chosen ledger file. No new ledger semantics.
+
+Zero server changes are required for everything in §3 (same conclusion the
+UI-surfaces RFC reached for its v1).
+
+---
+
+## 4. Deferred features — each needs a real backend first
+
+These are the requested features that **do not exist** and therefore must not
+ship as working UI. Each is a small RFC of its own; listing the shape so the
+desktop roadmap is honest:
+
+- **`thymos-schedule`** — a scheduler that fires `POST /runs` on a cron/interval
+  under a *named, scoped writ*. The schedule itself should be a ledger-recorded
+  object so "why did the agent run at 3am" is auditable. Until this exists, the
+  Scheduling tab is a labeled placeholder.
+- **Message gateways (inbound)** — Slack/Telegram/email/webhook adapters that
+  turn an inbound message into a governed run and stream the verdict back. The
+  *API-key gateway* (`/usage`) is unrelated plumbing; do not conflate. Needs its
+  own RFC (auth, per-channel writs, rate limits, no silent egress).
+- **`thymos-memory`** — a cross-session memory store the agent can *propose*
+  reads/writes against, governed like any other effect (memory writes are
+  commits; reads are tool calls under scope). Per-run world projection is **not**
+  this. Must preserve replay determinism.
+- **Skills** — needs a definition distinct from tools/marketplace packages
+  (likely: a signed bundle of a system prompt + tool scopes + policy defaults).
+  Until defined, "Skills" is not in the UI.
+- **Durable profiles** — a profile = (provider + default model + default writ
+  scopes + tenant + ledger path). v1 can keep these **local to the app** (a
+  config file the app owns); a server-side profile/tenant object is a later RFC
+  if profiles need to be shared or enforced server-side.
+
+Sequencing recommendation: ship §3 (all real), then `thymos-schedule` (highest
+"normal person" value, smallest backend), then `thymos-memory`, then inbound
+gateways, then skills.
+
+---
+
+## 5. The download story (honest, no vaporware)
+
+CLAUDE.md: **never vaporware.** A "Download" button in the README must point at a
+real artifact or not exist. Plan:
+
+1. Add a `thymos-desktop` Tauri crate/app under `clients/desktop` (Rust host +
+   webview UI), supervising `thymos-server`.
+2. Extend `.github/workflows/release.yml` (already tag-driven, already builds
+   linux/macOS/windows binaries) with a Tauri bundle job that produces
+   `.dmg` / `.msi` / `.AppImage` and attaches them to the **GitHub Release**.
+   Code-signing/notarization is a prerequisite for a frictionless macOS/Windows
+   install and is its own task (needs signing certs as CI secrets).
+3. **Only after** the first tagged release carries those assets, add a
+   **Download** section to `README.md` linking to
+   `releases/latest` (per-OS). Until then: no button, or a clearly-labeled
+   "desktop app — in progress, see `docs/rfcs/desktop-app.md`" line. A dead
+   download link is exactly the credibility hit this project refuses to take.
+4. `STATUS.md` gets a row: desktop app = *scaffolded / unreleased* until assets
+   ship, then *released vX.Y.Z*. The README and STATUS must not claim a download
+   that the Releases page can't back.
+
+---
+
+## 6. Invariants (don't regress)
+
+- The app is a **read-and-propose client**; it never executes effects, mutates
+  projected state, or spends budget outside the runtime's pipeline.
+- **No phone-home / no silent egress.** No analytics. Egress is only to the
+  user's local runtime and the user's chosen provider with the user's key.
+- Replay is unaffected: the app produces no ledger entries of its own and never
+  re-runs a tool or calls a provider on the replay path.
+- A v1 UI element exists **only** if it maps to a live endpoint in §2; deferred
+  features are labeled placeholders, never functional-looking dead ends.
+- The **README/STATUS download claim tracks the Releases page** exactly.
+
+---
+
+## 7. Unresolved questions
+
+- **Server lifecycle:** embed `thymos-server` in-process vs. supervise it as a
+  child binary the installer also ships? (Child binary = reuse release.yml
+  artifacts + crash isolation; in-process = one binary, simpler.)
+- **Signing/notarization:** whose certs, stored as which CI secrets? Without
+  this, macOS Gatekeeper / Windows SmartScreen make "normal people install" rough.
+- **Ledger location & multi-profile storage** on a desktop (one SQLite file per
+  profile under the app data dir?).
+- **Provider keys at rest:** OS keychain (Keychain / Credential Manager /
+  libsecret) vs. the server's existing server-side env handling.
+- Reuse the marketing three.js ledger-DAG scene in the Audit tab, or a lighter
+  2D graph (same open question as the web surface)?

--- a/docs/rfcs/ui-surfaces-and-programmability.md
+++ b/docs/rfcs/ui-surfaces-and-programmability.md
@@ -1,0 +1,202 @@
+# Design: UI Surfaces & Programmability
+
+Status: **Draft / design** · Scope: how humans *and* machines drive and observe
+OpenThymos. Nothing here changes the runtime — every surface is a **client** of
+the existing HTTP/SSE API and the ledger. The runtime stays the single source of
+truth; surfaces only *observe* and *propose*.
+
+---
+
+## 0. The one idea every surface must show
+
+OpenThymos is not "another agent runner." Its differentiator is **governance you
+can watch and prove**. So every surface is organized around the same spine:
+
+```
+Intent ──▶ Proposal ──▶ [ permit | deny | require-approval ] ──▶ Commit ──▶ Ledger ──▶ Replay ✓
+                              the boundary, visible
+```
+
+A generic agent UI shows "the agent did things." A *Thymos* UI shows **what was
+proposed, what the runtime allowed and why, what it refused, and proof the record
+is intact.** If a screen doesn't surface a verdict, a writ, or the ledger, it's
+off-brand.
+
+Shared visual language (already live in the CLI, reuse everywhere):
+`◆ Intent` · `▸ Proposal` · `✓ Commit` (green) · `✕ Rejected` (red) ·
+`⏸ Suspended` (amber) · violet brand, star-cyan accents.
+
+---
+
+## 1. Data sources (what every surface reads)
+
+All three surfaces are built from endpoints that already exist:
+
+| Need | Endpoint |
+|------|----------|
+| Liveness · live-vs-mock · ledger backend | `GET /health` |
+| Create work | `POST /runs` |
+| Operator-truth run state | `GET /runs/:id/execution` |
+| **Live updates** | `GET /runs/:id/execution/stream` (SSE) |
+| Ledger entries (the trail) | `GET /audit/entries?run_id=` |
+| Verify + fold | `GET /runs/:id/replay` |
+| World projection | `GET /runs/:id/world` |
+| Clear a gate | `POST /runs/:id/approvals/:channel` |
+| Run history | `GET /runs` |
+
+No surface needs new server work to reach **v1**. (The one fix that unblocked
+live UIs — the execution SSE stream closing on terminal status — is already in.)
+
+---
+
+## 2. Surface A — TUI governance cockpit (`thymos watch`)
+
+The most on-brand surface for a CLI-first runtime, and the cheapest to build
+(ratatui + the SSE client we already have). A full-screen, live cockpit.
+
+```
+┌ OPEN THYMOS ── watch ────────────────────────── ●live  anthropic  ledger:sqlite ┐
+│ RUNS                          │ run 9e88… · "map the repo and summarize"         │
+│ ▸ 9e88  ✓ commit  step 4/16   │ ◆ intent    step4  grep "fn main"               │
+│   a17c  ⏸ approval ops        │ ▸ proposal  permit  [WritAuthority]  writ ab12…  │
+│   4f01  ✓ done   12 commits   │ ✓ commit    grep    14ms  → world c9f2…          │
+│   2bd0  ✕ failed              │ ▸ proposal  DENY    effect ceiling: External>RW  │
+│                               │ ⏸ proposal  approval ops "irreversible: delete"  │
+│ ─ writ ────────────────────── │ ───────────────────────────────────────────────│
+│ budget  tok 12k/100k  ▓▓░░░   │ [a]pprove  [d]eny  [enter] audit  [w] world      │
+│ scopes  fs_read grep kv_*     │ commits 4  rejections 1  pending 1               │
+└───────────────────────────────┴─────────────────────────────────────────────────┘
+```
+
+- **Left:** run list (live status glyphs) + the selected run's **writ** — budget
+  burn-down bars, granted scopes, effect ceiling. *This is the unique panel:* you
+  watch authority being spent.
+- **Right:** the live governance feed (the SSE snapshots), each line a verdict.
+- **Inline action:** `a`/`d` resolves a suspended proposal via the approvals
+  endpoint — human-in-the-loop without leaving the terminal.
+- **`enter`** drops into the existing `thymos audit` render for the run.
+
+Build: new `thymos-tui` crate (or `thymos watch` behind a feature), ~1 screen,
+reuses `thymos-client` + the SSE stream. No server changes.
+
+---
+
+## 3. Surface B — VS Code sidebar (grow `clients/vscode`)
+
+For developers who live in the editor. A `thymos` activity-bar view with three
+tree sections + one webview.
+
+```
+THYMOS ▾
+├─ ● runtime   localhost:3001 · anthropic · sqlite
+├─ RUNS
+│  ├─ ✓ map the repo…            9e88  4 commits
+│  ├─ ⏸ deploy staging           a17c  needs: ops ▸ [Approve] [Deny]
+│  └─ ✕ refactor auth            2bd0
+├─ THIS RUN  (selected)
+│  ├─ ◆ intent  grep "fn main"
+│  ├─ ▸ permit  [WritAuthority]
+│  ├─ ✓ commit  grep → c9f2…
+│  └─ ✕ deny    effect ceiling
+└─ [ Open Audit ]  [ New Run… ]
+```
+
+- **Approve/Deny as inline tree buttons** on suspended runs — the killer editor
+  feature (review an agent's risky action without context-switching).
+- **`fs_patch` commits** can offer "Open Diff" against the workspace file.
+- **Audit** opens a webview rendering the same governance trail (reuse the render
+  model) with the replay verdict badge.
+- **CodeLens (stretch):** above a function the agent touched, "governed by writ
+  ab12 · committed c9f2 · replay ✓".
+
+Build: TypeScript extension using the SSE stream; the webview reuses the audit
+render. No server changes; this is the surface with the most product leverage.
+
+---
+
+## 4. Surface C — Web operator overview
+
+For operators / reviewers who aren't in a terminal, and for **sharing** a run.
+
+```
+OPEN THYMOS · operator
+┌ fleet ───────────────────────────────────────────────────────────┐
+│ runs today 142   commits 1.2k   rejections 38   pending 3 ⏸       │
+│ providers: anthropic ●  openai ●  ollama ●        ledger: postgres │
+├ timeline ─────────────────────────────────────────────────────────┤
+│ ▸▸✓✓✕▸✓⏸✓✓✓✕✓  (governance events, color = verdict)              │
+├ run drill-down ───────────────────────────────────────────────────┤
+│ writ · budget · scopes  │  ledger DAG  │  replay: verified ✓        │
+└───────────────────────────────────────────────────────────────────┘
+```
+
+- **Fleet view:** aggregate verdict counters, provider health, ledger backend.
+- **Governance timeline:** a scrub-able stream of verdicts across all runs — the
+  "what is my agent fleet allowed to do, and what did it try" board.
+- **Run drill-down:** writ + ledger DAG (the 3D motif from the marketing site,
+  reused as a real ledger graph) + replay status.
+- **Approvals queue:** a shared inbox of `⏸` proposals for a team to clear.
+
+Build: served from `thymos-server` (or a static SPA hitting the API). Heaviest of
+the three; do it after the TUI proves the data model.
+
+---
+
+## 5. Recommended sequence
+
+1. **TUI `thymos watch`** — cheapest, most on-brand, proves the live data model.
+2. **VS Code sidebar** — highest product leverage (inline approvals where devs work).
+3. **Web overview** — operators + sharing, once the model is proven.
+
+Each is independently shippable and adds zero runtime risk (read-only clients +
+the existing approvals endpoint).
+
+---
+
+## 6. Programmability — machines *and* people
+
+> "Can we make this machine-programmable to take real action, usable by machines
+> or with people?" — yes; here's the surface area, all of it already present.
+
+**Machines drive it three ways:**
+
+- **HTTP/SSE API** — `POST /runs` to start work, consume `/execution/stream` for
+  live state, `GET /replay` for proof. Any service/agent/cron can drive a governed
+  run and get back a verifiable trail. This is the integration boundary.
+- **CLI as a scriptable tool** — every command is pipe-friendly and TTY-aware
+  (clean plain output when piped). `Run started: <id>` is a stable parse line.
+- **Rust SDK** — `thymos-client` for in-process embedding.
+
+**The agent takes real-world action through governed tools** (`thymos tools`):
+
+- `shell` (run commands) · `http` (call any API) · `fs_read`/`fs_patch` (edit
+  files) · `test_run` · and **`mcp_bridge`** — connect *any* MCP server, which
+  opens the entire MCP ecosystem (databases, browsers, SaaS, cloud) as governed
+  tools. Custom tools arrive via signed **manifests** + the marketplace.
+- Every call is checked against the writ's **effect ceiling**
+  (`Read ≤ Write ≤ External ≤ Irreversible`) *before* it runs — so "real-world
+  power" is always bounded by an explicit, signed grant.
+
+**People stay in the loop by design:**
+
+- **Approval gates** — `Irreversible`-class (or policy-flagged) proposals
+  *suspend* and wait for a human via `POST /runs/:id/approvals/:channel` (the
+  approve/deny in every surface above). M-of-N quorum is supported.
+- **Audit for humans** — `thymos audit` / the webview render the whole trail in
+  human terms: what was done, under whose authority, which policy decided it.
+
+**Machines + people together:** an automated system starts a run; the agent
+proposes a wire transfer / a prod deploy / a destructive migration; the runtime
+**suspends** it; a person approves in the TUI, the sidebar, or the web queue; the
+ledger records who approved, when, and the replayable result. That hand-off —
+autonomous proposal, human authorization, provable record — is the product.
+
+---
+
+## 7. Open questions
+
+- Auth model for the web surface (the API key gateway exists; SSO for operators?).
+- Ledger-DAG rendering: reuse the marketing three.js scene as a real graph, or a
+  lighter 2D view for the operator board?
+- TUI: standalone `thymos-tui` crate vs. `thymos watch` subcommand behind a
+  feature flag (leaning subcommand for discoverability).

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -1,0 +1,53 @@
+# Homebrew tap setup
+
+Goal: `brew install gryszzz/tap/thymos` installs the `thymos` CLI + `thymos-server`
+from the published GitHub release binaries — no Rust, no compile.
+
+Homebrew taps are a **separate repo** named `homebrew-<name>`. Two one-time steps,
+then it stays current automatically.
+
+## 1. Create the tap repo + seed the formula (works immediately)
+
+```bash
+# create the tap repo (public)
+gh repo create gryszzz/homebrew-tap --public \
+  --description "Homebrew tap for OpenThymos"
+
+# seed it with the verified v0.5.0 formula from this repo
+git clone https://github.com/gryszzz/homebrew-tap.git /tmp/homebrew-tap
+mkdir -p /tmp/homebrew-tap/Formula
+cp packaging/homebrew/thymos.rb /tmp/homebrew-tap/Formula/thymos.rb
+cd /tmp/homebrew-tap
+git add Formula/thymos.rb && git commit -m "thymos v0.5.0" && git push
+```
+
+Now anyone can:
+
+```bash
+brew install gryszzz/tap/thymos
+thymos doctor
+```
+
+`thymos.rb` here is pinned to **v0.5.0 with real sha256 sums**, so install works
+the moment it lands in the tap — you do not need to cut a new release first.
+
+## 2. Keep it current automatically (optional)
+
+Add a `HOMEBREW_TAP_TOKEN` secret to the **open-thymos** repo: a PAT (or
+fine-grained token) with **write access to `gryszzz/homebrew-tap`**.
+
+```bash
+gh secret set HOMEBREW_TAP_TOKEN --repo gryszzz/open-thymos
+# paste the token when prompted
+```
+
+After that, the `homebrew` job in `.github/workflows/release.yml` regenerates
+`Formula/thymos.rb` from the release tarballs on every `vX.Y.Z` tag. Without the
+secret that job is a clean no-op, so nothing breaks until you opt in.
+
+## Notes
+
+- The formula installs prebuilt binaries (a "bottle"-less binary formula); it
+  does not compile from source, matching `scripts/get.sh`.
+- macOS Apple Silicon + Intel and Linux x86_64 are covered. Windows users use the
+  `.msi` (once the desktop job ships) or `scoop`/direct download.

--- a/packaging/homebrew/thymos.rb
+++ b/packaging/homebrew/thymos.rb
@@ -1,0 +1,35 @@
+# OpenThymos Homebrew formula.
+#
+# This is the SEED formula for the tap repo (<owner>/homebrew-tap). It is pinned
+# to v0.5.0 with real sha256 sums so `brew install <owner>/tap/thymos` works the
+# moment you drop it into the tap — no new release needed. After that, the
+# `homebrew` job in .github/workflows/release.yml regenerates it on every tag.
+class Thymos < Formula
+  desc "Governed-cognition runtime — Intent → Proposal → Commit"
+  homepage "https://github.com/gryszzz/open-thymos"
+  version "0.5.0"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/gryszzz/open-thymos/releases/download/v0.5.0/thymos-v0.5.0-aarch64-apple-darwin.tar.gz"
+      sha256 "e6ac0cb0b6e8306da251dae99c06d0bb72817b6650375c9a49e36ac020694a23"
+    end
+    on_intel do
+      url "https://github.com/gryszzz/open-thymos/releases/download/v0.5.0/thymos-v0.5.0-x86_64-apple-darwin.tar.gz"
+      sha256 "a56c92564019e1f5fb1598376d03dbf25cf5734ebab0e6ec98550d6182f798fd"
+    end
+  end
+
+  on_linux do
+    url "https://github.com/gryszzz/open-thymos/releases/download/v0.5.0/thymos-v0.5.0-x86_64-unknown-linux-gnu.tar.gz"
+    sha256 "dcecba4a00358cc8c135417292ff880b143c156a7bc525dc66b2b7a2e748ae23"
+  end
+
+  def install
+    bin.install "thymos", "thymos-server"
+  end
+
+  test do
+    system "#{bin}/thymos", "--help"
+  end
+end

--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env sh
+# OpenThymos prebuilt installer — no Rust, no clone, no compile.
+#
+#   curl -fsSL https://raw.githubusercontent.com/gryszzz/open-thymos/main/scripts/get.sh | sh
+#
+# Downloads the right prebuilt `thymos` + `thymos-server` for your OS/arch from
+# the GitHub Release that .github/workflows/release.yml publishes, and installs
+# them to ~/.local/bin (override with THYMOS_INSTALL_PREFIX).
+#
+# Pin a version:  THYMOS_VERSION=v0.5.0 sh get.sh
+#
+# Privacy: this fetches ONLY from github.com (the release assets). No telemetry,
+# no phone-home — same posture as the runtime itself.
+set -eu
+
+REPO="${THYMOS_REPO:-gryszzz/open-thymos}"
+PREFIX="${THYMOS_INSTALL_PREFIX:-$HOME/.local}"
+BIN_DIR="$PREFIX/bin"
+
+blue='\033[38;2;124;92;255m'; green='\033[38;2;70;211;154m'
+dim='\033[2m'; bold='\033[1m'; reset='\033[0m'
+if [ -n "${NO_COLOR:-}" ] || [ "${TERM:-}" = "dumb" ] || [ ! -t 1 ]; then
+  blue=''; green=''; dim=''; bold=''; reset=''
+fi
+say() { printf '%b\n' "$1"; }
+die() { printf '%b\n' "error: $1" >&2; exit 1; }
+
+command -v curl >/dev/null 2>&1 || die "curl is required."
+command -v tar  >/dev/null 2>&1 || die "tar is required."
+
+# --- detect target triple (must match release.yml's matrix) ---
+os="$(uname -s)"; arch="$(uname -m)"
+case "$os" in
+  Darwin)
+    case "$arch" in
+      arm64|aarch64) target="aarch64-apple-darwin" ;;
+      x86_64)        target="x86_64-apple-darwin" ;;
+      *) die "unsupported macOS arch: $arch" ;;
+    esac ;;
+  Linux)
+    case "$arch" in
+      x86_64) target="x86_64-unknown-linux-gnu" ;;
+      *) die "unsupported Linux arch: $arch (build from source, or open an issue for a $arch release)" ;;
+    esac ;;
+  MINGW*|MSYS*|CYGWIN*)
+    die "On Windows use the .msi installer from the Releases page (or Scoop), not this script." ;;
+  *) die "unsupported OS: $os" ;;
+esac
+
+# --- resolve version (default: latest published release) ---
+ver="${THYMOS_VERSION:-}"
+if [ -z "$ver" ]; then
+  # Follow the /releases/latest redirect; the final URL ends in the tag.
+  latest_url="$(curl -fsSLI -o /dev/null -w '%{url_effective}' \
+    "https://github.com/$REPO/releases/latest" 2>/dev/null || true)"
+  ver="${latest_url##*/tag/}"
+  case "$ver" in
+    v*) : ;;
+    *) die "no published release found for $REPO yet.
+   The runtime is real, but binaries ship with the first tagged release.
+   Until then: build from source — https://github.com/$REPO#quick-start" ;;
+  esac
+fi
+
+asset="thymos-${ver}-${target}.tar.gz"
+url="https://github.com/$REPO/releases/download/${ver}/${asset}"
+
+say "${blue}${bold}OpenThymos${reset} ${dim}prebuilt installer${reset}"
+say "${dim}target${reset}   $target"
+say "${dim}version${reset}  $ver"
+say "${dim}prefix${reset}   $PREFIX"
+printf '\n'
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+say "downloading ${dim}$url${reset}"
+curl -fSL --proto '=https' --tlsv1.2 "$url" -o "$tmp/$asset" \
+  || die "download failed. Asset for $target may not exist in $ver — check https://github.com/$REPO/releases/$ver"
+tar -xzf "$tmp/$asset" -C "$tmp"
+
+mkdir -p "$BIN_DIR"
+for b in thymos thymos-server; do
+  [ -f "$tmp/$b" ] || die "archive missing $b (unexpected release layout)"
+  install -m 0755 "$tmp/$b" "$BIN_DIR/$b"
+done
+
+say "\n${green}${bold}Installed${reset}"
+say "  $BIN_DIR/thymos"
+say "  $BIN_DIR/thymos-server"
+
+case ":$PATH:" in
+  *":$BIN_DIR:"*) ;;
+  *) say "\n${blue}${bold}Add to PATH${reset}"
+     say "  export PATH=\"$BIN_DIR:\$PATH\"   ${dim}# add to your shell rc${reset}" ;;
+esac
+
+say "\n${blue}${bold}Next${reset}"
+say "  thymos-server &     ${dim}# start the runtime (mock until you set a provider key)${reset}"
+say "  thymos doctor       ${dim}# check readiness${reset}"
+say "  thymos shell        ${dim}# interactive governed shell${reset}"

--- a/thymos/clients/desktop/.gitignore
+++ b/thymos/clients/desktop/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+src-tauri/target/
+src-tauri/gen/
+# Generated icons (run `npm run icon` to regenerate from thymosG.PNG)
+src-tauri/icons/*.png
+src-tauri/icons/*.icns
+src-tauri/icons/*.ico

--- a/thymos/clients/desktop/README.md
+++ b/thymos/clients/desktop/README.md
@@ -1,0 +1,64 @@
+# OpenThymos Desktop
+
+A downloadable, install-once desktop app for OpenThymos — for people who will
+never open a terminal. It is a **client** of the governed-cognition runtime: it
+supervises a local `thymos-server`, starts chat sessions as governed runs, and
+shows every proposal, verdict, commit, and replay-verification result.
+
+> **It cannot bypass the boundary.** The app never executes a tool, mutates
+> world state, or spends budget — all of that stays inside the runtime's
+> `Intent → Proposal → Commit` pipeline. The only network egress is to the local
+> runtime and (server-side) the provider *you* configured. **No phone-home, no
+> analytics.** See [`docs/rfcs/desktop-app.md`](../../../docs/rfcs/desktop-app.md).
+
+## Architecture
+
+- **`src-tauri/`** — the Tauri (Rust) host. It supervises a `thymos-server`
+  child process (a bundled sidecar in release builds, or `thymos-server` on
+  `PATH` in dev) and exposes `start_runtime` / `stop_runtime` / `runtime_running`
+  / `runtime_addr` commands. It does no governance itself.
+- **`src/`** — the webview UI (plain HTML/CSS/JS, no build step, so it's
+  inspectable). Tabs: **Chat** (a message = a governed run, streamed),
+  **Runs**, **Providers**, **Tools**, **Audit** (+ replay badge), **Backups**.
+  Every tab is a thin client of an endpoint that already exists.
+
+## Status (honest)
+
+- **v1 surfaces wired to real endpoints:** chat/runs, provider/health, tools
+  catalog, audit + replay, thin backups, local provider setup.
+- **Deferred (no backend yet, shown as labeled placeholders, never fake
+  buttons):** scheduling, inbound message gateways, memory, skills. See the RFC
+  §4.
+- **Not yet built/verified here:** this is a scaffold. It has **not** been
+  `cargo build`/`tauri build`-compiled in this environment (the Tauri toolchain
+  + crates were not fetched), and there is **no signed installer / download link
+  yet**. The README Download section lands only when the release pipeline
+  attaches real signed bundles.
+
+## Develop
+
+Prereqs: Rust, Node, and the [Tauri v2 system deps](https://tauri.app/start/prerequisites/).
+
+```bash
+# 1) Have a runtime binary on PATH for dev:
+cargo install --path ../../crates/thymos-server   # provides `thymos-server`
+
+# 2) Run the desktop app (hot-reloads the webview):
+cd clients/desktop
+npm install
+npm run icon            # generate icons from thymosG.PNG (first run)
+npm run dev
+```
+
+Start the runtime from the app's top bar, then send a task in **Chat**.
+
+## Build installers
+
+```bash
+npm run build           # -> src-tauri/target/release/bundle/{dmg,msi,appimage}
+```
+
+For a frictionless install on macOS/Windows these need **code-signing +
+notarization** (certs as CI secrets) — tracked alongside the release-pipeline
+work in the RFC §5. The tag-driven `.github/workflows/release.yml` is where the
+bundle job and Release-asset upload will be added.

--- a/thymos/clients/desktop/package.json
+++ b/thymos/clients/desktop/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "thymos-desktop",
+  "version": "0.5.0",
+  "private": true,
+  "description": "OpenThymos Desktop — governed-cognition runtime, install once.",
+  "scripts": {
+    "dev": "tauri dev",
+    "build": "tauri build",
+    "icon": "tauri icon ../../thymosG.PNG"
+  },
+  "devDependencies": {
+    "@tauri-apps/cli": "^2"
+  }
+}

--- a/thymos/clients/desktop/src-tauri/Cargo.toml
+++ b/thymos/clients/desktop/src-tauri/Cargo.toml
@@ -1,0 +1,27 @@
+# Standalone workspace: an empty [workspace] table makes this crate its own
+# workspace root so it is NOT pulled into ../../Cargo.toml (the runtime
+# workspace). `cargo build --workspace` in thymos/ never compiles Tauri.
+[workspace]
+
+[package]
+name = "thymos-desktop"
+version = "0.5.0"
+edition = "2021"
+license = "Apache-2.0"
+description = "OpenThymos Desktop — a governed-cognition client that supervises a local runtime."
+
+[lib]
+name = "thymos_desktop_lib"
+crate-type = ["staticlib", "cdylib", "rlib"]
+
+[build-dependencies]
+tauri-build = { version = "2", features = [] }
+
+[dependencies]
+tauri = { version = "2", features = [] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[features]
+# Tauri custom protocol assets in production builds.
+custom-protocol = ["tauri/custom-protocol"]

--- a/thymos/clients/desktop/src-tauri/build.rs
+++ b/thymos/clients/desktop/src-tauri/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    tauri_build::build()
+}

--- a/thymos/clients/desktop/src-tauri/icons/README.md
+++ b/thymos/clients/desktop/src-tauri/icons/README.md
@@ -1,0 +1,12 @@
+# App icons
+
+These are generated, not checked in. From `clients/desktop/`:
+
+```bash
+npm install
+npm run icon          # = tauri icon ../../thymosG.PNG
+```
+
+`tauri icon` produces every size the bundler needs (`32x32.png`,
+`128x128.png`, `128x128@2x.png`, `icon.icns`, `icon.ico`) into this directory.
+`tauri.conf.json` already references them.

--- a/thymos/clients/desktop/src-tauri/src/lib.rs
+++ b/thymos/clients/desktop/src-tauri/src/lib.rs
@@ -1,0 +1,115 @@
+//! OpenThymos Desktop — Tauri host process.
+//!
+//! Design rule (see `docs/rfcs/desktop-app.md`): this process is a **supervisor
+//! and a client**, never an executor. It starts/stops a local `thymos-server`
+//! child and the webview talks to that server over HTTP/SSE. It does **not**
+//! call tools, mutate world state, or spend budget — all of that stays inside
+//! the governed `Intent → Proposal → Commit` pipeline in the runtime. The only
+//! network egress is to the local runtime and (server-side) the provider the
+//! user configured. No analytics, no phone-home.
+
+use std::path::PathBuf;
+use std::process::{Child, Command};
+use std::sync::Mutex;
+
+use tauri::{Manager, State};
+
+/// Address the supervised runtime listens on. The webview's CSP only allows
+/// connections here (see `tauri.conf.json`).
+const RUNTIME_ADDR: &str = "http://127.0.0.1:3001";
+
+/// Holds the supervised `thymos-server` child, if running.
+#[derive(Default)]
+struct Supervisor(Mutex<Option<Child>>);
+
+/// Resolve the `thymos-server` binary. Prefer a sidecar shipped next to the app
+/// executable (what the bundler installs); fall back to the name on `PATH` for
+/// `cargo tauri dev` against a `cargo install`-ed server.
+fn server_binary() -> PathBuf {
+    let name = if cfg!(windows) {
+        "thymos-server.exe"
+    } else {
+        "thymos-server"
+    };
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(dir) = exe.parent() {
+            let sidecar = dir.join(name);
+            if sidecar.exists() {
+                return sidecar;
+            }
+        }
+    }
+    PathBuf::from(name)
+}
+
+#[tauri::command]
+fn runtime_addr() -> String {
+    RUNTIME_ADDR.to_string()
+}
+
+#[tauri::command]
+fn start_runtime(state: State<Supervisor>) -> Result<String, String> {
+    let mut guard = state.0.lock().map_err(|e| e.to_string())?;
+    if let Some(child) = guard.as_mut() {
+        // Already supervising — unless it has exited, report running.
+        match child.try_wait() {
+            Ok(Some(_)) => {} // exited; fall through and respawn
+            Ok(None) => return Ok("already-running".into()),
+            Err(e) => return Err(format!("status check failed: {e}")),
+        }
+    }
+    let bin = server_binary();
+    let child = Command::new(&bin)
+        .spawn()
+        .map_err(|e| format!("failed to start {}: {e}", bin.display()))?;
+    *guard = Some(child);
+    Ok("started".into())
+}
+
+#[tauri::command]
+fn stop_runtime(state: State<Supervisor>) -> Result<String, String> {
+    let mut guard = state.0.lock().map_err(|e| e.to_string())?;
+    if let Some(mut child) = guard.take() {
+        let _ = child.kill();
+        let _ = child.wait();
+        return Ok("stopped".into());
+    }
+    Ok("not-running".into())
+}
+
+#[tauri::command]
+fn runtime_running(state: State<Supervisor>) -> Result<bool, String> {
+    let mut guard = state.0.lock().map_err(|e| e.to_string())?;
+    let running = match guard.as_mut() {
+        Some(child) => matches!(child.try_wait(), Ok(None)),
+        None => false,
+    };
+    Ok(running)
+}
+
+#[cfg_attr(mobile, tauri::mobile_entry_point)]
+pub fn run() {
+    tauri::Builder::default()
+        .manage(Supervisor::default())
+        .invoke_handler(tauri::generate_handler![
+            runtime_addr,
+            start_runtime,
+            stop_runtime,
+            runtime_running
+        ])
+        .on_window_event(|window, event| {
+            // Don't orphan the runtime when the app window closes.
+            if let tauri::WindowEvent::Destroyed = event {
+                if let Some(state) = window.try_state::<Supervisor>() {
+                    if let Ok(mut guard) = state.0.lock() {
+                        if let Some(mut child) = guard.take() {
+                            let _ = child.kill();
+                            let _ = child.wait();
+                        }
+                    }
+                }
+            }
+        })
+        .run(tauri::generate_context!())
+        .expect("error while running OpenThymos Desktop");
+}

--- a/thymos/clients/desktop/src-tauri/src/main.rs
+++ b/thymos/clients/desktop/src-tauri/src/main.rs
@@ -1,0 +1,6 @@
+// Prevents an extra console window on Windows in release.
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
+fn main() {
+    thymos_desktop_lib::run()
+}

--- a/thymos/clients/desktop/src-tauri/tauri.conf.json
+++ b/thymos/clients/desktop/src-tauri/tauri.conf.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "productName": "OpenThymos",
+  "version": "0.5.0",
+  "identifier": "com.openthymos.desktop",
+  "build": {
+    "frontendDist": "../src"
+  },
+  "app": {
+    "withGlobalTauri": true,
+    "windows": [
+      {
+        "title": "OpenThymos",
+        "width": 1180,
+        "height": 800,
+        "minWidth": 900,
+        "minHeight": 600
+      }
+    ],
+    "security": {
+      "csp": "default-src 'self'; connect-src 'self' http://127.0.0.1:3001 http://localhost:3001; style-src 'self' 'unsafe-inline'"
+    }
+  },
+  "bundle": {
+    "active": true,
+    "targets": ["dmg", "msi", "appimage"],
+    "icon": [
+      "icons/32x32.png",
+      "icons/128x128.png",
+      "icons/128x128@2x.png",
+      "icons/icon.icns",
+      "icons/icon.ico"
+    ],
+    "longDescription": "OpenThymos Desktop is a read-and-propose client of the OpenThymos governed-cognition runtime. It supervises a local runtime, starts chat sessions as governed runs, and shows every proposal, verdict, commit, and replay-verification result. It never executes effects itself and never phones home.",
+    "shortDescription": "Governed-cognition runtime — install once, watch the boundary work."
+  }
+}

--- a/thymos/clients/desktop/src/index.html
+++ b/thymos/clients/desktop/src/index.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>OpenThymos</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <!-- Top bar: identity + the governance "is it live" truth from /health -->
+    <header class="topbar">
+      <div class="brand">◆ OPEN&nbsp;THYMOS</div>
+      <div class="status" id="status">
+        <span id="dot" class="dot dot-off"></span>
+        <span id="statusText">runtime: stopped</span>
+        <span id="provider" class="pill">provider: —</span>
+        <span id="ledger" class="pill">ledger: —</span>
+      </div>
+      <div class="controls">
+        <button id="startBtn">Start runtime</button>
+        <button id="stopBtn" class="ghost">Stop</button>
+      </div>
+    </header>
+
+    <nav class="tabs">
+      <button class="tab active" data-tab="chat">◆ Chat</button>
+      <button class="tab" data-tab="runs">▸ Runs</button>
+      <button class="tab" data-tab="providers">⚙ Providers</button>
+      <button class="tab" data-tab="tools">🧰 Tools</button>
+      <button class="tab" data-tab="audit">📜 Audit</button>
+      <button class="tab" data-tab="backups">💾 Backups</button>
+    </nav>
+
+    <main>
+      <!-- CHAT: a message starts a governed run; the reply IS the verdict feed -->
+      <section class="panel active" id="tab-chat">
+        <div class="feed" id="chatFeed">
+          <div class="hint">
+            Start the runtime, then send a task. Each message becomes a governed
+            run — you'll watch every <b>intent</b>, <b>verdict</b>, and
+            <b>commit</b>. Risky steps suspend for your approval.
+          </div>
+        </div>
+        <form class="composer" id="composer">
+          <input id="taskInput" autocomplete="off"
+            placeholder="e.g. summarize the repo and open a PR" />
+          <button type="submit">Send</button>
+        </form>
+      </section>
+
+      <!-- RUNS: history from GET /runs -->
+      <section class="panel" id="tab-runs">
+        <div class="panel-head">
+          <h2>Runs</h2>
+          <button class="ghost" id="refreshRuns">Refresh</button>
+        </div>
+        <div id="runsList" class="list"></div>
+      </section>
+
+      <!-- PROVIDERS: /health truth + how to set a key -->
+      <section class="panel" id="tab-providers">
+        <div class="panel-head"><h2>Providers</h2>
+          <button class="ghost" id="refreshHealth">Refresh</button></div>
+        <div id="providerCard" class="card"></div>
+        <p class="note">
+          Keys are read <b>server-side</b> — only the provider name crosses the
+          wire, and cognition gains no execution authority. Set
+          <code>ANTHROPIC_API_KEY</code> (or another provider's key) in the
+          environment the runtime starts in. With no key the runtime answers with
+          the deterministic <b>mock</b> — real governance, no real model.
+        </p>
+      </section>
+
+      <!-- TOOLS: marketplace catalog (read-only v1) -->
+      <section class="panel" id="tab-tools">
+        <div class="panel-head"><h2>Tools</h2>
+          <button class="ghost" id="refreshTools">Refresh</button></div>
+        <div id="toolsList" class="list"></div>
+        <p class="note">
+          Every tool call is checked against the writ's effect ceiling
+          (Read ≤ Write ≤ External ≤ Irreversible) <b>before</b> it runs.
+        </p>
+      </section>
+
+      <!-- AUDIT: ledger entries + replay verdict for a run -->
+      <section class="panel" id="tab-audit">
+        <div class="panel-head"><h2>Audit</h2></div>
+        <form id="auditForm" class="inline-form">
+          <input id="auditRunId" placeholder="run id" />
+          <button type="submit">Load trail</button>
+        </form>
+        <div id="replayBadge"></div>
+        <div id="auditTrail" class="list"></div>
+      </section>
+
+      <!-- BACKUPS: thin — explained honestly, no fake one-click yet -->
+      <section class="panel" id="tab-backups">
+        <div class="panel-head"><h2>Backups</h2></div>
+        <div class="card">
+          <p>
+            The ledger is a single content-addressed, hash-chained SQLite file.
+            A backup is a copy of that file; integrity is re-verifiable with
+            <code>thymos replay &lt;run&gt; --verify</code> or the runtime's
+            <code>verify_integrity</code>.
+          </p>
+          <p class="note">
+            One-click backup/restore + a chain-head integrity report is a v1
+            task wired to the runtime's file path — tracked in
+            <code>docs/rfcs/desktop-app.md §3</code>. Until then this tab tells
+            you the truth instead of pretending.
+          </p>
+        </div>
+      </section>
+    </main>
+
+    <script src="main.js"></script>
+  </body>
+</html>

--- a/thymos/clients/desktop/src/main.js
+++ b/thymos/clients/desktop/src/main.js
@@ -1,0 +1,292 @@
+// OpenThymos Desktop — webview client.
+//
+// This file ONLY observes and proposes: it calls the runtime's HTTP/SSE API.
+// It never executes effects. A chat message is a `POST /runs`; the "reply" is
+// the streamed governance feed (intents, verdicts, commits) from the runtime.
+// See docs/rfcs/desktop-app.md.
+
+const invoke = window.__TAURI__?.core?.invoke;
+
+// Resolve the runtime address from the Tauri host (falls back for browser dev).
+let BASE = "http://127.0.0.1:3001";
+async function resolveBase() {
+  try {
+    if (invoke) BASE = await invoke("runtime_addr");
+  } catch (_) {}
+}
+
+const $ = (id) => document.getElementById(id);
+const api = (path) => `${BASE}${path}`;
+
+async function getJSON(path) {
+  const r = await fetch(api(path));
+  if (!r.ok) throw new Error(`${r.status} ${path}`);
+  return r.json();
+}
+async function postJSON(path, body) {
+  const r = await fetch(api(path), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!r.ok) throw new Error(`${r.status} ${path}`);
+  return r.json().catch(() => ({}));
+}
+
+/* ---------- tabs ---------- */
+document.querySelectorAll(".tab").forEach((btn) => {
+  btn.addEventListener("click", () => {
+    document.querySelectorAll(".tab").forEach((b) => b.classList.remove("active"));
+    document.querySelectorAll(".panel").forEach((p) => p.classList.remove("active"));
+    btn.classList.add("active");
+    $(`tab-${btn.dataset.tab}`).classList.add("active");
+    if (btn.dataset.tab === "runs") loadRuns();
+    if (btn.dataset.tab === "providers") loadHealth();
+    if (btn.dataset.tab === "tools") loadTools();
+  });
+});
+
+/* ---------- runtime supervision + health ---------- */
+async function refreshStatus() {
+  let running = false;
+  try { running = invoke ? await invoke("runtime_running") : false; } catch (_) {}
+  let health = null;
+  try { health = await getJSON("/health"); } catch (_) {}
+  const up = !!health && health.status === "ok";
+  $("dot").className = "dot " + (up ? "dot-on" : "dot-off");
+  $("statusText").textContent = up
+    ? "runtime: live"
+    : running
+    ? "runtime: starting…"
+    : "runtime: stopped";
+  if (health) {
+    $("provider").textContent = `provider: ${health.default_provider}${
+      health.cognition_live ? "" : " (mock)"
+    }`;
+    $("ledger").textContent = `ledger: ${health.ledger}`;
+  }
+}
+
+$("startBtn").addEventListener("click", async () => {
+  try {
+    if (invoke) await invoke("start_runtime");
+    // Poll briefly until /health answers.
+    for (let i = 0; i < 20; i++) {
+      await new Promise((r) => setTimeout(r, 400));
+      await refreshStatus();
+      if ($("dot").classList.contains("dot-on")) break;
+    }
+  } catch (e) { alert("Could not start runtime: " + e); }
+});
+$("stopBtn").addEventListener("click", async () => {
+  try { if (invoke) await invoke("stop_runtime"); } catch (_) {}
+  await refreshStatus();
+});
+
+/* ---------- chat = a governed run ---------- */
+const feed = $("chatFeed");
+function pushLine(cls, text) {
+  const div = document.createElement("div");
+  div.className = `line ${cls}`;
+  div.textContent = text;
+  feed.appendChild(div);
+  feed.scrollTop = feed.scrollHeight;
+  return div;
+}
+
+// Map a runtime log entry to a glyph + css class (the shared visual language).
+function glyphFor(entry) {
+  const p = entry.phase, lvl = entry.level;
+  if (lvl === "error") return ["✕", "deny"];
+  if (lvl === "warning") return ["⏸", "suspend"];
+  if (p === "intent") return ["◆", "intent"];
+  if (p === "proposal") return ["▸", "permit"];
+  if (p === "result" || p === "execution")
+    return lvl === "success" ? ["✓", "commit"] : ["·", "sys"];
+  return ["·", "sys"];
+}
+
+let currentStream = null;
+let renderedUpTo = 0;
+
+function renderSnapshot(s) {
+  // Snapshot carries the full log; render only newly-arrived entries.
+  (s.log || []).forEach((e) => {
+    if (e.idx < renderedUpTo) return;
+    renderedUpTo = e.idx + 1;
+    const [g, cls] = glyphFor(e);
+    const detail = e.detail ? `  ${e.detail}` : "";
+    pushLine(cls, `${g} ${e.title}${detail}`);
+  });
+  if (s.status === "waiting_approval") showApproval(s.run_id);
+  if (["completed", "failed", "cancelled"].includes(s.status) && s.final_answer)
+    pushLine("sys", `— ${s.status}: ${s.final_answer}`);
+}
+
+function showApproval(runId) {
+  if (document.querySelector(`.approval-row[data-run="${runId}"]`)) return;
+  const row = document.createElement("div");
+  row.className = "approval-row";
+  row.dataset.run = runId;
+  row.innerHTML = `<span class="q">⏸ approval required — channel</span>`;
+  const chan = document.createElement("input");
+  chan.value = "ops";
+  chan.style.maxWidth = "120px";
+  const approve = document.createElement("button");
+  approve.textContent = "Approve";
+  const deny = document.createElement("button");
+  deny.textContent = "Deny";
+  deny.className = "ghost";
+  const act = async (decision) => {
+    try {
+      await postJSON(`/runs/${runId}/approvals/${chan.value}`, { decision });
+      pushLine("sys", `— ${decision} (${chan.value})`);
+      row.remove();
+    } catch (e) { alert("Approval failed: " + e); }
+  };
+  approve.onclick = () => act("approve");
+  deny.onclick = () => act("deny");
+  row.append(chan, approve, deny);
+  feed.appendChild(row);
+  feed.scrollTop = feed.scrollHeight;
+}
+
+$("composer").addEventListener("submit", async (ev) => {
+  ev.preventDefault();
+  const task = $("taskInput").value.trim();
+  if (!task) return;
+  $("taskInput").value = "";
+  pushLine("you", `you ▸ ${task}`);
+  try {
+    const { run_id } = await postJSON("/runs", { task });
+    pushLine("sys", `— run ${run_id}`);
+    if (currentStream) currentStream.close();
+    renderedUpTo = 0;
+    currentStream = new EventSource(api(`/runs/${run_id}/execution/stream`));
+    currentStream.onmessage = (m) => {
+      try { renderSnapshot(JSON.parse(m.data)); } catch (_) {}
+    };
+    currentStream.onerror = () => { currentStream && currentStream.close(); };
+  } catch (e) {
+    pushLine("deny", `✕ could not start run: ${e}. Is the runtime live?`);
+  }
+});
+
+/* ---------- runs history ---------- */
+async function loadRuns() {
+  const el = $("runsList");
+  el.innerHTML = "<div class='hint'>loading…</div>";
+  try {
+    const runs = await getJSON("/runs");
+    el.innerHTML = "";
+    const list = Array.isArray(runs) ? runs : runs.runs || [];
+    if (!list.length) { el.innerHTML = "<div class='hint'>no runs yet</div>"; return; }
+    list.forEach((r) => {
+      const glyph = r.status === "completed" ? "✓" : r.status === "failed" ? "✕" : "▸";
+      const cls = r.status === "completed" ? "commit" : r.status === "failed" ? "deny" : "permit";
+      const commits = r.summary?.commits ?? "";
+      const div = document.createElement("div");
+      div.className = "item";
+      div.innerHTML =
+        `<span class="glyph ${cls}">${glyph}</span>` +
+        `<b>${escapeHtml(r.task || "")}</b>` +
+        `<span class="meta">${r.trajectory_id?.slice(0, 8) || ""}` +
+        `${commits !== "" ? " · " + commits + " commits" : ""}</span>`;
+      div.style.cursor = "pointer";
+      div.onclick = () => openAudit(r.trajectory_id);
+      el.appendChild(div);
+    });
+  } catch (e) { el.innerHTML = `<div class='hint'>could not load runs: ${e}</div>`; }
+}
+$("refreshRuns").addEventListener("click", loadRuns);
+
+/* ---------- providers ---------- */
+async function loadHealth() {
+  const el = $("providerCard");
+  try {
+    const h = await getJSON("/health");
+    el.innerHTML =
+      `<div><b>Default provider:</b> ${h.default_provider} ` +
+      `<span class="badge ${h.cognition_live ? "ok" : "bad"}">` +
+      `${h.cognition_live ? "live" : "mock — no key set"}</span></div>` +
+      `<div><b>Mode:</b> ${h.mode}</div>` +
+      `<div><b>Ledger backend:</b> ${h.ledger}</div>`;
+  } catch (e) {
+    el.innerHTML = `<div class='hint'>runtime not reachable — start it from the top bar (${e})</div>`;
+  }
+}
+$("refreshHealth").addEventListener("click", loadHealth);
+
+/* ---------- tools (marketplace catalog, read-only) ---------- */
+async function loadTools() {
+  const el = $("toolsList");
+  el.innerHTML = "<div class='hint'>loading…</div>";
+  try {
+    const res = await getJSON("/marketplace/search");
+    const pkgs = res.packages || res.results || (Array.isArray(res) ? res : []);
+    el.innerHTML = "";
+    if (!pkgs.length) { el.innerHTML = "<div class='hint'>no tools published</div>"; return; }
+    pkgs.forEach((p) => {
+      const div = document.createElement("div");
+      div.className = "item";
+      div.innerHTML =
+        `<span class="glyph permit">🧰</span><b>${escapeHtml(p.name || "")}</b>` +
+        `<span class="meta">${escapeHtml(p.description || p.version || "")}</span>`;
+      el.appendChild(div);
+    });
+  } catch (e) { el.innerHTML = `<div class='hint'>could not load tools: ${e}</div>`; }
+}
+$("refreshTools").addEventListener("click", loadTools);
+
+/* ---------- audit + replay verdict ---------- */
+async function openAudit(runId) {
+  document.querySelector('.tab[data-tab="audit"]').click();
+  $("auditRunId").value = runId || "";
+  if (runId) loadAudit(runId);
+}
+async function loadAudit(runId) {
+  const trail = $("auditTrail");
+  const badge = $("replayBadge");
+  trail.innerHTML = "<div class='hint'>loading…</div>";
+  badge.innerHTML = "";
+  try {
+    const entries = await getJSON(`/audit/entries?run_id=${encodeURIComponent(runId)}`);
+    const list = Array.isArray(entries) ? entries : entries.entries || [];
+    trail.innerHTML = "";
+    list.forEach((e) => {
+      const div = document.createElement("div");
+      div.className = "item";
+      div.innerHTML =
+        `<span class="meta">#${e.seq}</span><b>${escapeHtml(e.kind)}</b>` +
+        `<span class="meta">${escapeHtml((e.commit_id || e.id || "").slice(0, 12))}</span>`;
+      trail.appendChild(div);
+    });
+    // Replay always verifies integrity; a 200 means the chain folded cleanly.
+    try {
+      const rep = await getJSON(`/runs/${runId}/replay`);
+      badge.innerHTML =
+        `<span class="badge ok">replay ✓ verified</span> ` +
+        `<span class="meta">${rep.commits_replayed} commits · ` +
+        `${rep.rejected_proposals} rejected · head ${(rep.head_commit || "").slice(0, 12)}</span>`;
+    } catch (_) {
+      badge.innerHTML = `<span class="badge bad">replay could not verify</span>`;
+    }
+  } catch (e) { trail.innerHTML = `<div class='hint'>could not load trail: ${e}</div>`; }
+}
+$("auditForm").addEventListener("submit", (ev) => {
+  ev.preventDefault();
+  const id = $("auditRunId").value.trim();
+  if (id) loadAudit(id);
+});
+
+function escapeHtml(s) {
+  return String(s).replace(/[&<>"']/g, (c) =>
+    ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
+}
+
+/* ---------- boot ---------- */
+(async function boot() {
+  await resolveBase();
+  await refreshStatus();
+  setInterval(refreshStatus, 4000);
+})();

--- a/thymos/clients/desktop/src/styles.css
+++ b/thymos/clients/desktop/src/styles.css
@@ -1,0 +1,110 @@
+:root {
+  --bg: #0e0b1a;
+  --panel: #15112a;
+  --panel-2: #1c1738;
+  --line: #2b2350;
+  --violet: #7c5cff;
+  --violet-dim: #6a4ef0;
+  --cyan: #45e0ff;
+  --text: #e8e6f5;
+  --muted: #9b95c4;
+  --green: #46d39a;
+  --red: #ff6b8a;
+  --amber: #ffc24b;
+}
+
+* { box-sizing: border-box; }
+html, body { margin: 0; height: 100%; }
+body {
+  background: var(--bg);
+  color: var(--text);
+  font: 14px/1.5 -apple-system, "Segoe UI", Roboto, sans-serif;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Top bar */
+.topbar {
+  display: flex; align-items: center; gap: 16px;
+  padding: 10px 16px;
+  background: var(--panel);
+  border-bottom: 1px solid var(--line);
+}
+.brand { font-weight: 700; letter-spacing: 1px; color: var(--violet); }
+.status { display: flex; align-items: center; gap: 10px; color: var(--muted); }
+.dot { width: 9px; height: 9px; border-radius: 50%; display: inline-block; }
+.dot-on { background: var(--green); box-shadow: 0 0 8px var(--green); }
+.dot-off { background: #4a4466; }
+.pill {
+  background: var(--panel-2); border: 1px solid var(--line);
+  border-radius: 999px; padding: 2px 10px; font-size: 12px;
+}
+.controls { margin-left: auto; display: flex; gap: 8px; }
+
+button {
+  background: var(--violet); color: white; border: 0;
+  border-radius: 8px; padding: 7px 14px; cursor: pointer; font-weight: 600;
+}
+button:hover { background: var(--violet-dim); }
+button.ghost { background: transparent; border: 1px solid var(--line); color: var(--text); }
+button.ghost:hover { background: var(--panel-2); }
+
+/* Tabs */
+.tabs { display: flex; gap: 4px; padding: 8px 12px 0; background: var(--panel); }
+.tab {
+  background: transparent; color: var(--muted); border: 0;
+  border-bottom: 2px solid transparent; border-radius: 6px 6px 0 0;
+  padding: 8px 14px; font-weight: 600;
+}
+.tab:hover { background: var(--panel-2); color: var(--text); }
+.tab.active { color: var(--text); border-bottom-color: var(--cyan); }
+
+main { flex: 1; overflow: auto; padding: 16px; }
+.panel { display: none; max-width: 980px; margin: 0 auto; }
+.panel.active { display: block; }
+.panel-head { display: flex; align-items: center; justify-content: space-between; }
+h2 { margin: 4px 0 12px; }
+
+/* Chat */
+.feed {
+  background: var(--panel); border: 1px solid var(--line); border-radius: 10px;
+  padding: 12px; min-height: 360px; max-height: 58vh; overflow: auto;
+  font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 13px;
+}
+.hint, .note { color: var(--muted); }
+.note { font-size: 12.5px; margin-top: 10px; }
+.line { padding: 2px 4px; white-space: pre-wrap; }
+.line .g { font-weight: 700; }
+.you { color: var(--cyan); }
+.intent { color: var(--text); }
+.permit { color: var(--green); }
+.commit { color: var(--green); font-weight: 600; }
+.deny { color: var(--red); }
+.suspend { color: var(--amber); }
+.sys { color: var(--muted); font-style: italic; }
+.approval-row { display: flex; gap: 8px; align-items: center; margin: 6px 0; }
+.approval-row .q { color: var(--amber); }
+
+.composer { display: flex; gap: 8px; margin-top: 12px; }
+.composer input, .inline-form input, #taskInput {
+  flex: 1; background: var(--panel-2); border: 1px solid var(--line);
+  color: var(--text); border-radius: 8px; padding: 10px 12px; font-size: 14px;
+}
+.inline-form { display: flex; gap: 8px; margin-bottom: 12px; }
+
+/* Lists / cards */
+.list { display: flex; flex-direction: column; gap: 8px; }
+.card, .item {
+  background: var(--panel); border: 1px solid var(--line);
+  border-radius: 10px; padding: 12px 14px;
+}
+.item { display: flex; align-items: center; gap: 10px; }
+.item .meta { color: var(--muted); font-size: 12.5px; margin-left: auto; }
+code {
+  background: var(--panel-2); border: 1px solid var(--line);
+  border-radius: 5px; padding: 1px 5px; font-size: 12.5px;
+}
+.badge { border-radius: 999px; padding: 3px 10px; font-size: 12px; font-weight: 700; }
+.badge.ok { background: rgba(70,211,154,.15); color: var(--green); border: 1px solid var(--green); }
+.badge.bad { background: rgba(255,107,138,.15); color: var(--red); border: 1px solid var(--red); }
+.glyph { width: 1.4em; display: inline-block; text-align: center; }


### PR DESCRIPTION
## What this adds

Makes OpenThymos **easy to get and verifiably under control**, across three threads. Every surface here is a *client* of the existing runtime — nothing changes the `Intent → Proposal → Commit` boundary.

### 1. OpenThymos Desktop (RFC + scaffold)
- `docs/rfcs/desktop-app.md` — design + **honest feature map** (what's wired to real endpoints now vs. what needs a backend: scheduling/gateways/memory/skills are deferred, not faked).
- `thymos/clients/desktop/` — Tauri app skeleton: Rust host supervises a local `thymos-server`; no-build webview UI wired to real HTTP/SSE endpoints (chat=governed run, runs, providers/health, tools, audit+replay, backups). Standalone workspace so `cargo build --workspace` never compiles Tauri.

### 2. Easy download
- `scripts/get.sh` — prebuilt installer (OS/arch detection → the exact `release.yml` asset → `~/.local/bin`), github-only fetch, no telemetry. **Verified live against the published v0.5.0 release.**
- `README.md` — download button in the hero + a "Download — prebuilt binaries" section (curl one-liner, direct per-OS links, verified GHCR docker run). Desktop GUI installer stays honestly marked in-progress.
- `release.yml` — two **additive, safe** jobs: `desktop` (.dmg/.msi/.AppImage via tauri-action, `continue-on-error`, *appends* to the release) and `homebrew` (guarded on `HOMEBREW_TAP_TOKEN`, green no-op until a tap repo + secret exist).

### 3. Agent-control audit
- `docs/audits/agent-control-audit.md` — captures the cognition→runtime authority audit: the compiler gate order, the single execution chokepoint, the **PoisonTool "never executed" proof** (10/10 gate tests run green), live `thymos audit` output, and the honest trust boundaries (tool-declared effect class, key custody, policy/approval config).

## Honestly not verified here
- The Tauri app is a **scaffold** — not `cargo build`/`tauri build`-compiled in this environment (toolchain not fetched). No signed installer yet.
- The new `desktop`/`homebrew` CI jobs are **untested** — they only run on a tag push. Designed so neither can break the existing binary/container release.
- `brew install` and signed installers need a one-time setup (tap repo + token; signing certs) — documented inline in `release.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)