### PR TITLE
feat(desktop): chat UX — capability grants, stop, new chat, copy

### DIFF
--- a/thymos/clients/desktop/src/index.html
+++ b/thymos/clients/desktop/src/index.html
@@ -41,6 +41,18 @@
     <main>
       <!-- CHAT: a message starts a governed run; the reply IS the verdict feed -->
       <section class="panel active" id="tab-chat">
+        <div class="chatbar">
+          <div class="grants" id="grants" title="What this run is allowed to do — the writ scope. The runtime rejects anything not granted.">
+            <span class="grant-label">grant</span>
+            <button type="button" class="chip on" data-scope="fs_read">fs_read</button>
+            <button type="button" class="chip on" data-scope="grep">grep</button>
+            <button type="button" class="chip" data-scope="fs_patch">fs_patch</button>
+            <button type="button" class="chip" data-scope="shell">shell</button>
+            <button type="button" class="chip" data-scope="http">http</button>
+            <button type="button" class="chip" data-scope="test_run">test_run</button>
+          </div>
+          <button type="button" class="ghost" id="newChat">＋ New chat</button>
+        </div>
         <div class="feed" id="chatFeed">
           <div class="welcome">
             <div class="spine">◆ Intent&nbsp;&nbsp;▸ Proposal&nbsp;&nbsp;✓ Commit&nbsp;&nbsp;✕ Rejected&nbsp;&nbsp;⏸ Suspended</div>
@@ -50,14 +62,16 @@
               Each message becomes a <b>governed run</b>: you see every intent, the
               runtime's verdict, and each commit, with replay proof. The model can
               propose anything; only an authorized proposal ever runs, and risky
-              steps pause for your approval.
+              steps pause for your approval. Use <b>grant</b> above to decide what
+              it may touch — the runtime enforces it.
             </p>
           </div>
         </div>
         <form class="composer" id="composer">
           <input id="taskInput" autocomplete="off"
             placeholder="Describe a task in plain language…" />
-          <button type="submit">Send</button>
+          <button type="submit" id="sendBtn">Send</button>
+          <button type="button" id="chatStop" class="danger" hidden>■ Stop</button>
         </form>
       </section>
 

--- a/thymos/clients/desktop/src/main.js
+++ b/thymos/clients/desktop/src/main.js
@@ -108,6 +108,22 @@ function glyphFor(entry) {
 
 let currentStream = null;
 let renderedUpTo = 0;
+let activeRunId = null;
+
+// Capability grants: clicking a chip toggles whether the run's writ authorizes
+// that tool. Empty selection lets the server grant `*` (all tools).
+document.querySelectorAll("#grants .chip").forEach((chip) =>
+  chip.addEventListener("click", () => chip.classList.toggle("on")));
+function selectedScopes() {
+  return [...document.querySelectorAll("#grants .chip.on")].map((c) => c.dataset.scope);
+}
+
+// Toggle Send/Stop + input while a run is in flight.
+function setBusy(on) {
+  $("sendBtn").hidden = on;
+  $("chatStop").hidden = !on;
+  $("taskInput").disabled = on;
+}
 
 function renderSnapshot(s) {
   // Snapshot carries the full log; render only newly-arrived entries.
@@ -119,9 +135,53 @@ function renderSnapshot(s) {
     pushLine(cls, `${g} ${e.title}${detail}`);
   });
   if (s.status === "waiting_approval") showApproval(s.run_id);
-  if (["completed", "failed", "cancelled"].includes(s.status) && s.final_answer)
-    pushLine("sys", `— ${s.status}: ${s.final_answer}`);
+  if (["completed", "failed", "cancelled"].includes(s.status)) {
+    if (s.final_answer) pushAnswer(s.status, s.final_answer);
+    activeRunId = null;
+    setBusy(false);
+  }
 }
+
+// The model's answer, with a copy button (typical chat affordance).
+function pushAnswer(status, text) {
+  const wrap = document.createElement("div");
+  wrap.className = "answer";
+  const body = document.createElement("div");
+  body.className = "answer-body";
+  body.textContent = text;
+  const copy = document.createElement("button");
+  copy.className = "ghost copy";
+  copy.textContent = "Copy";
+  copy.onclick = async () => {
+    try { await navigator.clipboard.writeText(text); copy.textContent = "Copied"; }
+    catch (_) { copy.textContent = "—"; }
+    setTimeout(() => (copy.textContent = "Copy"), 1200);
+  };
+  const head = document.createElement("div");
+  head.className = "answer-head";
+  head.textContent = status === "completed" ? "✓ answer" : `— ${status}`;
+  head.appendChild(copy);
+  wrap.append(head, body);
+  feed.appendChild(wrap);
+  feed.scrollTop = feed.scrollHeight;
+}
+
+// New chat: clear the thread and stop watching (does not touch the ledger).
+$("newChat")?.addEventListener("click", () => {
+  if (currentStream) currentStream.close();
+  activeRunId = null;
+  renderedUpTo = 0;
+  feed.innerHTML = "";
+  setBusy(false);
+  $("taskInput").focus();
+});
+
+// Stop: cancel the in-flight run via the real cancel endpoint.
+$("chatStop")?.addEventListener("click", async () => {
+  if (!activeRunId) return;
+  try { await postJSON(`/runs/${activeRunId}/cancel`, {}); pushLine("sys", "— cancel requested"); }
+  catch (e) { pushLine("deny", `✕ cancel failed: ${e}`); }
+});
 
 function showApproval(runId) {
   if (document.querySelector(`.approval-row[data-run="${runId}"]`)) return;
@@ -154,11 +214,17 @@ function showApproval(runId) {
 $("composer").addEventListener("submit", async (ev) => {
   ev.preventDefault();
   const task = $("taskInput").value.trim();
-  if (!task) return;
+  if (!task || activeRunId) return;
   $("taskInput").value = "";
+  const scopes = selectedScopes();
   pushLine("you", `you ▸ ${task}`);
+  if (scopes.length) pushLine("sys", `— granted: ${scopes.join(", ")}`);
+  setBusy(true);
   try {
-    const { run_id } = await postJSON("/runs", { task });
+    const body = { task };
+    if (scopes.length) body.tool_scopes = scopes;
+    const { run_id } = await postJSON("/runs", body);
+    activeRunId = run_id;
     pushLine("sys", `— run ${run_id}`);
     if (currentStream) currentStream.close();
     renderedUpTo = 0;
@@ -169,6 +235,8 @@ $("composer").addEventListener("submit", async (ev) => {
     currentStream.onerror = () => { currentStream && currentStream.close(); };
   } catch (e) {
     pushLine("deny", `✕ could not start run: ${e}. Is the runtime live?`);
+    activeRunId = null;
+    setBusy(false);
   }
 });
 

--- a/thymos/clients/desktop/src/styles.css
+++ b/thymos/clients/desktop/src/styles.css
@@ -134,6 +134,36 @@ code {
 .badge.bad { background: rgba(255,107,138,.15); color: var(--red); border: 1px solid var(--red); }
 .glyph { width: 1.4em; display: inline-block; text-align: center; }
 
+/* Chat toolbar: capability grants + new chat */
+.chatbar { display: flex; align-items: center; gap: 12px; margin-bottom: 10px; }
+.grants { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
+.grant-label { color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: .6px; }
+.chip {
+  background: var(--panel-2); color: var(--muted); border: 1px solid var(--line);
+  border-radius: 999px; padding: 4px 11px; font-size: 12px; font-weight: 600;
+}
+.chip:hover { color: var(--text); }
+.chip.on {
+  background: rgba(124, 92, 255, .16); color: var(--text);
+  border-color: var(--violet); box-shadow: 0 0 8px rgba(124, 92, 255, .25);
+}
+.chatbar #newChat { margin-left: auto; }
+button.danger { background: var(--red); }
+button.danger:hover { background: #e85c7c; }
+
+/* Model answer block with copy */
+.answer {
+  margin: 10px 2px 2px; border: 1px solid var(--line); border-radius: 10px;
+  background: rgba(70, 211, 154, .05); overflow: hidden;
+}
+.answer-head {
+  display: flex; align-items: center; gap: 8px;
+  padding: 7px 12px; border-bottom: 1px solid var(--line);
+  color: var(--green); font-weight: 700; font-size: 12.5px;
+}
+.answer-head .copy { margin-left: auto; padding: 3px 10px; font-size: 12px; }
+.answer-body { padding: 12px; white-space: pre-wrap; font-family: -apple-system, "Segoe UI", sans-serif; }
+
 /* Mind — 3D reasoning view */
 .mind-controls { display: flex; gap: 8px; }
 .mind-controls input {


### PR DESCRIPTION
## What
The typical chat-agent affordances, but tuned to OpenThymos (governance is the product):

- **Capability grants** — chips above the composer set the run's **writ scope** (`fs_read`/`grep`/`fs_patch`/`shell`/`http`/`test_run`). Grant only `fs_read`+`grep` and the runtime *rejects* a shell/http proposal. Empty = `*`. This is "what is the agent allowed to do" as a first-class control, enforced by the compiler.
- **Stop** — cancels the in-flight run (`POST /runs/:id/cancel`).
- **New chat** — clears the thread (ledger untouched).
- **Busy state** — Send↔Stop toggle; input disabled while a run streams.
- **Copy answer** — final answer rendered in its own block with a Copy button.

## Honest scope
All wired to **existing** endpoints (`tool_scopes`, `/cancel`). True cross-session **memory** is intentionally deferred — it needs the `thymos-memory` backend (`docs/rfcs/desktop-app.md`), so I didn't fake it.

## Verified
`node --check` clean; all referenced ids exist; frontend-only; hot-reloads in `tauri dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)