### PR TITLE
chore(release): v0.6.0

### DIFF
--- a/thymos/Cargo.lock
+++ b/thymos/Cargo.lock
@@ -2699,7 +2699,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-cli"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "axum 0.8.9",
  "clap",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-client"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "axum-test",
  "reqwest",
@@ -2733,7 +2733,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-cognition"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -2747,7 +2747,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-compiler"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2758,7 +2758,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "blake3",
  "ed25519-dalek",
@@ -2771,7 +2771,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-ledger"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "blake3",
  "deadpool-postgres",
@@ -2787,7 +2787,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-marketplace"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "blake3",
  "hex",
@@ -2800,7 +2800,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-policy"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2809,7 +2809,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-runtime"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "serde",
@@ -2826,7 +2826,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-server"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2859,7 +2859,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-tools"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "blake3",
  "reqwest",
@@ -2872,7 +2872,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-worker"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "serde_json",
  "thymos-tools",

--- a/thymos/Cargo.toml
+++ b/thymos/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license = "Apache-2.0"
 rust-version = "1.80"

--- a/thymos/clients/desktop/package.json
+++ b/thymos/clients/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thymos-desktop",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "description": "OpenThymos Desktop — governed-cognition runtime, install once.",
   "scripts": {

--- a/thymos/clients/desktop/src-tauri/Cargo.toml
+++ b/thymos/clients/desktop/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "thymos-desktop"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "OpenThymos Desktop — a governed-cognition client that supervises a local runtime."

--- a/thymos/clients/desktop/src-tauri/tauri.conf.json
+++ b/thymos/clients/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenThymos",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "identifier": "com.openthymos.desktop",
   "build": {
     "frontendDist": "../src"


### PR DESCRIPTION
## chore(release): v0.6.0

Version bump only — no code changes — to cut the **v0.6.0** stable release covering everything merged to `main` since `v0.5.0` (currently only on the `nightly` prerelease).

Bumps `0.5.0 → 0.6.0` in:
- `thymos/Cargo.toml` (workspace — all 12 crates inherit it) + `Cargo.lock`
- `thymos/clients/desktop/src-tauri/Cargo.toml`
- `thymos/clients/desktop/src-tauri/tauri.conf.json`
- `thymos/clients/desktop/package.json`

### What v0.6.0 will ship (since v0.5.0)
- **Desktop app scaffold** + easy-download path (`#49`, `#53`, `#54`) — unsigned/experimental.
- **`thymos --version`** with git sha + nightly channel (`#52`).
- **Runtime perf**: cache last commit observation to skip a per-commit ledger re-scan (`#51`).
- **CLI onboarding/branding**: banner, home/setup/use/tools screens, violet terminal graphics, friendlier shell (`#41`, `#42`, `#44`, `#46`).
- **Fixes**: `--follow` SSE stream now closes on terminal status (`#47`); trajectory seeded from writ id to avoid a ledger collision (`#43`); CI/docs/site fixes.

(v0.5.0 already shipped the OpenAI-compatible model presets and the Phase III Postgres hardening.)

### After merge
Tagging `v0.6.0` at the merge commit triggers `release.yml` → cross-platform binaries, the GHCR container, a GitHub Release with auto-generated notes, and desktop installers.

https://claude.ai/code/session_01BTiNYcDGfvthQMJwfCgBjY

---
_Generated by [Claude Code](https://claude.ai/code/session_01BTiNYcDGfvthQMJwfCgBjY)_