### PR TITLE
chore(ci,docs): reconcile Phase III status + wire gated live-provider CI job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -71,3 +71,25 @@ jobs:
         run: |
           cargo test -p thymos-ledger --features postgres \
             --test postgres_integration -- --ignored --nocapture
+
+  # Prove the live-LLM agent loop end-to-end when a key is configured. The test
+  # skips cleanly (prints SKIP, passes) when ANTHROPIC_API_KEY is unset, so this
+  # job is green without the secret and only spends a real API call when one is
+  # set. Restricted to pushes on `main` to avoid spending budget on every PR
+  # (and forks never receive the secret anyway).
+  live-provider:
+    name: Live provider (gated)
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: thymos
+      - name: Run gated live-provider test (skips cleanly without a key)
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          cargo test -p thymos-runtime --test live_provider \
+            -- --ignored --nocapture

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,12 +37,19 @@ outside commit folding, or makes replay depend on a live provider), don't.
 - **Phase I — Unified deterministic runtime.** Largely done: I→P→C, ledger as
   truth, replay, signed writs, typed tools, policy traces.
 - **Phase II — Multi-agent coordination.** Delegation, child writs (strict
-  subsets of parent), child trajectories — implemented + tested; needs a
-  demonstrable end-to-end walkthrough.
-- **Phase III — Distributed execution ledger.** Postgres backend exists but is
-  **not yet wired into the HTTP runtime** (blocked on the runtime/ledger trait
-  refactor). This is the biggest claims-vs-reality gap; closing it is top
-  priority. See the tracking issues.
+  subsets of parent), child trajectories — implemented + tested, with a
+  demonstrable walkthrough (`cargo run --example delegation_lineage -p
+  thymos-runtime`, `docs/demos/delegation-lineage.md`). The same strict-subset
+  rule now also governs authority-narrowing **skills** (`skill_narrowing`
+  example + `docs/demos/skill-narrowing.md`).
+- **Phase III — Distributed execution ledger.** The Postgres backend **is wired
+  into the HTTP runtime** (feature-gated): `Runtime<L: LedgerStore>` with a
+  `BlockingPostgresLedger` facade, selected at startup via `THYMOS_POSTGRES_URL`
+  (default build stays SQLite, no Postgres dep compiled). It is **continuously
+  proven in CI** — the `postgres-integration` job in `rust.yml` runs the gated
+  tests against a real Postgres service container (append → read-back →
+  `verify_integrity` → replay). Remaining Phase-III work is operational hardening
+  (multi-writer/distributed semantics), not the basic wiring.
 
 Source of truth for current reality: **`STATUS.md`** (CI-proven vs gated vs
 caveats). Reconcile it every release; if it drifts from the code, the code wins.


### PR DESCRIPTION
## What

Two "make us up to date and ready" fixes:

1. **Reconcile `CLAUDE.md` with reality.** It still claimed the Postgres backend was *"not yet wired into the HTTP runtime (blocked on the runtime/ledger trait refactor) — biggest claims-vs-reality gap."* That's stale: Postgres **is** wired (`Runtime<L: LedgerStore>` + a `BlockingPostgresLedger` facade, selected at startup via `THYMOS_POSTGRES_URL`; default build stays SQLite) and **continuously proven in CI** by the existing `postgres-integration` service-container job. Updated Phase II/III to match (delegation + skills walkthroughs now exist too).

2. **Wire the last gated proof into CI.** Adds a `live-provider` job that runs the `live_provider` test when `ANTHROPIC_API_KEY` is configured and **skips cleanly (green)** when it isn't. Restricted to `push` on `main` so it never spends API budget on PRs (and forks never receive the secret).

## Verified

- `rust.yml` is valid YAML; the new job mirrors the existing gated-Postgres pattern.
- The `live_provider` test already self-skips when the key is absent (`live_anthropic_closes_the_loop_and_commits` returns early with a SKIP notice), so the job is green with or without the secret.
- Docs/`CLAUDE.md` only — no code paths touched.

## Note

To actually exercise the live job, add an `ANTHROPIC_API_KEY` repo secret. Without it the job stays green (skips). Phase III Postgres needs no secret — it uses a service container.

https://claude.ai/code/session_01BTiNYcDGfvthQMJwfCgBjY

---
_Generated by [Claude Code](https://claude.ai/code/session_01BTiNYcDGfvthQMJwfCgBjY)_