### PR TITLE
feat: thymos --version (git sha), dev-build docs, nightly channel

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,93 @@
+# Nightly dev builds: fresh prebuilt binaries from `main`, published to a single
+# rolling `nightly` prerelease so people can download the latest unreleased code
+# without a toolchain. UNTESTED until first run (scheduled/dispatch only).
+# Install:  curl -fsSL .../scripts/get.sh | THYMOS_VERSION=nightly sh
+name: Nightly
+
+on:
+  schedule:
+    - cron: "0 7 * * *" # daily 07:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: nightly
+  cancel-in-progress: true
+
+jobs:
+  binaries:
+    name: Nightly binaries (${{ matrix.target }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            ext: ""
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            ext: ""
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            ext: ""
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            ext: ".exe"
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        working-directory: thymos
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: thymos
+          key: nightly-${{ matrix.target }}
+      - name: Build
+        run: cargo build --release --target ${{ matrix.target }} -p thymos-server -p thymos-cli
+      - name: Package
+        shell: bash
+        run: |
+          mkdir -p dist
+          cp target/${{ matrix.target }}/release/thymos-server${{ matrix.ext }} dist/
+          cp target/${{ matrix.target }}/release/thymos${{ matrix.ext }}        dist/
+          cd dist
+          tar czf ../../thymos-nightly-${{ matrix.target }}.tar.gz thymos-server${{ matrix.ext }} thymos${{ matrix.ext }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: nightly-${{ matrix.target }}
+          path: thymos-nightly-*.tar.gz
+
+  publish:
+    name: Publish nightly prerelease
+    needs: binaries
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          pattern: nightly-*
+          merge-multiple: true
+      - name: Move the nightly tag to current main
+        run: |
+          git tag -f nightly
+          git push -f origin nightly
+      - name: Publish / refresh the nightly prerelease
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          sha="$(git rev-parse --short HEAD)"
+          notes="Automated build from \`main\` (${sha}) on $(date -u +%FT%TZ). Unsigned and unstable — for tracking unreleased changes. Install: \`curl -fsSL https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/main/scripts/get.sh | THYMOS_VERSION=nightly sh\`"
+          if ! gh release view nightly >/dev/null 2>&1; then
+            gh release create nightly --prerelease --title "OpenThymos nightly" --notes "$notes"
+          else
+            gh release edit nightly --prerelease --notes "$notes"
+          fi
+          gh release upload nightly artifacts/thymos-nightly-*.tar.gz --clobber

--- a/README.md
+++ b/README.md
@@ -313,6 +313,33 @@ feature-by-feature status: **[docs/rfcs/desktop-app.md](docs/rfcs/desktop-app.md
 The Download button above is the terminal runtime today; the desktop GUI installer
 (`.dmg` / `.msi` / `.AppImage`) lands here once it's signed and released.
 
+### Run a dev build & track changes
+
+Want the latest unreleased code (e.g. the freshest CLI/UI) instead of a tagged
+release? Build from source — every binary reports its exact build:
+
+```bash
+git clone https://github.com/gryszzz/open-thymos && cd open-thymos/thymos
+cargo run -p thymos-server                       # dev runtime
+cargo run -p thymos-cli -- shell                 # dev CLI
+cargo install --path crates/thymos-cli           # put the dev `thymos` on PATH
+
+thymos --version                                 # e.g. "thymos 0.5.0 (a1b2c3d)"
+git log --oneline -10                            # the changes that build contains
+```
+
+`thymos --version` prints `<version> (<git-sha>)`, so you can always tell which
+build you're on and map it to a commit. Desktop dev mode:
+`cd clients/desktop && npm install && npm run dev` (hot-reloads the UI).
+
+**Nightly builds** (no toolchain): once the Nightly workflow has run, the
+[`nightly`](https://github.com/gryszzz/open-thymos/releases/tag/nightly)
+prerelease carries fresh binaries rebuilt from `main` each day:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/gryszzz/open-thymos/main/scripts/get.sh | THYMOS_VERSION=nightly sh
+```
+
 **Multi-agent delegation** — a parent mints a child writ ⊆ its own authority, the
 child runs on its own trajectory, the ledger shows the lineage, replay reconstructs both:
 

--- a/thymos/crates/thymos-cli/build.rs
+++ b/thymos/crates/thymos-cli/build.rs
@@ -1,0 +1,27 @@
+//! Embeds the current git short SHA so `thymos --version` can report exactly
+//! which build is running (dev vs. release, and the precise commit) — the
+//! "track changes" signal. Falls back to "unknown" outside a git checkout
+//! (e.g. a source tarball), so the build never fails for lack of git.
+use std::process::Command;
+
+fn main() {
+    let sha = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".to_string());
+    println!("cargo:rustc-env=THYMOS_GIT_SHA={sha}");
+
+    // Best-effort: rebuild when HEAD moves so the SHA stays fresh in dev. The
+    // path is relative to this crate dir (thymos/crates/thymos-cli). Only emit
+    // it when present to avoid a warning in tarball builds with no .git.
+    for rel in ["../../../.git/HEAD", "../../../.git/packed-refs"] {
+        if std::path::Path::new(rel).exists() {
+            println!("cargo:rerun-if-changed={rel}");
+        }
+    }
+}

--- a/thymos/crates/thymos-cli/src/main.rs
+++ b/thymos/crates/thymos-cli/src/main.rs
@@ -16,8 +16,12 @@ use std::process::Command as ProcessCommand;
 
 mod shell;
 
+/// `<pkg-version> (<git-sha>)`, e.g. `0.5.0 (a1b2c3d)`. Lets any binary report
+/// the exact build it came from — `thymos --version`.
+const VERSION: &str = concat!(env!("CARGO_PKG_VERSION"), " (", env!("THYMOS_GIT_SHA"), ")");
+
 #[derive(Parser)]
-#[command(name = "thymos", about = "Thymos governed-cognition CLI")]
+#[command(name = "thymos", version = VERSION, about = "Thymos governed-cognition CLI")]
 struct Cli {
     /// Server URL (default: http://localhost:3001).
     #[arg(long, env = "THYMOS_URL", default_value = "http://localhost:3001")]


### PR DESCRIPTION
Lets you see exactly which build you're on and download unreleased code.

## 1. `thymos --version`
Previously the CLI declared no version, so `thymos --version` errored — you couldn't tell which build you had. Now it prints `<version> (<git-sha>)`, e.g. `thymos 0.5.0 (30fbcea)`. A `build.rs` embeds the git short SHA, falling back to `unknown` outside a checkout so builds never fail for lack of git.

## 2. Dev-build docs (README)
"Run a dev build & track changes": `cargo run` / `cargo install --path` for CLI+server, `npm run dev` for the desktop app, `git log` to see what a build contains.

## 3. Nightly channel (`.github/workflows/nightly.yml`)
Daily (+ manual `workflow_dispatch`) prebuilt binaries from `main`, published to a rolling `nightly` prerelease. Install with the existing installer:
```
curl -fsSL https://raw.githubusercontent.com/gryszzz/open-thymos/main/scripts/get.sh | THYMOS_VERSION=nightly sh
```

## Verified / honest
- `cargo build -p thymos-cli` ok; `thymos --version` → `thymos 0.5.0 (30fbcea)` (matches HEAD).
- `node scripts/check-docs.mjs` passes; `nightly.yml` parses.
- Nightly workflow is **untested** until its first scheduled/dispatch run (only runs once on `main`); the `nightly` release link 404s until then (README says so).

🤖 Generated with [Claude Code](https://claude.com/claude-code)