### PR TITLE
fix(docs): unbreak Validate Site — liquid links in skill-narrowing demo

### DIFF
--- a/docs/demos/skill-narrowing.md
+++ b/docs/demos/skill-narrowing.md
@@ -17,9 +17,9 @@ does the opposite, by construction:
 
 The effective authority is the *intersection* of the caller's writ and the skill:
 `tools = requested ∩ allow-list`, `ceiling = AND`, `budget = min`. This is the same
-strict-subset rule that governs [delegation](./delegation-lineage/), applied to a
+strict-subset rule that governs [delegation]({{ '/demos/delegation-lineage' | relative_url }}), applied to a
 template instead of a parent writ. The binding is recorded as a content-addressed
-`skill_bound` ledger entry that [replay](../replay/) re-verifies by hash.
+`skill_bound` ledger entry that [replay]({{ '/replay' | relative_url }}) re-verifies by hash.
 
 Every claim here is asserted in
 [`thymos-core`'s `skill` tests](https://github.com/gryszzz/open-thymos/blob/main/thymos/crates/thymos-core/src/skill.rs)


### PR DESCRIPTION
## Problem

`main` is red — the **Validate Site** workflow (`scripts/check-docs.mjs`) has failed on the last two pushes (runs #74/#75) since the skills PR (#61) merged:

```
- docs/demos/skill-narrowing.md: missing target docs/demos/delegation-lineage
- docs/demos/skill-narrowing.md: missing target docs/replay
```

The checker resolves relative markdown links as **literal filesystem paths**, so `./delegation-lineage/` and `../replay/` pointed at nonexistent *directories* (the real files are `delegation-lineage.md` / `replay.md`).

## Fix

Switch those two links to the repo's established Jekyll convention, `{{ '/path' | relative_url }}` (used throughout `docs/`, e.g. `delegation-lineage.md` links to other demos this way). The checker maps that form to the real `.md` target, and it renders correctly on the published site.

Two links changed; no other content touched.

## Verified

- `node scripts/check-docs.mjs` → **Documentation check passed for 55 files.**
- The `next build` half of the job was already passing; this unblocks the `docs:check` half.

Branched off `main` (the skills feature already merged via #61 squash, so the original feature branch was stale for a hotfix).

https://claude.ai/code/session_01BTiNYcDGfvthQMJwfCgBjY

---
_Generated by [Claude Code](https://claude.ai/code/session_01BTiNYcDGfvthQMJwfCgBjY)_