### PR TITLE
docs: enterprise/monetization strategy + OpenAPI 3.1 spec

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,285 @@
+openapi: 3.1.0
+info:
+  title: OpenThymos Runtime API
+  version: "0.6.0"
+  description: >
+    Governed-cognition runtime control plane. Cognition proposes; the runtime
+    governs; the ledger records. Every effect passes through Intent → Proposal →
+    Commit and is recorded on an append-only, hash-chained, replayable ledger.
+    This spec is the machine-programmability contract: generate a typed SDK in
+    any language from it. Hand-authored against the live router; covers the core
+    surface. Control-plane endpoints accept a Bearer JWT (tenant + roles claims).
+  license:
+    name: Apache-2.0
+servers:
+  - url: http://localhost:3001
+    description: Local runtime (default)
+security:
+  - bearerAuth: []
+  - {}   # auth is enforced on control-plane endpoints; local/dev may run open
+tags:
+  - name: health
+  - name: runs
+  - name: governance
+paths:
+  /health:
+    get:
+      tags: [health]
+      summary: Liveness + honest provider/ledger truth
+      security: [{}]
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Health" }
+  /ready:
+    get:
+      tags: [health]
+      summary: Readiness probe
+      security: [{}]
+      responses:
+        "200": { description: ready }
+        "503": { description: not ready }
+  /runs:
+    get:
+      tags: [runs]
+      summary: List runs (tenant-scoped)
+      responses:
+        "200":
+          description: Run records
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: "#/components/schemas/RunRecord" }
+    post:
+      tags: [runs]
+      summary: Start a governed run
+      description: >
+        Spawns a run. `tool_scopes` sets the run's writ scope — the runtime
+        rejects any tool not granted (empty = `*`). `cognition` selects the
+        model per run (omit = server default; mock unless a key is set).
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/CreateRunRequest" }
+      responses:
+        "202":
+          description: Accepted; run started
+          content:
+            application/json:
+              schema:
+                type: object
+                properties: { run_id: { type: string } }
+        "400": { description: invalid task / max_steps }
+        "429": { description: at capacity (global or per-tenant) }
+  /runs/{id}:
+    get:
+      tags: [runs]
+      summary: Get a run record
+      parameters: [{ $ref: "#/components/parameters/RunId" }]
+      responses:
+        "200":
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/RunRecord" }
+        "404": { description: not found }
+  /runs/{id}/execution:
+    get:
+      tags: [runs]
+      summary: Operator-truth execution snapshot
+      parameters: [{ $ref: "#/components/parameters/RunId" }]
+      responses:
+        "200":
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ExecutionSession" }
+  /runs/{id}/execution/stream:
+    get:
+      tags: [runs]
+      summary: Live execution snapshots (SSE)
+      description: text/event-stream of ExecutionSession snapshots; closes on terminal status.
+      parameters: [{ $ref: "#/components/parameters/RunId" }]
+      responses:
+        "200":
+          description: SSE stream
+          content:
+            text/event-stream:
+              schema: { type: string }
+  /runs/{id}/world:
+    get:
+      tags: [governance]
+      summary: World projection (folded from committed deltas)
+      parameters: [{ $ref: "#/components/parameters/RunId" }]
+      responses:
+        "200": { description: world projection }
+  /runs/{id}/replay:
+    get:
+      tags: [governance]
+      summary: Verify the ledger and fold the world (replay)
+      description: Recomputes the hash chain and folds committed deltas; provider/tool-free.
+      parameters: [{ $ref: "#/components/parameters/RunId" }]
+      responses:
+        "200":
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ReplayReport" }
+  /runs/{id}/approvals/{channel}:
+    post:
+      tags: [governance]
+      summary: Approve or deny a suspended proposal
+      parameters:
+        - { $ref: "#/components/parameters/RunId" }
+        - { name: channel, in: path, required: true, schema: { type: string } }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/ApprovalRequest" }
+      responses:
+        "200": { description: decision recorded }
+        "404": { description: no pending approval for this run/channel }
+  /runs/{id}/cancel:
+    post:
+      tags: [runs]
+      summary: Cancel an in-flight run
+      parameters: [{ $ref: "#/components/parameters/RunId" }]
+      responses:
+        "200": { description: cancelling }
+  /audit/entries:
+    get:
+      tags: [governance]
+      summary: Ledger entries for a run (the audit trail)
+      parameters:
+        - { name: run_id, in: query, required: true, schema: { type: string } }
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: "#/components/schemas/Entry" }
+        "404": { description: run not found or has no trajectory }
+  /usage:
+    get:
+      tags: [governance]
+      summary: API gateway usage stats (per key)
+      responses:
+        "200": { description: usage stats }
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  parameters:
+    RunId:
+      name: id
+      in: path
+      required: true
+      schema: { type: string }
+  schemas:
+    Health:
+      type: object
+      properties:
+        status: { type: string, example: ok }
+        mode: { type: string, enum: [reference, production] }
+        default_provider: { type: string, example: anthropic }
+        cognition_live:
+          type: boolean
+          description: false = runs without their own cognition use the deterministic mock
+        ledger: { type: string, enum: [sqlite, postgres] }
+        shutdown: { type: boolean }
+    CreateRunRequest:
+      type: object
+      required: [task]
+      properties:
+        task: { type: string, maxLength: 10000 }
+        max_steps: { type: integer, default: 16, maximum: 256 }
+        tool_scopes:
+          type: array
+          items: { type: string }
+          description: Writ scope; empty grants `*`. e.g. ["fs_read","grep"]
+        cognition: { $ref: "#/components/schemas/CognitionConfig" }
+    CognitionConfig:
+      type: object
+      properties:
+        provider:
+          type: string
+          description: anthropic | openai | ollama | lmstudio | groq | gemini | … (preset id)
+        model: { type: string }
+        max_tokens: { type: integer }
+        base_url: { type: string }
+        thinking_budget_tokens: { type: integer }
+    RunRecord:
+      type: object
+      properties:
+        run_id: { type: string }
+        trajectory_id: { type: string }
+        task: { type: string }
+        status: { type: string, enum: [running, completed, failed] }
+        tenant_id: { type: string }
+        summary: { $ref: "#/components/schemas/RunSummary" }
+    RunSummary:
+      type: object
+      properties:
+        steps_executed: { type: integer }
+        intents_submitted: { type: integer }
+        commits: { type: integer }
+        rejections: { type: integer }
+        failures: { type: integer }
+        final_answer: { type: [string, "null"] }
+        terminated_by: { type: string }
+    ExecutionSession:
+      type: object
+      properties:
+        run_id: { type: string }
+        task: { type: string }
+        trajectory_id: { type: [string, "null"] }
+        status: { type: string, enum: [running, waiting_approval, completed, failed, cancelled] }
+        phase: { type: string, enum: [system, intent, proposal, execution, result] }
+        current_step: { type: integer }
+        max_steps: { type: integer }
+        final_answer: { type: [string, "null"] }
+        log:
+          type: array
+          items: { $ref: "#/components/schemas/LogEntry" }
+    LogEntry:
+      type: object
+      properties:
+        idx: { type: integer }
+        phase: { type: string }
+        level: { type: string, enum: [info, success, warning, error] }
+        title: { type: string }
+        detail: { type: string }
+        commit_id: { type: [string, "null"] }
+        seq: { type: [integer, "null"] }
+    Entry:
+      type: object
+      properties:
+        seq: { type: integer }
+        kind: { type: string, description: ROOT | Commit | Rejection | PendingApproval | Delegation | … }
+        id: { type: string }
+        detail: {}
+        commit_id: { type: string, description: full 64-hex id (commit entries only) }
+    ReplayReport:
+      type: object
+      properties:
+        run_id: { type: string }
+        trajectory_id: { type: string }
+        entries_seen: { type: integer }
+        commits_replayed: { type: integer }
+        head_commit: { type: [string, "null"] }
+        head_seq: { type: integer }
+        final_world_hash: { type: string }
+        rejected_proposals: { type: integer }
+        pending_approvals: { type: integer }
+        delegations: { type: integer }
+    ApprovalRequest:
+      type: object
+      required: [approve]
+      properties:
+        approve: { type: boolean }
+        proposal_id: { type: [string, "null"] }

--- a/docs/rfcs/enterprise-and-monetization.md
+++ b/docs/rfcs/enterprise-and-monetization.md
@@ -1,0 +1,152 @@
+# Design: Enterprise, Machine-Programmability & Monetization
+
+Status: **Draft / strategy** · Scope: how OpenThymos becomes machine-drivable at
+enterprise scale and how that is monetized — **without** weakening the core
+invariant or the no-phone-home value. Nothing here lets cognition assert
+authority; every addition is a control-plane or observability surface around the
+existing `Intent → Proposal → Commit` pipeline.
+
+---
+
+## 0. The unfair advantage (what we sell that others can't)
+
+Every LLM agent product bills **per token** and asks you to *trust* what the
+agent did. OpenThymos can do the one thing they structurally cannot:
+
+> **Bill per *governed action*, and let the customer audit every charge against
+> an append-only, replayable ledger.**
+
+A commit is a content-addressed, hash-chained, optionally-signed record of *one
+authorized effect*. That makes a governed action a **countable, provable,
+non-repudiable unit** — a billing primitive *and* a compliance artifact at once.
+"You were charged for exactly these 1,204 authorized actions; here is the
+cryptographic proof of each, under whose writ, and which policy permitted it."
+No token-metered competitor can offer provable billing. This is the wedge.
+
+---
+
+## 1. What already exists (the enterprise bones)
+
+Grounded in the code — we are closer than it looks:
+
+| Capability | Where it lives today |
+|---|---|
+| **API-key gateway + usage tracking** | `middleware::ApiGateway`, `GET /usage` (`usage_stats()`), `thymos-gateway.db` |
+| **Multi-tenancy** | `auth::JwtClaims.tenant_id`, tenant-scoped writs, per-tenant concurrency caps |
+| **RBAC primitive** | `JwtClaims.roles` (admin-gated control-plane endpoints) |
+| **Bearer-token auth** | HMAC-SHA256 JWT middleware |
+| **Durable, distributable ledger** | SQLite default; **Postgres backend** selectable on the HTTP runtime |
+| **Signed tool supply chain** | `thymos-marketplace` (signed manifests) |
+| **Operator-owned telemetry** | OTLP to the operator's endpoint (no phone-home) |
+| **Commercial licensing intent** | `COMMERCIAL-LICENSE.md`, `GOVERNANCE.md` |
+
+So the monetization substrate (auth, tenancy, gateway, usage, durable ledger) is
+**already present**. The work is to formalize it into products.
+
+---
+
+## 2. Machine-programmability surface (drive it from anything)
+
+"More machine programming" = make every capability reachable, typed, and
+automatable by other systems — not just humans in the app.
+
+1. **OpenAPI 3.1 spec** (`docs/openapi.yaml`, shipped alongside this RFC) — the
+   contract. Generates typed SDKs in any language, powers API explorers, and is
+   the enterprise integration handshake. *This is the single highest-leverage
+   machine-programmability artifact and costs no runtime change.*
+2. **Webhooks / event egress** — *operator-configured* (never phone-home;
+   opt-in, off by default, documented — per the core value) push of governance
+   events (`commit`, `rejection`, `approval_required`, `run_finished`) to a
+   customer endpoint (SIEM, Slack, PagerDuty, ServiceNow). Turns the runtime
+   into a node in an enterprise event mesh.
+3. **External approval gateway** — a suspended `Irreversible` proposal calls out
+   to the customer's approval system and resumes on signed callback
+   (`POST /runs/:id/approvals/:channel`). Human-in-the-loop at enterprise scale,
+   recorded on the ledger (who approved, when).
+4. **Idempotency keys** on `POST /runs` — machine-safe retries (an at-least-once
+   caller can't double-spawn). The commit layer is already idempotent per
+   proposal id; extend that to run creation.
+5. **Stable, versioned API** + the existing pipe-friendly CLI and Rust SDK
+   (`thymos-client`) round out three integration tiers (HTTP, CLI, in-process).
+
+---
+
+## 3. Enterprise edition (what regulated buyers need)
+
+These are the open-core line items — each maps to a real compliance/ops need:
+
+- **SSO / OIDC / SAML** — replace (or augment) the HMAC JWT with enterprise IdP
+  federation; map IdP groups → `roles` → writ ceilings.
+- **RBAC enforcement** — roles already in the token; enforce role→capability
+  (who may approve `Irreversible`, who may mint writs, who may revoke).
+- **Provable compliance reports** — signed, exportable audit packs per
+  tenant/time-range (commits, rejections, approvals, the policy decision per
+  action, replay verdict). The auditor's artifact, on demand.
+- **Retention & legal hold** — ledger retention windows, immutable export to
+  object storage, e-discovery query API.
+- **HA Postgres ledger** — multi-replica, backup/restore, the distributed
+  execution ledger (Phase III) productized with an SLA.
+- **Data-residency / air-gap** — fully self-hosted, no egress (already a value);
+  region-pinned ledgers for the managed offering.
+- **Metering API** (§4) — per-tenant governed-action counts for chargeback.
+
+---
+
+## 4. The metering keystone (build this first to unlock revenue)
+
+A per-tenant **metering API** is the smallest change that turns the existing
+gateway + ledger into a billable product:
+
+- Aggregate, per tenant + period: `runs`, `commits` (governed actions),
+  `rejections`, `approvals`, `tokens`, `tool_calls`, by effect class.
+- Source of truth is the **ledger** (already counts these), so every metered
+  number is **auditable** — the customer can replay and reconcile their bill.
+- Expose `GET /metering?tenant=&from=&to=` (admin/tenant-scoped) + a signed
+  export for billing pipelines (Stripe usage records, etc.).
+- This is provable usage-based billing — the §0 wedge made concrete.
+
+---
+
+## 5. Monetization model (open-core, three lines)
+
+1. **OSS core (Apache-2.0)** — the runtime, governance, ledger, replay, CLI,
+   single-tenant self-host. The credibility + adoption engine. *Never crippled.*
+2. **Enterprise edition (commercial license)** — §3 features (SSO, RBAC
+   enforcement, compliance reports, retention/legal-hold, HA Postgres, support
+   SLA). Sold to regulated industries (finance, healthcare, gov) that *must*
+   prove what their agents did. `COMMERCIAL-LICENSE.md` already anticipates this.
+3. **Managed Cloud** — hosted governed runtime, **metered per governed action**
+   (§4) and/or per operator seat (the web operator console). The meter is the
+   gateway + metering API; the proof is the ledger.
+
+Additional streams: **marketplace take-rate** on paid signed tools/skills;
+**provable-compliance reports** as a per-seat or per-export add-on.
+
+**Guardrails (non-negotiable):** monetization must never add phone-home or
+silent egress; usage signal stays operator-owned and auditable; the OSS core
+stays genuinely useful (no "open-core bait"). Candor is the brand.
+
+---
+
+## 6. Real-vs-needed (honest)
+
+| Item | Status |
+|---|---|
+| API gateway, usage stats, tenancy, roles, JWT | **exists** |
+| Postgres ledger backend | **exists** (selectable) |
+| OpenAPI spec | **new** — `docs/openapi.yaml` (ships with this RFC) |
+| Metering API (`/metering`) | **needs build** (small; aggregates the ledger) |
+| Webhooks / event egress | **needs build** (operator-configured, opt-in) |
+| Idempotency keys on `POST /runs` | **needs build** (small) |
+| SSO/OIDC, RBAC enforcement, compliance export, retention | **needs build** (enterprise edition) |
+
+## 7. Recommended build order
+
+1. **OpenAPI spec** (done here) → unblocks SDKs + enterprise integration today.
+2. **Metering API** → unlocks usage-based billing (smallest path to revenue).
+3. **Webhooks** → enterprise event-mesh integration.
+4. **Idempotency keys** → machine-safe automation.
+5. **SSO + RBAC enforcement + compliance export** → the enterprise edition.
+
+Each is independently shippable and strengthens (never blurs) the authority
+boundary. Items 2–7 each get their own RFC before code.


### PR DESCRIPTION
## Why
more machine-programming, enterprise, — grounded in what already exists (API gateway, JWT tenant/roles, Postgres ledger, marketplace, commercial license).

## Two deliverables
- **`docs/rfcs/enterprise-and-monetization.md`** — open-core model. The wedge: **bill per *governed action*** (a ledger commit), so usage-based billing is **provable and auditable** against the ledger — something no token-metered competitor can offer. Plus the machine-programmability surface (OpenAPI, webhooks, external approval gateway, idempotency keys), the enterprise edition (SSO, RBAC enforcement, compliance export, retention/legal-hold, HA Postgres), an honest real-vs-needed table, and a build order. Guardrail: **never** add phone-home; the OSS core stays genuinely useful.
- **`docs/openapi.yaml`** — OpenAPI 3.1 contract for the core surface (health, runs, execution SSE, replay, approvals, cancel, audit, usage). Generates typed SDKs in any language. Validated (12 paths, 10 schemas).

Strategy + contract only — **no runtime change**. Each build item (metering API first) gets its own RFC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)