### PR TITLE
perf(runtime): skip per-commit ledger re-scan via observation cache

### DIFF
--- a/thymos/crates/thymos-runtime/src/agent.rs
+++ b/thymos/crates/thymos-runtime/src/agent.rs
@@ -365,12 +365,17 @@ pub fn run_agent<L: LedgerStore>(
     })
 }
 
-/// Fetch the Observation from the commit that just landed. The ledger is the
-/// source of truth — we don't trust cached values.
+/// Fetch the Observation from the commit that just landed. Fast path: `submit`
+/// memoizes the observation it just produced on the `Run`, so we avoid a
+/// full-trajectory ledger re-scan for the common case. On a miss we fall back to
+/// the ledger, which remains the source of truth.
 fn last_observation<L: LedgerStore>(
     run: &Run<'_, L>,
     commit_id: thymos_core::CommitId,
 ) -> Result<Observation> {
+    if let Some(obs) = run.cached_commit_observation(commit_id) {
+        return Ok(obs);
+    }
     let entries: Vec<Entry> = run.runtime().ledger.entries(run.trajectory_id())?;
     for e in entries.into_iter().rev() {
         if let EntryPayload::Commit(c) = &e.payload {

--- a/thymos/crates/thymos-runtime/src/lib.rs
+++ b/thymos/crates/thymos-runtime/src/lib.rs
@@ -346,6 +346,7 @@ impl<L: LedgerStore> Runtime<L> {
         Ok(Run {
             runtime: self,
             trajectory_id,
+            last_commit: std::sync::Mutex::new(None),
         })
     }
 
@@ -362,6 +363,7 @@ impl<L: LedgerStore> Runtime<L> {
         Ok(Run {
             runtime: self,
             trajectory_id,
+            last_commit: std::sync::Mutex::new(None),
         })
     }
 }
@@ -369,6 +371,11 @@ impl<L: LedgerStore> Runtime<L> {
 pub struct Run<'a, L: LedgerStore = Ledger> {
     runtime: &'a Runtime<L>,
     trajectory_id: TrajectoryId,
+    /// Memoizes the observation from the most recent commit this `Run` executed,
+    /// so callers don't re-read and re-scan the whole trajectory ledger just to
+    /// fetch what `submit` already produced. Pure optimization: a miss falls
+    /// back to the ledger (still the source of truth), so behavior is identical.
+    last_commit: std::sync::Mutex<Option<(CommitId, thymos_core::commit::Observation)>>,
 }
 
 /// The result of submitting one Intent to the runtime.
@@ -403,6 +410,21 @@ impl<'a, L: LedgerStore> Run<'a, L> {
     /// trajectory up to the current head. For branched trajectories, first
     /// folds the ancestor chain up to the branch point, then this trajectory's
     /// own commits on top.
+    /// The observation from the most recent commit this `Run` executed, if it
+    /// matches `commit_id`. Lets the agent loop avoid a full-ledger re-scan for
+    /// the commit `submit` just produced; returns `None` on a miss so callers
+    /// fall back to the ledger (the source of truth).
+    pub fn cached_commit_observation(
+        &self,
+        commit_id: CommitId,
+    ) -> Option<thymos_core::commit::Observation> {
+        let guard = self.last_commit.lock().unwrap();
+        match &*guard {
+            Some((id, obs)) if *id == commit_id => Some(obs.clone()),
+            _ => None,
+        }
+    }
+
     pub fn project_world(&self) -> Result<World> {
         let entries = self.runtime.ledger.entries(self.trajectory_id)?;
         self.project_world_from(&entries)
@@ -449,6 +471,7 @@ impl<'a, L: LedgerStore> Run<'a, L> {
         Ok(Run {
             runtime: self.runtime,
             trajectory_id: new_traj,
+            last_commit: std::sync::Mutex::new(None),
         })
     }
 
@@ -752,6 +775,9 @@ impl<'a, L: LedgerStore> Run<'a, L> {
                 let _commit_span =
                     tracing::info_span!("triad.commit", seq = parent_seq + 1).entered();
 
+                // Keep a copy of the observation to memoize on the Run after the
+                // commit lands, so the agent loop need not re-scan the ledger.
+                let observation_for_cache = outcome.observation.clone();
                 let commit_body = CommitBody {
                     parent: vec![CommitId(parent_hash)],
                     trajectory_id: self.trajectory_id,
@@ -773,6 +799,7 @@ impl<'a, L: LedgerStore> Run<'a, L> {
                 let committed_id = CommitId(commit.id.0);
 
                 self.runtime.ledger.append_commit(commit)?;
+                *self.last_commit.lock().unwrap() = Some((committed_id, observation_for_cache));
 
                 crate::agent::emit_event(
                     trace,


### PR DESCRIPTION
## Bottleneck
The sync agent loop called `last_observation()` after **every** commit, which read + scanned the **entire trajectory ledger** to fetch the observation `submit` already produced — an O(n) scan per commit, O(n²) over a run.

## Fix
`Run` memoizes `(commit_id, observation)` for the commit it just executed. `last_observation` uses that fast path and **falls back to the ledger on a miss** — so the ledger stays the source of truth and behavior is byte-identical (a miss is indistinguishable from the old path). No `Step`/trait/API changes.

## Scope (honest)
This removes the *redundant* per-commit read. `submit`'s own single full read (for world + budget projection) is **necessary per intent** without an incremental projection cache — that larger change is a separate, more careful PR.

## Verified
`cargo test -p thymos-runtime` → exit 0, no failures/panics (agent_loop, idempotency, compensation, delegation, revocation, …).

🤖 Generated with [Claude Code](https://claude.com/claude-code)