### PR TITLE
feat(desktop): connect any model in-app + RFC for skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,9 @@ thymos replay <run-id>          # verify the ledger folds to its world
 <img src="thymos/Thymos-logo.PNG" width="78" />
 
 Immersive, **local-first** GUI — chat, live runs, the 3D **Mind** reasoning view,
-audit + replay. Your keys never leave your machine; no phone-home.
+audit + replay. Connect **any model** from the Providers tab — Claude, OpenAI,
+Ollama / LM Studio (local), or any OpenAI-compatible adapter. Your keys never
+leave your machine; no phone-home.
 
 [![Get the Desktop app](https://img.shields.io/badge/▶_Get_Desktop_App-7c5cff?style=for-the-badge&labelColor=1c1738)](docs/rfcs/desktop-app.md)
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -97,6 +97,20 @@ never produces a false failure — and proves the real path when you supply it.
   boundary for sandboxed tool execution; the substance lives in
   `thymos_tools::worker_entrypoint` (kept in the library so it is unit-tested and
   can also run in-process). Thinness is the design, not a stub.
+- **Desktop in-app provider setup (connect any model).** The desktop Providers
+  tab now writes a per-user `provider.json` and injects it (`THYMOS_DEFAULT_*`,
+  `OPENAI_API_KEY`/`OPENAI_BASE_URL`, `ANTHROPIC_*`) into the supervised runtime
+  child at spawn — covering Claude, OpenAI, Ollama/LM Studio, and any
+  OpenAI-compatible preset or custom base-URL adapter, mirroring the CLI's
+  `thymos use`. The key is never returned to the webview. **Not compiled in CI
+  here:** the desktop is a separate Tauri workspace needing GTK/WebKit system
+  libs, built only by the release pipeline's desktop job on real OS runners; the
+  JS is syntax-checked and the host code follows the existing command patterns.
+- **Skills are designed, not implemented.** `docs/rfcs/skills.md` (Draft)
+  specifies a content-addressed, *authority-narrowing* skill abstraction (prompt
+  + tool allow-list + effect ceiling/writ template + tunable params) plus the
+  CLI/desktop surfaces to edit it. No runtime code yet — it lands after the RFC is
+  accepted, per the RFC-first rule.
 
 ## Release status
 

--- a/docs/rfcs/skills.md
+++ b/docs/rfcs/skills.md
@@ -1,0 +1,253 @@
+# OpenThymos RFC
+
+## Title
+
+Skills — reusable, tunable, content-addressed agent capabilities over tools and writs.
+
+## Status
+
+Draft
+
+## Summary
+
+A **skill** is a named, versioned, content-addressed bundle that packages *how*
+to do a recurring class of task: a system/instruction prompt, an allow-list of
+tools, a maximum effect ceiling + writ-scope template, and a set of tunable
+parameters. Skills are **authored and tuned by operators**, stored in a registry,
+editable from both the CLI (`thymos skill …`) and the desktop **Skills** tab, and
+referenced by a run (`POST /runs { "skill": "<name|id>" }`).
+
+A skill is **not** a new execution authority. It is a *proposal template*.
+Selecting a skill shapes the prompt cognition sees and **narrows** (never widens)
+the writ the compiler issues; every tool call still passes the unchanged
+`Intent → Proposal → Commit` pipeline, the writ still gates every effect, and the
+ledger records exactly which skill **content hash** governed the run. This RFC
+affects operator surfaces, the compiler (writ derivation), the ledger (one new
+entry kind), and replay (hash verification). It does **not** change provider
+authority, tool contracts, or the hash-chain rules.
+
+## Motivation
+
+Today every run starts from zero: the caller supplies a free-form task and
+(optionally) a `cognition` block, and the compiler issues a writ from defaults or
+the request. Recurring work — "triage this inbox", "review a diff", "research and
+cite", "reconcile two ledgers" — is re-specified each time, with prompt quality,
+tool scoping, and effect ceilings re-decided ad hoc. There is no first-class,
+reviewable, *tunable* unit that captures "this is how we want the agent to do X,
+and this is the most authority X may ever request."
+
+Operators have asked to "create and tune a skill specific for Thymos" and to
+"edit it" from the app. The missing capability is a governed, content-addressed
+**capability template** that is safe by construction: tuning a skill can change
+its behavior and its *ceiling*, but can never let cognition grant itself
+authority, and every run remains independently replay-verifiable against the
+exact skill version it used.
+
+## Current Semantics
+
+- `POST /runs` accepts `{ task, cognition?, writ? }`. `thymos-compiler` compiles
+  intents into proposals, enforcing writ scope, effect ceiling
+  (`Read ≤ Write ≤ External ≤ Irreversible`), budget, and time windows.
+- Capability writs are signed; delegation issues **child writs that are strict
+  subsets of the parent** (Phase II).
+- Ledger entries are content-addressed: `id = blake3(canonical_json(payload))`;
+  replay verifies sequence continuity + parent linkage and never calls a provider
+  or re-runs a tool.
+- Tools are typed contracts resolved from manifest dirs; the marketplace is a
+  read-only catalog. There is **no** "skill" type anywhere in the codebase.
+
+## Proposed Semantics
+
+### Skill definition (content-addressed)
+
+```jsonc
+{
+  "name": "diff-review",
+  "version": 3,
+  "title": "Review a code diff",
+  "instructions": "You review diffs for correctness…",   // prompt fragment
+  "tools": ["fs.read", "shell.run:git", "http.get"],      // allow-list (⊆ available)
+  "ceiling": "External",                                   // max effect this skill may request
+  "writ_template": {                                       // scope template, all optional
+    "paths": ["./**"], "domains": ["api.github.com"], "budget": { "usd": 0.50 }
+  },
+  "params": [                                              // tunable knobs, typed + defaulted
+    { "key": "strictness", "type": "enum", "values": ["low","high"], "default": "high" }
+  ],
+  "model_hint": { "provider": null, "model": null }        // optional, never authoritative
+}
+```
+
+The **skill id** is `blake3(canonical_json(definition))`. Editing any field
+("tuning") produces a **new id** and bumps `version`; the old version remains
+addressable. A skill id is therefore an immutable, replay-stable reference.
+
+`name` is a mutable human handle resolved through the registry to the *current*
+id; a run may pin either `name` (resolved at submit time, the resolved id is
+recorded) or an explicit `id` (already pinned).
+
+### Applying a skill to a run
+
+`POST /runs { "task": "...", "skill": "<name|id>", "skill_params": { … } }`:
+
+1. Resolve the skill to a concrete id (recording it). Unknown id/name → 400.
+2. Build the cognition prompt by prepending the skill `instructions` (with
+   `params` interpolated) to the task. Cognition still only **proposes**.
+3. **Derive the writ as an intersection, never a union:**
+   `effective_writ = caller_writ ∩ skill_writ_template`, with
+   `effective_ceiling = min(caller_ceiling, skill_ceiling)` and
+   `tools = caller_tools ∩ skill_tools`. A skill can only *shrink* authority — it
+   is exactly the child-writ (strict-subset) rule from delegation, applied to a
+   template instead of a parent.
+4. Compile + run unchanged. Every tool call is gated by `effective_writ`.
+
+If the intersection is empty for a tool the skill needs, the run proceeds with
+that tool denied (surfaced as a normal policy denial), not by widening authority.
+
+### Registry
+
+A `SkillRegistry` trait with a default local backend (JSON files under the
+operator's data dir, mirroring how the desktop persists `provider.json`) and,
+later, a ledger-backed backend so skill provenance is itself auditable. The
+registry resolves `name → current id`, lists versions, and returns definitions by
+id. The marketplace may later distribute skills, but distribution is out of scope
+here.
+
+## Invariants
+
+- A skill MUST NOT grant authority. `effective_writ ⊆ caller_writ` and
+  `effective_ceiling ≤ caller_ceiling` always hold; a skill can only narrow.
+- A skill's `model_hint` MUST NOT confer execution authority and MUST be
+  overridable by the request and operator config; it is advisory only.
+- The skill id MUST be `blake3(canonical_json(definition))`; tuning MUST mint a
+  new id, never mutate an existing one.
+- A run MUST record the resolved skill id it used; replay MUST verify it.
+- Cognition MUST NOT author or mutate a skill inline during a run (skills are
+  operator-authored data, not a tool the model can call to escalate). Authoring
+  happens only through the operator surfaces below.
+- No projected-state mutation outside commit folding; skills change *inputs to*
+  the pipeline, not the pipeline.
+
+## Ledger Impact
+
+Add one entry kind, `skill.bound`, written at run start: `{ run_id, skill_id,
+skill_name, resolved_params_hash }`. It is content-addressed like every other
+entry and chained normally. Existing ledgers are unaffected (the kind is additive;
+runs without a skill simply never emit it). No existing entry changes shape.
+
+## Replay Impact
+
+Replay gains one check: when a `skill.bound` entry is present, replay recomputes
+`blake3(canonical_json(definition))` for the recorded definition (captured inline
+or resolved from a content-addressed store) and asserts it equals `skill_id`, and
+that the prompt/writ actually used (already recorded in the proposal) is
+consistent with the bound skill + params. Replay still **never** calls a provider
+or re-runs a tool. The skill definition is captured by hash at bind time so replay
+does not depend on a live registry; if only the hash (not the body) is retained,
+replay verifies continuity but flags the definition as externally trusted — this
+trade-off is an Unresolved Question.
+
+## Writ And Policy Impact
+
+This is the load-bearing section. Skill application is a **writ-narrowing**
+operation reusing the delegation subset machinery:
+
+- `tools`, `paths`, `domains`, `budget`, `time window`, and `ceiling` from the
+  skill template are intersected with the caller's writ.
+- Policy evaluation is unchanged and runs against the *effective* writ; policy
+  traces remain first-class proposal data and will note the binding skill id.
+- Approval flows are unchanged; a skill may *lower* the auto-approve ceiling
+  (e.g. force `External`+ to require approval) but may never raise it.
+
+## Provider Impact
+
+None to provider authority. `model_hint` is advisory and resolved with the
+existing precedence (request > operator `THYMOS_DEFAULT_*` > skill hint > mock).
+Providers gain no fields and no execution authority. This composes directly with
+the in-app/CLI provider configuration (any LLM / Ollama / OpenAI-compatible
+adapter): a skill says *how* to think, provider config says *which mind* thinks.
+
+## Tool Contract Impact
+
+None. Skills reference existing tool contracts by id and can only allow-list a
+**subset**; no schema, precondition, postcondition, or cost field changes. A
+skill referencing an unknown tool id is a validation error at author time and a
+denial at run time.
+
+## Compatibility
+
+- Compatible: all current `vX.Y.Z` runtimes for runs that omit `skill`
+  (purely additive request field + additive ledger kind).
+- Incompatible: an older runtime cannot *honor* a `skill` field — it ignores it,
+  so a caller relying on skill-narrowing against an old server would get the
+  caller's full writ. Servers therefore MUST reject `skill` with 400 if the
+  feature is disabled, so silence never means "ran with more authority than
+  intended."
+- Migration: none for existing ledgers. New skills are created going forward.
+- Cannot migrate: pre-existing ad-hoc runs are not retro-fitted with skills.
+
+## Security Considerations
+
+- **Authority escalation (primary risk):** mitigated by the intersection rule —
+  a skill is mathematically incapable of widening a writ. Tests must assert this
+  with adversarial templates (over-broad paths/domains/ceiling).
+- **Prompt-injection via tuned instructions:** a malicious skill could instruct
+  cognition to attempt harmful actions — but it still cannot *do* them past the
+  writ. Authoring is operator-gated; skills are not a model-callable tool.
+- **Replay divergence:** prevented by binding the skill id into the ledger and
+  verifying the hash on replay.
+- **Registry tampering:** a swapped local skill file changes the id; a run pinned
+  to an id is unaffected, and a run pinned to a name records the resolved id, so
+  tampering is detectable after the fact.
+
+## Alternatives
+
+- **Skills as marketplace tools.** Rejected: tools are single typed effects;
+  skills are prompt + scope + params spanning many tools. Conflating them would
+  blur the tool contract.
+- **Skills that carry their own signed writ (grant authority).** Rejected
+  outright: violates "cognition proposes, the runtime governs." Skills narrow;
+  they never grant.
+- **Mutable skills (edit in place, stable id).** Rejected: breaks replay
+  determinism. Content-addressing + version bump is non-negotiable.
+- **Prompt-only skills (no writ template).** Rejected as too weak: the value is
+  binding *how to think* to *the most authority that thinking may request*.
+
+## Test Plan
+
+- Unit: skill id = `blake3(canonical_json)`; tuning mints a new id; param
+  interpolation; registry name→id resolution + versioning.
+- Writ: `effective_writ ⊆ caller_writ` for randomized templates (property test);
+  ceiling intersection; empty-intersection → denial, never widening.
+- Integration: `POST /runs { skill }` end-to-end on mock cognition; `/skills`
+  CRUD; CLI `thymos skill new|show|tune|use`.
+- Ledger/replay: `skill.bound` is written, chained, and hash-verified on replay;
+  a tampered definition fails replay.
+- Negative: unknown skill → 400; cognition attempting to author a skill mid-run
+  is rejected; old-runtime rejection path returns 400 rather than silently
+  ignoring `skill`.
+
+## Operator Surfaces (informative)
+
+Not protocol, but the reason this RFC exists — the "spot to edit it":
+
+- **CLI:** `thymos skill list | show <name> | new | tune <name> | use <name>`;
+  `thymos run <task> --skill <name>`.
+- **Desktop:** a **Skills** tab — list/create/tune (name, instructions, tool
+  allow-list, ceiling, writ template, typed params), backed by `GET/POST /skills`
+  and `GET /skills/{id}`; a skill picker on the Chat composer. Mirrors the
+  Providers tab: edit locally, applied by the governed runtime.
+
+## Unresolved Questions
+
+- **Definition capture for replay:** store the full skill body inline in
+  `skill.bound`, or store only the hash + a content-addressed skill store? Inline
+  is fully self-verifying but larger; hash-only keeps entries small but makes the
+  body externally trusted. Must be resolved before implementation (affects replay
+  correctness).
+- **Registry backend:** ship local-JSON only first, or land the ledger-backed
+  registry in the same change so skill provenance is auditable from day one?
+- **Param typing surface:** how rich should `params` be (enums/strings/numbers
+  only, vs. structured) without becoming a config language?
+- **Marketplace distribution + signing of shared skills:** deferred; should it
+  reuse the tool marketplace's signing path?

--- a/thymos/clients/desktop/README.md
+++ b/thymos/clients/desktop/README.md
@@ -16,19 +16,29 @@ shows every proposal, verdict, commit, and replay-verification result.
 - **`src-tauri/`** — the Tauri (Rust) host. It supervises a `thymos-server`
   child process (a bundled sidecar in release builds, or `thymos-server` on
   `PATH` in dev) and exposes `start_runtime` / `stop_runtime` / `runtime_running`
-  / `runtime_addr` commands. It does no governance itself.
+  / `runtime_addr` / `ledger_path` / `get_provider_config` / `set_provider_config`
+  commands. It does no governance itself. Provider config is persisted as
+  `provider.json` in the app-data dir and injected as env vars (`THYMOS_DEFAULT_*`,
+  `OPENAI_API_KEY`/`OPENAI_BASE_URL`, `ANTHROPIC_*`) into the runtime child at
+  spawn — the API key is never returned to the webview.
 - **`src/`** — the webview UI (plain HTML/CSS/JS, no build step, so it's
   inspectable). Tabs: **Chat** (a message = a governed run, streamed),
-  **Runs**, **Providers**, **Tools**, **Audit** (+ replay badge), **Backups**.
-  Every tab is a thin client of an endpoint that already exists.
+  **Runs**, **Providers** (connect any model — Claude, OpenAI, Ollama/LM Studio,
+  or any OpenAI-compatible preset/adapter), **Tools**, **Audit** (+ replay
+  badge), **Backups**. Every tab is a thin client of an endpoint that already
+  exists.
 
 ## Status (honest)
 
 - **v1 surfaces wired to real endpoints:** chat/runs, provider/health, tools
-  catalog, audit + replay, thin backups, local provider setup.
+  catalog, audit + replay, thin backups, and **in-app provider setup** — the
+  Providers tab connects any model (Claude / OpenAI / Ollama / LM Studio / any
+  OpenAI-compatible preset or custom base-URL adapter), persisting the choice and
+  restarting the runtime to apply it.
 - **Deferred (no backend yet, shown as labeled placeholders, never fake
-  buttons):** scheduling, inbound message gateways, memory, skills. See the RFC
-  §4.
+  buttons):** scheduling, inbound message gateways, memory, skills (designed in
+  [`docs/rfcs/skills.md`](../../../docs/rfcs/skills.md), not yet implemented). See
+  also the desktop RFC §4.
 - **Not yet built/verified here:** this is a scaffold. It has **not** been
   `cargo build`/`tauri build`-compiled in this environment (the Tauri toolchain
   + crates were not fetched), and there is **no signed installer / download link

--- a/thymos/clients/desktop/src-tauri/Cargo.lock
+++ b/thymos/clients/desktop/src-tauri/Cargo.lock
@@ -3233,7 +3233,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-desktop"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/thymos/clients/desktop/src-tauri/src/lib.rs
+++ b/thymos/clients/desktop/src-tauri/src/lib.rs
@@ -12,6 +12,7 @@ use std::path::PathBuf;
 use std::process::{Child, Command};
 use std::sync::Mutex;
 
+use serde::{Deserialize, Serialize};
 use tauri::{Manager, State};
 
 /// Address the supervised runtime listens on. The webview's CSP only allows
@@ -47,6 +48,118 @@ fn runtime_addr() -> String {
     RUNTIME_ADDR.to_string()
 }
 
+/// User-chosen cognition provider, persisted in the app-data dir as plain JSON
+/// (`provider.json`). Same trust model as the CLI's `.env`: the key lives on the
+/// user's machine, is injected only into the **local** runtime child at spawn,
+/// and is never returned to the webview — `get_provider_config` reports only
+/// whether a key is stored.
+#[derive(Default, Serialize, Deserialize)]
+struct ProviderConfig {
+    /// `anthropic`, `openai`, `mock`, or any preset id (`ollama`, `groq`,
+    /// `openrouter`, `lmstudio`, `huggingface`, …) — or a custom OpenAI-
+    /// compatible adapter via provider `openai` + a `base_url`.
+    #[serde(default)]
+    provider: String,
+    #[serde(default)]
+    model: String,
+    /// Base URL for OpenAI-compatible / self-hosted adapters (e.g. Ollama,
+    /// LM Studio, vLLM, a corporate gateway). Empty = use the provider default.
+    #[serde(default)]
+    base_url: String,
+    #[serde(default)]
+    api_key: String,
+}
+
+fn provider_config_path(app: &tauri::AppHandle) -> Result<PathBuf, String> {
+    let dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("resolve app data dir: {e}"))?;
+    std::fs::create_dir_all(&dir).map_err(|e| format!("create app data dir: {e}"))?;
+    Ok(dir.join("provider.json"))
+}
+
+fn load_provider_config(app: &tauri::AppHandle) -> ProviderConfig {
+    provider_config_path(app)
+        .ok()
+        .and_then(|p| std::fs::read_to_string(p).ok())
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_default()
+}
+
+/// Inject the stored provider as env vars on the runtime child. Anthropic uses
+/// its dedicated key/base-URL vars; everything else (native `openai` plus every
+/// OpenAI-compatible preset) resolves the generic `OPENAI_API_KEY` /
+/// `OPENAI_BASE_URL` fallback in `resolve_default_cognition` + the preset
+/// registry — so a single code path covers any adapter.
+fn apply_provider_env(cmd: &mut Command, cfg: &ProviderConfig) {
+    let anthropic = cfg.provider.eq_ignore_ascii_case("anthropic");
+    if !cfg.provider.is_empty() {
+        cmd.env("THYMOS_DEFAULT_PROVIDER", &cfg.provider);
+    }
+    if !cfg.model.is_empty() {
+        cmd.env("THYMOS_DEFAULT_MODEL", &cfg.model);
+    }
+    if !cfg.api_key.is_empty() {
+        cmd.env(
+            if anthropic {
+                "ANTHROPIC_API_KEY"
+            } else {
+                "OPENAI_API_KEY"
+            },
+            &cfg.api_key,
+        );
+    }
+    if !cfg.base_url.is_empty() {
+        cmd.env(
+            if anthropic {
+                "ANTHROPIC_BASE_URL"
+            } else {
+                "OPENAI_BASE_URL"
+            },
+            &cfg.base_url,
+        );
+    }
+}
+
+/// Current provider config for the Settings UI. Never returns the key itself —
+/// only whether one is stored — so the secret never round-trips to the webview.
+#[tauri::command]
+fn get_provider_config(app: tauri::AppHandle) -> serde_json::Value {
+    let cfg = load_provider_config(&app);
+    serde_json::json!({
+        "provider": cfg.provider,
+        "model": cfg.model,
+        "base_url": cfg.base_url,
+        "key_set": !cfg.api_key.is_empty(),
+    })
+}
+
+/// Persist the chosen provider/model/base-URL/key. An empty `api_key` leaves any
+/// stored key untouched (so editing the model doesn't wipe the secret); pass
+/// whitespace to clear it. The caller restarts the runtime to apply.
+#[tauri::command]
+fn set_provider_config(
+    app: tauri::AppHandle,
+    provider: String,
+    model: String,
+    base_url: String,
+    api_key: String,
+) -> Result<(), String> {
+    let mut cfg = load_provider_config(&app);
+    cfg.provider = provider.trim().to_string();
+    cfg.model = model.trim().to_string();
+    cfg.base_url = base_url.trim().to_string();
+    if !api_key.is_empty() {
+        // Real key stored trimmed; pure whitespace clears it.
+        cfg.api_key = api_key.trim().to_string();
+    }
+    let path = provider_config_path(&app)?;
+    let json = serde_json::to_string_pretty(&cfg).map_err(|e| e.to_string())?;
+    std::fs::write(&path, &json).map_err(|e| format!("write {}: {e}", path.display()))?;
+    Ok(())
+}
+
 #[tauri::command]
 fn start_runtime(app: tauri::AppHandle, state: State<Supervisor>) -> Result<String, String> {
     let mut guard = state.0.lock().map_err(|e| e.to_string())?;
@@ -72,8 +185,10 @@ fn start_runtime(app: tauri::AppHandle, state: State<Supervisor>) -> Result<Stri
     let ledger_path = data_dir.join("ledger.db");
 
     let bin = server_binary();
-    let child = Command::new(&bin)
-        .env("THYMOS_LEDGER_PATH", &ledger_path)
+    let mut cmd = Command::new(&bin);
+    cmd.env("THYMOS_LEDGER_PATH", &ledger_path);
+    apply_provider_env(&mut cmd, &load_provider_config(&app));
+    let child = cmd
         .spawn()
         .map_err(|e| format!("failed to start {}: {e}", bin.display()))?;
     *guard = Some(child);
@@ -121,7 +236,9 @@ pub fn run() {
             start_runtime,
             stop_runtime,
             runtime_running,
-            ledger_path
+            ledger_path,
+            get_provider_config,
+            set_provider_config
         ])
         .on_window_event(|window, event| {
             // Don't orphan the runtime when the app window closes.

--- a/thymos/clients/desktop/src/index.html
+++ b/thymos/clients/desktop/src/index.html
@@ -89,17 +89,71 @@
         <div id="runsList" class="list"></div>
       </section>
 
-      <!-- PROVIDERS: /health truth + how to set a key -->
+      <!-- PROVIDERS: /health truth + connect ANY model (LLM, Ollama, adapter) -->
       <section class="panel" id="tab-providers">
         <div class="panel-head"><h2>Providers</h2>
           <button class="ghost" id="refreshHealth">Refresh</button></div>
         <div id="providerCard" class="card"></div>
+
+        <form id="providerForm" class="card provider-form">
+          <h3>Connect a model</h3>
+          <label>Provider
+            <input id="pfProvider" list="providerList" autocomplete="off"
+              placeholder="anthropic" />
+            <datalist id="providerList">
+              <option value="anthropic">Claude — native Messages API</option>
+              <option value="openai">OpenAI (or any OpenAI-compatible endpoint)</option>
+              <option value="ollama">Ollama — local</option>
+              <option value="lmstudio">LM Studio — local</option>
+              <option value="groq">Groq</option>
+              <option value="openrouter">OpenRouter</option>
+              <option value="together">Together</option>
+              <option value="deepseek">DeepSeek</option>
+              <option value="mistral">Mistral</option>
+              <option value="gemini">Google Gemini</option>
+              <option value="huggingface">Hugging Face Router</option>
+              <option value="perplexity">Perplexity</option>
+              <option value="xai">xAI Grok</option>
+              <option value="fireworks">Fireworks</option>
+              <option value="nvidia">NVIDIA NIM</option>
+              <option value="cerebras">Cerebras</option>
+              <option value="mock">Mock — offline, deterministic</option>
+            </datalist>
+          </label>
+          <label>Model <span class="dim">(blank = provider default)</span>
+            <input id="pfModel" autocomplete="off" placeholder="e.g. claude-sonnet-4-6 · llama3.2 · gpt-4o" /></label>
+          <label>Base URL <span class="dim">(OpenAI-compatible / self-hosted — optional)</span>
+            <input id="pfBaseUrl" autocomplete="off" placeholder="e.g. http://localhost:11434/v1" /></label>
+          <label>API key <span class="dim">(stored locally on this machine; local models need none)</span>
+            <input id="pfKey" type="password" autocomplete="off" placeholder="leave blank to keep current key" /></label>
+          <div class="provider-actions">
+            <button type="submit">Save &amp; restart runtime</button>
+            <span id="pfStatus" class="dim"></span>
+          </div>
+        </form>
+
         <p class="note">
-          Keys are read <b>server-side</b> — only the provider name crosses the
-          wire, and cognition gains no execution authority. Set
-          <code>ANTHROPIC_API_KEY</code> (or another provider's key) in the
-          environment the runtime starts in. With no key the runtime answers with
-          the deterministic <b>mock</b> — real governance, no real model.
+          <b>Hook up any LLM.</b> Pick a name above (or type any preset id) and
+          Save — the runtime restarts using it. Three shapes:
+        </p>
+        <ul class="note">
+          <li><b>Claude</b>: provider <code>anthropic</code> + your key.</li>
+          <li><b>Hosted (OpenAI, Groq, OpenRouter, DeepSeek, Gemini, …)</b>:
+            pick the preset + paste its key. The model field is optional.</li>
+          <li><b>Local / self-hosted (Ollama, LM Studio, vLLM, a gateway)</b>:
+            provider <code>ollama</code> (or <code>openai</code> for a custom
+            endpoint), set <b>Base URL</b> (Ollama defaults to
+            <code>http://localhost:11434/v1</code>), model = the local model name,
+            key optional.</li>
+        </ul>
+        <p class="note">
+          Keys are read <b>server-side</b> only — they're injected into the local
+          runtime at startup, never sent to the model and never leave your
+          machine. Cognition gains no execution authority. With no working key the
+          runtime answers with the deterministic <b>mock</b> (real governance, no
+          real model). The CLI mirrors this: <code>thymos providers</code> lists
+          every preset, <code>thymos use &lt;name&gt;</code> sets one,
+          <code>thymos doctor</code> verifies the wiring.
         </p>
       </section>
 

--- a/thymos/clients/desktop/src/main.js
+++ b/thymos/clients/desktop/src/main.js
@@ -200,7 +200,7 @@ async function loadRuns() {
 }
 $("refreshRuns").addEventListener("click", loadRuns);
 
-/* ---------- providers ---------- */
+/* ---------- providers: live truth + connect any model ---------- */
 async function loadHealth() {
   const el = $("providerCard");
   try {
@@ -214,8 +214,66 @@ async function loadHealth() {
   } catch (e) {
     el.innerHTML = `<div class='hint'>runtime not reachable — start it from the top bar (${e})</div>`;
   }
+  await loadProviderForm();
 }
 $("refreshHealth").addEventListener("click", loadHealth);
+
+// Populate the connect-a-model form from the host's stored config. The key is
+// never returned — we only learn whether one is set, and reflect that in the
+// placeholder.
+async function loadProviderForm() {
+  if (!invoke) {
+    $("pfStatus").textContent = "provider editing needs the desktop app";
+    $("providerForm")
+      .querySelectorAll("input,button")
+      .forEach((n) => (n.disabled = true));
+    return;
+  }
+  try {
+    const cfg = await invoke("get_provider_config");
+    $("pfProvider").value = cfg.provider || "";
+    $("pfModel").value = cfg.model || "";
+    $("pfBaseUrl").value = cfg.base_url || "";
+    $("pfKey").value = "";
+    $("pfKey").placeholder = cfg.key_set
+      ? "•••••••• stored — blank keeps it"
+      : "leave blank to keep current key";
+  } catch (_) {}
+}
+
+$("providerForm").addEventListener("submit", async (e) => {
+  e.preventDefault();
+  if (!invoke) return;
+  const status = $("pfStatus");
+  const provider = $("pfProvider").value.trim();
+  if (!provider) {
+    status.textContent = "pick a provider first";
+    return;
+  }
+  status.textContent = "saving…";
+  try {
+    await invoke("set_provider_config", {
+      provider,
+      model: $("pfModel").value,
+      baseUrl: $("pfBaseUrl").value,
+      apiKey: $("pfKey").value,
+    });
+    // Apply by restarting the supervised runtime (env is read at spawn).
+    const wasRunning = await invoke("runtime_running").catch(() => false);
+    if (wasRunning) await invoke("stop_runtime").catch(() => {});
+    await invoke("start_runtime").catch(() => {});
+    status.textContent = "saved — runtime restarting…";
+    for (let i = 0; i < 20; i++) {
+      await new Promise((r) => setTimeout(r, 400));
+      await refreshStatus();
+      if ($("dot").classList.contains("dot-on")) break;
+    }
+    await loadHealth();
+    status.textContent = `now using ${provider}`;
+  } catch (err) {
+    status.textContent = "save failed: " + err;
+  }
+});
 
 /* ---------- tools (marketplace catalog, read-only) ---------- */
 async function loadTools() {

--- a/thymos/clients/desktop/src/styles.css
+++ b/thymos/clients/desktop/src/styles.css
@@ -105,6 +105,18 @@ h2 { margin: 4px 0 12px; }
 }
 .inline-form { display: flex; gap: 8px; margin-bottom: 12px; }
 
+/* Provider settings form: connect any model */
+.provider-form { margin-top: 12px; display: flex; flex-direction: column; gap: 10px; }
+.provider-form h3 { margin: 0; color: var(--cyan); font-weight: 700; letter-spacing: .4px; font-size: 14px; }
+.provider-form label { display: flex; flex-direction: column; gap: 5px; font-size: 12.5px; color: var(--muted); }
+.provider-form input {
+  background: var(--panel-2); border: 1px solid var(--line);
+  color: var(--text); border-radius: 8px; padding: 9px 11px; font-size: 14px;
+}
+.provider-form input:focus { outline: none; border-color: var(--violet); }
+.provider-actions { display: flex; align-items: center; gap: 12px; margin-top: 2px; }
+.dim { color: var(--muted); font-weight: 400; }
+
 /* Lists / cards */
 .list { display: flex; flex-direction: column; gap: 8px; }
 .card, .item {


### PR DESCRIPTION
## What

Two things, both serving "hook up any model, clearly" + "create/tune a skill":

### 1) Desktop: connect **any** model in-app (was read-only)
The Providers tab gains a real **"connect a model"** form — provider/preset, model, optional base URL, optional API key → **Save & restart runtime**.

- **One code path covers every adapter** — Claude (`anthropic`), OpenAI, local **Ollama / LM Studio / vLLM / custom base-URL** endpoints, and every OpenAI-compatible preset (`groq`, `openrouter`, `together`, `deepseek`, `gemini`, `huggingface`, …) — because `resolve_default_cognition` + the preset registry fall back to the generic `OPENAI_API_KEY` / `OPENAI_BASE_URL`.
- The Tauri host persists `provider.json` in the app-data dir and injects it (`THYMOS_DEFAULT_PROVIDER`/`THYMOS_DEFAULT_MODEL`, `OPENAI_API_KEY`/`OPENAI_BASE_URL`, `ANTHROPIC_*`) into the supervised runtime child **at spawn**.
- **Boundary preserved:** the API key is never returned to the webview (`get_provider_config` reports only whether one is set); keys stay server-side; cognition gains no authority. Mirrors the CLI's `thymos use`. Clear in-app instructions added (hosted / local / custom).

New Tauri commands: `get_provider_config`, `set_provider_config`. New JS form + styling; no build step (plain HTML/CSS/JS).

### 2) RFC: thymos **skills** (Draft, design only)
`docs/rfcs/skills.md` specifies a **content-addressed, authority-*narrowing*** skill: prompt + tool allow-list + effect ceiling/writ template + tunable params, editable from the CLI (`thymos skill …`) and a desktop **Skills** tab.

Core invariant: **skills propose; the writ still governs.** `effective_writ = caller_writ ∩ skill_template` (never wider — the delegation strict-subset rule applied to a template). One additive ledger kind `skill.bound`; replay verifies the bound skill hash; providers gain no authority. RFC-first per repo rules — **no runtime code in this PR.**

## Verification / honesty
- **Desktop crate not compiled here:** it's a separate Tauri workspace needing GTK/WebKit system libs (`gdk-3.0`) absent in this sandbox — built only by the release pipeline's desktop job on real OS runners. JS is `node --check`-clean; the Rust host follows the existing `start_runtime`/`ledger_path` command patterns.
- The main Rust workspace is untouched, so its CI is unaffected.
- `STATUS.md` updated with honest caveats for both the in-app provider setup and the not-yet-implemented skills.

https://claude.ai/code/session_01BTiNYcDGfvthQMJwfCgBjY

---
_Generated by [Claude Code](https://claude.ai/code/session_01BTiNYcDGfvthQMJwfCgBjY)_