### PR TITLE
feat(desktop,server): wire dead Tools tab to real /tools + chat UX & visual overhaul

### DIFF
--- a/thymos/clients/desktop/src/index.html
+++ b/thymos/clients/desktop/src/index.html
@@ -10,7 +10,9 @@
     <!-- Top bar: identity + the governance "is it live" truth from /health -->
     <header class="topbar">
       <div class="brandwrap">
-        <img class="brandlogo" src="logo.png" alt="OpenThymos" />
+        <div class="logobox">
+          <img class="brandlogo" src="logo.png" alt="OpenThymos" />
+        </div>
         <div class="brandtext">
           <div class="brand">OPEN&nbsp;THYMOS</div>
           <div class="tagline">cognition proposes · the runtime governs · the ledger records</div>
@@ -52,6 +54,7 @@
             <button type="button" class="chip" data-scope="http">http</button>
             <button type="button" class="chip" data-scope="test_run">test_run</button>
           </div>
+          <button type="button" class="ghost" id="regenBtn" disabled title="Re-run the last task on a fresh trajectory">↻ Regenerate</button>
           <button type="button" class="ghost" id="newChat">＋ New chat</button>
         </div>
         <div class="feed" id="chatFeed">
@@ -72,8 +75,8 @@
           <select id="composerSkill" title="Bind a skill (narrows authority + adds instructions)">
             <option value="">no skill</option>
           </select>
-          <input id="taskInput" autocomplete="off"
-            placeholder="Describe a task in plain language…" />
+          <textarea id="taskInput" rows="1" autocomplete="off"
+            placeholder="Describe a task in plain language…   (Enter to send · Shift+Enter for a new line)"></textarea>
           <button type="submit" id="sendBtn">Send</button>
           <button type="button" id="chatStop" class="danger" hidden>■ Stop</button>
         </form>
@@ -220,10 +223,19 @@
       <section class="panel" id="tab-tools">
         <div class="panel-head"><h2>Tools</h2>
           <button class="ghost" id="refreshTools">Refresh</button></div>
+        <div class="effect-legend">
+          <span class="effect eff-pure">pure</span>
+          <span class="effect eff-read">read</span>
+          <span class="effect eff-write">write</span>
+          <span class="effect eff-external">external</span>
+          <span class="effect eff-irreversible">irreversible</span>
+        </div>
         <div id="toolsList" class="list"></div>
         <p class="note">
-          Every tool call is checked against the writ's effect ceiling
-          (Read ≤ Write ≤ External ≤ Irreversible) <b>before</b> it runs.
+          These are the runtime's <b>registered tool contracts</b>, each tagged
+          with the effect ceiling the governor enforces. Every call is checked
+          against the writ (Pure ≤ Read ≤ Write ≤ External ≤ Irreversible)
+          <b>before</b> it runs — a tool can never exceed its class.
         </p>
       </section>
 
@@ -248,11 +260,15 @@
             <code>thymos replay &lt;run&gt; --verify</code> or the runtime's
             <code>verify_integrity</code>.
           </p>
+          <div class="ledger-path-row">
+            <span class="dim">ledger file</span>
+            <code id="ledgerPath" class="path">—</code>
+            <button type="button" id="copyLedgerPath" class="ghost">Copy path</button>
+          </div>
           <p class="note">
-            One-click backup/restore + a chain-head integrity report is a v1
-            task wired to the runtime's file path — tracked in
-            <code>docs/rfcs/desktop-app.md §3</code>. Until then this tab tells
-            you the truth instead of pretending.
+            Copy that file anywhere to back it up; restore by pointing the
+            runtime at the copy. One-click backup/restore + a chain-head
+            integrity report is tracked in <code>docs/rfcs/desktop-app.md §3</code>.
           </p>
         </div>
       </section>

--- a/thymos/clients/desktop/src/main.js
+++ b/thymos/clients/desktop/src/main.js
@@ -44,6 +44,7 @@ document.querySelectorAll(".tab").forEach((btn) => {
     if (btn.dataset.tab === "providers") loadHealth();
     if (btn.dataset.tab === "skills") loadSkills();
     if (btn.dataset.tab === "tools") loadTools();
+    if (btn.dataset.tab === "backups") loadBackups();
   });
 });
 
@@ -119,11 +120,25 @@ function selectedScopes() {
   return [...document.querySelectorAll("#grants .chip.on")].map((c) => c.dataset.scope);
 }
 
-// Toggle Send/Stop + input while a run is in flight.
+// Toggle Send/Stop + a live "working" pulse while a run is in flight. The input
+// stays enabled (you can draft the next message); a second run is blocked by the
+// activeRunId guard, not by disabling the field.
 function setBusy(on) {
   $("sendBtn").hidden = on;
   $("chatStop").hidden = !on;
-  $("taskInput").disabled = on;
+  const regen = $("regenBtn");
+  if (regen) regen.disabled = on || !lastTask;
+  let w = document.getElementById("workingLine");
+  if (on && !w) {
+    w = document.createElement("div");
+    w.id = "workingLine";
+    w.className = "working";
+    w.innerHTML = `<span class="dots"><i></i><i></i><i></i></span><span>governing…</span>`;
+    feed.appendChild(w);
+    feed.scrollTop = feed.scrollHeight;
+  } else if (!on && w) {
+    w.remove();
+  }
 }
 
 function renderSnapshot(s) {
@@ -212,15 +227,38 @@ function showApproval(runId) {
   feed.scrollTop = feed.scrollHeight;
 }
 
-$("composer").addEventListener("submit", async (ev) => {
-  ev.preventDefault();
-  const task = $("taskInput").value.trim();
+let lastTask = null;
+
+// A user message rendered as a chat bubble, with its grant/skill context.
+function pushBubble(text, skill, scopes) {
+  const wrap = document.createElement("div");
+  wrap.className = "bubble you-bubble";
+  const body = document.createElement("div");
+  body.className = "bubble-body";
+  body.textContent = text;
+  wrap.appendChild(body);
+  const tags = [];
+  if (skill) tags.push(`✦ ${skill}`);
+  if (scopes && scopes.length) tags.push(`grant: ${scopes.join(", ")}`);
+  if (tags.length) {
+    const meta = document.createElement("div");
+    meta.className = "bubble-meta";
+    meta.textContent = tags.join("   ·   ");
+    wrap.appendChild(meta);
+  }
+  feed.appendChild(wrap);
+  feed.scrollTop = feed.scrollHeight;
+}
+
+// Start a governed run from a task string. Shared by Send and Regenerate.
+async function startRun(task) {
   if (!task || activeRunId) return;
-  $("taskInput").value = "";
+  const welcome = feed.querySelector(".welcome");
+  if (welcome) welcome.remove();
   const skill = $("composerSkill")?.value || "";
   const scopes = selectedScopes();
-  pushLine("you", `you ▸ ${task}${skill ? `  ·  skill: ${skill}` : ""}`);
-  if (scopes.length) pushLine("sys", `— granted: ${scopes.join(", ")}`);
+  lastTask = task;
+  pushBubble(task, skill, scopes);
   setBusy(true);
   try {
     const body = { task };
@@ -228,7 +266,7 @@ $("composer").addEventListener("submit", async (ev) => {
     if (scopes.length) body.tool_scopes = scopes;
     const { run_id } = await postJSON("/runs", body);
     activeRunId = run_id;
-    pushLine("sys", `— run ${run_id}`);
+    pushLine("sys", `— run ${String(run_id).slice(0, 8)}`);
     if (currentStream) currentStream.close();
     renderedUpTo = 0;
     currentStream = new EventSource(api(`/runs/${run_id}/execution/stream`));
@@ -241,6 +279,35 @@ $("composer").addEventListener("submit", async (ev) => {
     activeRunId = null;
     setBusy(false);
   }
+}
+
+$("composer").addEventListener("submit", (ev) => {
+  ev.preventDefault();
+  const task = $("taskInput").value.trim();
+  if (!task || activeRunId) return;
+  $("taskInput").value = "";
+  autoGrow($("taskInput"));
+  startRun(task);
+});
+
+// Enter sends; Shift+Enter inserts a newline (ChatGPT/Claude convention).
+function autoGrow(t) {
+  if (!t || t.tagName !== "TEXTAREA") return;
+  t.style.height = "auto";
+  t.style.height = Math.min(t.scrollHeight, 160) + "px";
+}
+$("taskInput").addEventListener("keydown", (e) => {
+  if (e.key === "Enter" && !e.shiftKey) {
+    e.preventDefault();
+    $("composer").requestSubmit();
+  }
+});
+$("taskInput").addEventListener("input", () => autoGrow($("taskInput")));
+
+// Regenerate: re-run the last task (new trajectory, fresh writ).
+$("regenBtn")?.addEventListener("click", () => {
+  if (activeRunId || !lastTask) return;
+  startRun(lastTask);
 });
 
 /* ---------- runs history ---------- */
@@ -388,26 +455,55 @@ $("providerForm").addEventListener("submit", async (e) => {
   }
 });
 
-/* ---------- tools (marketplace catalog, read-only) ---------- */
+/* ---------- tools: the runtime's governed tool contracts ---------- */
+// Effect class → the ceiling the governor enforces. This is the thymos-unique
+// signal: every tool is tagged with the maximum effect it may ever produce.
+const EFFECT_RANK = { pure: 0, read: 1, write: 2, external: 3, irreversible: 4 };
+function effectClassName(e) {
+  return ["pure", "read", "write", "external", "irreversible"][EFFECT_RANK[e] ?? 1];
+}
 async function loadTools() {
   const el = $("toolsList");
   el.innerHTML = "<div class='hint'>loading…</div>";
   try {
-    const res = await getJSON("/marketplace/search");
-    const pkgs = res.packages || res.results || (Array.isArray(res) ? res : []);
+    const res = await getJSON("/tools");
+    const tools = res.tools || (Array.isArray(res) ? res : []);
     el.innerHTML = "";
-    if (!pkgs.length) { el.innerHTML = "<div class='hint'>no tools published</div>"; return; }
-    pkgs.forEach((p) => {
-      const div = document.createElement("div");
-      div.className = "item";
-      div.innerHTML =
-        `<span class="glyph permit">▣</span><b>${escapeHtml(p.name || "")}</b>` +
-        `<span class="meta">${escapeHtml(p.description || p.version || "")}</span>`;
-      el.appendChild(div);
-    });
-  } catch (e) { el.innerHTML = `<div class='hint'>could not load tools: ${e}</div>`; }
+    if (!tools.length) { el.innerHTML = "<div class='hint'>no tools registered</div>"; return; }
+    tools
+      .sort((a, b) => (EFFECT_RANK[a.effect_class] ?? 0) - (EFFECT_RANK[b.effect_class] ?? 0))
+      .forEach((t) => {
+        const eff = effectClassName(t.effect_class);
+        const div = document.createElement("div");
+        div.className = "item tool-item";
+        div.innerHTML =
+          `<span class="glyph permit">▣</span>` +
+          `<b>${escapeHtml(t.name || "")}</b>` +
+          `<span class="effect eff-${eff}" title="effect ceiling enforced by the governor">${eff}</span>` +
+          (t.risk_class ? `<span class="risk risk-${escapeHtml(t.risk_class)}">${escapeHtml(t.risk_class)} risk</span>` : "") +
+          `<span class="meta">v${escapeHtml(t.version || "1")}</span>`;
+        el.appendChild(div);
+      });
+  } catch (e) { el.innerHTML = `<div class='hint'>could not load tools: ${e}. Is the runtime live?</div>`; }
 }
 $("refreshTools").addEventListener("click", loadTools);
+
+/* ---------- backups: the real on-disk ledger file ---------- */
+async function loadBackups() {
+  const pathEl = $("ledgerPath");
+  if (!pathEl) return;
+  if (!invoke) { pathEl.textContent = "available in the desktop app"; return; }
+  try {
+    const p = await invoke("ledger_path");
+    pathEl.textContent = p || "(runtime not started yet)";
+    const copy = $("copyLedgerPath");
+    if (copy) copy.onclick = async () => {
+      try { await navigator.clipboard.writeText(p); copy.textContent = "Copied"; }
+      catch (_) { copy.textContent = "—"; }
+      setTimeout(() => (copy.textContent = "Copy path"), 1200);
+    };
+  } catch (e) { pathEl.textContent = "could not resolve ledger path: " + e; }
+}
 
 /* ---------- skills: author + tune authority-narrowing templates ---------- */
 async function loadSkills() {

--- a/thymos/clients/desktop/src/styles.css
+++ b/thymos/clients/desktop/src/styles.css
@@ -1,88 +1,153 @@
 :root {
   --bg: #0e0b1a;
+  --bg-2: #0b0818;
   --panel: #15112a;
   --panel-2: #1c1738;
+  --panel-3: #221b42;
   --line: #2b2350;
+  --line-2: #383066;
   --violet: #7c5cff;
   --violet-dim: #6a4ef0;
+  --violet-deep: #5a3fd6;
   --cyan: #45e0ff;
   --text: #e8e6f5;
   --muted: #9b95c4;
   --green: #46d39a;
   --red: #ff6b8a;
   --amber: #ffc24b;
+  --radius: 9px;
+  --radius-sm: 6px;
+  --shadow: 0 8px 30px rgba(0, 0, 0, .35);
+  --glow: 0 0 18px rgba(124, 92, 255, .35);
 }
 
 * { box-sizing: border-box; }
 html, body { margin: 0; height: 100%; }
 body {
-  background: var(--bg);
+  background:
+    radial-gradient(900px 500px at 12% -8%, rgba(124, 92, 255, .14), transparent 60%),
+    radial-gradient(800px 480px at 100% 0%, rgba(69, 224, 255, .08), transparent 55%),
+    linear-gradient(180deg, var(--bg) 0%, var(--bg-2) 100%);
   color: var(--text);
   font: 14px/1.5 -apple-system, "Segoe UI", Roboto, sans-serif;
   display: flex;
   flex-direction: column;
 }
 
+/* Faint tech grid overlay */
+body::before {
+  content: "";
+  position: fixed; inset: 0; z-index: 0; pointer-events: none;
+  background-image:
+    linear-gradient(rgba(124, 92, 255, .035) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(124, 92, 255, .035) 1px, transparent 1px);
+  background-size: 38px 38px;
+  mask-image: radial-gradient(circle at 50% 30%, #000 30%, transparent 85%);
+}
+.topbar, .tabs, main { position: relative; z-index: 1; }
+
 /* Top bar */
 .topbar {
   display: flex; align-items: center; gap: 16px;
-  padding: 10px 16px;
-  background: linear-gradient(180deg, #181232 0%, var(--panel) 100%);
+  padding: 11px 18px;
+  background: linear-gradient(180deg, rgba(28, 22, 52, .92) 0%, rgba(21, 17, 42, .92) 100%);
   border-bottom: 1px solid var(--line);
+  backdrop-filter: blur(8px);
 }
-.brandwrap { display: flex; align-items: center; gap: 11px; }
-.brandlogo {
-  width: 34px; height: 34px; border-radius: 8px;
-  box-shadow: 0 0 14px rgba(124, 92, 255, .45);
+.brandwrap { display: flex; align-items: center; gap: 12px; }
+.logobox {
+  display: grid; place-items: center;
+  width: 42px; height: 42px;
+  border-radius: 11px;
+  background: linear-gradient(145deg, var(--panel-3), var(--panel));
+  border: 1px solid var(--line-2);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, .06),
+    0 0 0 1px rgba(124, 92, 255, .15),
+    0 6px 18px rgba(124, 92, 255, .28);
+  position: relative;
 }
+.logobox::after {
+  content: ""; position: absolute; inset: -1px; border-radius: 12px;
+  padding: 1px; pointer-events: none;
+  background: linear-gradient(140deg, rgba(124, 92, 255, .8), rgba(69, 224, 255, .5), transparent 60%);
+  -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor; mask-composite: exclude;
+}
+.brandlogo { width: 28px; height: 28px; border-radius: 6px; display: block; }
 .brandtext { display: flex; flex-direction: column; line-height: 1.15; }
-.brand { font-weight: 800; letter-spacing: 1.5px; color: var(--violet); font-size: 15px; }
-.tagline { font-size: 10.5px; color: var(--muted); letter-spacing: .2px; }
+.brand { font-weight: 800; letter-spacing: 2px; color: var(--text); font-size: 15px; }
+.brand::first-letter { color: var(--violet); }
+.tagline { font-size: 10.5px; color: var(--muted); letter-spacing: .3px; }
 .status { display: flex; align-items: center; gap: 10px; color: var(--muted); }
 .dot { width: 9px; height: 9px; border-radius: 50%; display: inline-block; }
-.dot-on { background: var(--green); box-shadow: 0 0 8px var(--green); }
+.dot-on { background: var(--green); box-shadow: 0 0 10px var(--green); animation: pulse 2.4s ease-in-out infinite; }
 .dot-off { background: #4a4466; }
+@keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: .45; } }
 .pill {
   background: var(--panel-2); border: 1px solid var(--line);
-  border-radius: 999px; padding: 2px 10px; font-size: 12px;
+  border-radius: 999px; padding: 2px 11px; font-size: 12px;
 }
 .controls { margin-left: auto; display: flex; gap: 8px; }
 
+/* Buttons — crisp, gradient, tech */
 button {
-  background: var(--violet); color: white; border: 0;
-  border-radius: 8px; padding: 7px 14px; cursor: pointer; font-weight: 600;
+  background: linear-gradient(180deg, var(--violet) 0%, var(--violet-deep) 100%);
+  color: white; border: 1px solid rgba(124, 92, 255, .6);
+  border-radius: var(--radius-sm); padding: 7px 15px; cursor: pointer;
+  font-weight: 600; letter-spacing: .2px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, .18), 0 2px 8px rgba(90, 63, 214, .35);
+  transition: transform .08s ease, box-shadow .15s ease, background .15s ease, border-color .15s ease;
 }
-button:hover { background: var(--violet-dim); }
-button.ghost { background: transparent; border: 1px solid var(--line); color: var(--text); }
-button.ghost:hover { background: var(--panel-2); }
+button:hover { box-shadow: inset 0 1px 0 rgba(255, 255, 255, .22), var(--glow); transform: translateY(-1px); }
+button:active { transform: translateY(0); }
+button:disabled { opacity: .45; cursor: not-allowed; transform: none; box-shadow: none; }
+button.ghost {
+  background: linear-gradient(180deg, rgba(34, 27, 66, .6), rgba(28, 23, 56, .6));
+  border: 1px solid var(--line-2); color: var(--text); box-shadow: none;
+}
+button.ghost:hover { background: var(--panel-3); border-color: var(--violet); box-shadow: none; }
+button.danger { background: linear-gradient(180deg, #ff7d97 0%, #e8517a 100%); border-color: rgba(255, 107, 138, .6); }
+button.danger:hover { box-shadow: 0 0 16px rgba(255, 107, 138, .4); }
 
 /* Tabs */
-.tabs { display: flex; gap: 4px; padding: 8px 12px 0; background: var(--panel); }
+.tabs { display: flex; gap: 4px; padding: 9px 14px 0; border-bottom: 1px solid var(--line); }
 .tab {
-  background: transparent; color: var(--muted); border: 0;
-  border-bottom: 2px solid transparent; border-radius: 6px 6px 0 0;
-  padding: 8px 14px; font-weight: 600;
+  background: transparent; color: var(--muted); border: 0; box-shadow: none;
+  border-bottom: 2px solid transparent; border-radius: 7px 7px 0 0;
+  padding: 8px 15px; font-weight: 600; letter-spacing: .3px;
+  transition: color .12s ease, background .12s ease;
 }
-.tab:hover { background: var(--panel-2); color: var(--text); }
-.tab.active { color: var(--text); border-bottom-color: var(--cyan); }
+.tab:hover { background: var(--panel-2); color: var(--text); transform: none; }
+.tab.active {
+  color: var(--text);
+  border-bottom-color: var(--cyan);
+  background: linear-gradient(180deg, rgba(69, 224, 255, .08), transparent);
+  text-shadow: 0 0 12px rgba(69, 224, 255, .4);
+}
 
-main { flex: 1; overflow: auto; padding: 16px; }
-.panel { display: none; max-width: 980px; margin: 0 auto; }
+main { flex: 1; overflow: auto; padding: 18px; }
+.panel { display: none; max-width: 980px; margin: 0 auto; animation: rise .2s ease; }
 .panel.active { display: block; }
+@keyframes rise { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: none; } }
 .panel-head { display: flex; align-items: center; justify-content: space-between; }
-h2 { margin: 4px 0 12px; }
+h2 { margin: 4px 0 14px; letter-spacing: .3px; }
 
 /* Chat */
 .feed {
-  background: var(--panel); border: 1px solid var(--line); border-radius: 10px;
-  padding: 12px; min-height: 360px; max-height: 58vh; overflow: auto;
-  font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 13px;
+  background: linear-gradient(180deg, rgba(21, 17, 42, .9), rgba(17, 13, 34, .9));
+  border: 1px solid var(--line); border-radius: var(--radius);
+  padding: 14px; min-height: 360px; max-height: 58vh; overflow: auto;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, .03);
+}
+.feed .line, .feed .working, .feed .sys {
+  font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 12.5px;
 }
 .welcome { padding: 18px 6px; }
 .spine {
   color: var(--cyan); font-weight: 700; letter-spacing: .5px;
-  padding: 10px 12px; margin-bottom: 12px; border-radius: 8px;
-  background: rgba(69, 224, 255, .06); border: 1px solid var(--line);
+  padding: 11px 13px; margin-bottom: 12px; border-radius: var(--radius-sm);
+  background: rgba(69, 224, 255, .06); border: 1px solid rgba(69, 224, 255, .25);
 }
 .hint, .note { color: var(--muted); }
 .note { font-size: 12.5px; margin-top: 10px; }
@@ -95,47 +160,71 @@ h2 { margin: 4px 0 12px; }
 .deny { color: var(--red); }
 .suspend { color: var(--amber); }
 .sys { color: var(--muted); font-style: italic; }
-.approval-row { display: flex; gap: 8px; align-items: center; margin: 6px 0; }
+.approval-row { display: flex; gap: 8px; align-items: center; margin: 8px 0; padding: 8px 10px; border: 1px solid rgba(255, 194, 75, .35); border-radius: var(--radius-sm); background: rgba(255, 194, 75, .06); }
 .approval-row .q { color: var(--amber); }
 
-.composer { display: flex; gap: 8px; margin-top: 12px; }
-.composer input, .inline-form input, #taskInput {
+/* User message bubble */
+.bubble { display: flex; flex-direction: column; align-items: flex-end; margin: 12px 2px 6px; }
+.you-bubble .bubble-body {
+  background: linear-gradient(180deg, rgba(124, 92, 255, .9), rgba(90, 63, 214, .9));
+  color: #fff; padding: 9px 13px; border-radius: 13px 13px 4px 13px;
+  max-width: 78%; white-space: pre-wrap; box-shadow: 0 4px 14px rgba(90, 63, 214, .3);
+}
+.bubble-meta { font-size: 11px; color: var(--muted); margin-top: 4px; letter-spacing: .2px; }
+
+/* Working indicator */
+.working { display: flex; align-items: center; gap: 9px; color: var(--muted); padding: 6px 4px; }
+.working .dots { display: inline-flex; gap: 4px; }
+.working .dots i {
+  width: 6px; height: 6px; border-radius: 50%; background: var(--violet);
+  animation: blink 1.2s infinite ease-in-out;
+}
+.working .dots i:nth-child(2) { animation-delay: .2s; }
+.working .dots i:nth-child(3) { animation-delay: .4s; }
+@keyframes blink { 0%, 80%, 100% { opacity: .25; transform: scale(.8); } 40% { opacity: 1; transform: scale(1); } }
+
+.composer { display: flex; gap: 8px; margin-top: 12px; align-items: flex-end; }
+.composer #taskInput {
+  flex: 1; background: var(--panel-2); border: 1px solid var(--line-2);
+  color: var(--text); border-radius: var(--radius); padding: 11px 13px; font-size: 14px;
+  font-family: inherit; line-height: 1.45; resize: none; min-height: 44px; max-height: 160px;
+}
+.composer #taskInput:focus { outline: none; border-color: var(--violet); box-shadow: var(--glow); }
+.inline-form input, #mindRunId, #auditRunId {
   flex: 1; background: var(--panel-2); border: 1px solid var(--line);
-  color: var(--text); border-radius: 8px; padding: 10px 12px; font-size: 14px;
+  color: var(--text); border-radius: var(--radius-sm); padding: 10px 12px; font-size: 14px;
 }
 .inline-form { display: flex; gap: 8px; margin-bottom: 12px; }
+.composer #sendBtn { padding: 10px 20px; }
 
-/* Provider settings form: connect any model */
-.provider-form { margin-top: 12px; display: flex; flex-direction: column; gap: 10px; }
+/* Provider settings form */
+.provider-form { margin-top: 12px; display: flex; flex-direction: column; gap: 11px; }
 .provider-form h3 { margin: 0; color: var(--cyan); font-weight: 700; letter-spacing: .4px; font-size: 14px; }
 .provider-form label { display: flex; flex-direction: column; gap: 5px; font-size: 12.5px; color: var(--muted); }
-.provider-form input {
+.provider-form input, .provider-form textarea, .provider-form select {
   background: var(--panel-2); border: 1px solid var(--line);
-  color: var(--text); border-radius: 8px; padding: 9px 11px; font-size: 14px;
-}
-.provider-form input:focus { outline: none; border-color: var(--violet); }
-.provider-actions { display: flex; align-items: center; gap: 12px; margin-top: 2px; }
-.dim { color: var(--muted); font-weight: 400; }
-.provider-form textarea, .provider-form select {
-  background: var(--panel-2); border: 1px solid var(--line);
-  color: var(--text); border-radius: 8px; padding: 9px 11px; font-size: 14px;
+  color: var(--text); border-radius: var(--radius-sm); padding: 9px 11px; font-size: 14px;
   font-family: inherit; resize: vertical;
 }
-.provider-form textarea:focus { outline: none; border-color: var(--violet); }
+.provider-form input:focus, .provider-form textarea:focus, .provider-form select:focus { outline: none; border-color: var(--violet); box-shadow: var(--glow); }
+.provider-actions { display: flex; align-items: center; gap: 12px; margin-top: 2px; }
+.dim { color: var(--muted); font-weight: 400; }
 .ceiling-row { display: flex; gap: 14px; flex-wrap: wrap; margin-top: 4px; }
 .ceiling-row .ck { flex-direction: row; align-items: center; gap: 5px; color: var(--text); }
 .composer select {
-  background: var(--panel-2); border: 1px solid var(--line);
-  color: var(--text); border-radius: 8px; padding: 0 8px; font-size: 13px; max-width: 140px;
+  background: var(--panel-2); border: 1px solid var(--line-2);
+  color: var(--text); border-radius: var(--radius-sm); padding: 0 8px; font-size: 13px; max-width: 140px;
 }
 
 /* Lists / cards */
 .list { display: flex; flex-direction: column; gap: 8px; }
 .card, .item {
-  background: var(--panel); border: 1px solid var(--line);
-  border-radius: 10px; padding: 12px 14px;
+  background: linear-gradient(180deg, var(--panel), rgba(17, 13, 34, .85));
+  border: 1px solid var(--line); border-radius: var(--radius); padding: 12px 14px;
 }
-.item { display: flex; align-items: center; gap: 10px; }
+.item { display: flex; align-items: center; gap: 10px; transition: border-color .12s ease, transform .08s ease; }
+.item:hover { border-color: var(--line-2); }
+.item[style*="cursor: pointer"]:hover, .item.tool-item:hover { border-color: var(--violet); transform: translateX(2px); }
 .item .meta { color: var(--muted); font-size: 12.5px; margin-left: auto; }
 code {
   background: var(--panel-2); border: 1px solid var(--line);
@@ -146,47 +235,63 @@ code {
 .badge.bad { background: rgba(255,107,138,.15); color: var(--red); border: 1px solid var(--red); }
 .glyph { width: 1.4em; display: inline-block; text-align: center; }
 
-/* Chat toolbar: capability grants + new chat */
-.chatbar { display: flex; align-items: center; gap: 12px; margin-bottom: 10px; }
+/* Tool effect-class badges (the governed ceiling) */
+.effect {
+  font-size: 11px; font-weight: 700; letter-spacing: .4px; text-transform: uppercase;
+  padding: 2px 9px; border-radius: 999px; border: 1px solid currentColor;
+}
+.eff-pure { color: var(--muted); }
+.eff-read { color: var(--cyan); }
+.eff-write { color: var(--violet); }
+.eff-external { color: var(--amber); }
+.eff-irreversible { color: var(--red); }
+.risk { font-size: 11px; color: var(--muted); }
+.risk-high, .risk-critical { color: var(--amber); }
+.effect-legend { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 12px; }
+
+/* Chat toolbar */
+.chatbar { display: flex; align-items: center; gap: 12px; margin-bottom: 12px; flex-wrap: wrap; }
 .grants { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
 .grant-label { color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: .6px; }
 .chip {
   background: var(--panel-2); color: var(--muted); border: 1px solid var(--line);
-  border-radius: 999px; padding: 4px 11px; font-size: 12px; font-weight: 600;
+  border-radius: 999px; padding: 4px 12px; font-size: 12px; font-weight: 600; box-shadow: none;
 }
-.chip:hover { color: var(--text); }
+.chip:hover { color: var(--text); transform: none; }
 .chip.on {
   background: rgba(124, 92, 255, .16); color: var(--text);
-  border-color: var(--violet); box-shadow: 0 0 8px rgba(124, 92, 255, .25);
+  border-color: var(--violet); box-shadow: 0 0 10px rgba(124, 92, 255, .3);
 }
-.chatbar #newChat { margin-left: auto; }
-button.danger { background: var(--red); }
-button.danger:hover { background: #e85c7c; }
+.chatbar #regenBtn { margin-left: auto; }
 
 /* Model answer block with copy */
 .answer {
-  margin: 10px 2px 2px; border: 1px solid var(--line); border-radius: 10px;
-  background: rgba(70, 211, 154, .05); overflow: hidden;
+  margin: 12px 2px 2px; border: 1px solid rgba(70, 211, 154, .35); border-radius: var(--radius);
+  background: rgba(70, 211, 154, .05); overflow: hidden; box-shadow: var(--shadow);
 }
 .answer-head {
   display: flex; align-items: center; gap: 8px;
-  padding: 7px 12px; border-bottom: 1px solid var(--line);
+  padding: 8px 13px; border-bottom: 1px solid var(--line);
   color: var(--green); font-weight: 700; font-size: 12.5px;
 }
-.answer-head .copy { margin-left: auto; padding: 3px 10px; font-size: 12px; }
-.answer-body { padding: 12px; white-space: pre-wrap; font-family: -apple-system, "Segoe UI", sans-serif; }
+.answer-head .copy { margin-left: auto; padding: 3px 11px; font-size: 12px; }
+.answer-body { padding: 13px; white-space: pre-wrap; line-height: 1.55; }
+
+/* Backups */
+.ledger-path-row { display: flex; align-items: center; gap: 10px; margin: 12px 0; flex-wrap: wrap; }
+.path { flex: 1; min-width: 0; overflow-wrap: anywhere; color: var(--cyan); }
 
 /* Mind — 3D reasoning view */
 .mind-controls { display: flex; gap: 8px; }
 .mind-controls input {
   background: var(--panel-2); border: 1px solid var(--line); color: var(--text);
-  border-radius: 8px; padding: 7px 10px; min-width: 220px;
+  border-radius: var(--radius-sm); padding: 8px 11px; min-width: 220px;
 }
 .mind-canvas {
   position: relative; width: 100%; height: 60vh; min-height: 380px;
   border: 1px solid var(--line); border-radius: 12px; overflow: hidden;
   background: radial-gradient(ellipse at center, #170f37 0%, #0b0818 72%);
-  cursor: grab;
+  cursor: grab; box-shadow: var(--shadow);
 }
 .mind-canvas:active { cursor: grabbing; }
 .mind-canvas canvas { display: block; width: 100%; height: 100%; }

--- a/thymos/crates/thymos-server/src/lib.rs
+++ b/thymos/crates/thymos-server/src/lib.rs
@@ -545,6 +545,7 @@ pub fn app(state: Arc<AppState>) -> Router {
     let router = Router::new()
         .route("/health", get(health))
         .route("/ready", get(ready))
+        .route("/tools", get(list_tools))
         .route("/runs", get(list_runs).post(create_run))
         .route("/runs/{id}", get(get_run))
         .route("/runs/{id}/execution", get(get_execution))
@@ -1008,6 +1009,41 @@ async fn health(State(state): State<Arc<AppState>>) -> impl IntoResponse {
         "ledger": state.runtime.ledger.backend(),
         "shutdown": *state.shutdown_tx.borrow(),
     }))
+}
+
+/// The runtime's registered tool contracts — name, version, and the effect /
+/// risk class the governor enforces for each. Read-only metadata (like
+/// `/health`); lets a UI show exactly what the runtime can do and at what
+/// effect ceiling, rather than guessing.
+async fn list_tools(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    let names: Vec<String> = state
+        .runtime
+        .tools
+        .names()
+        .map(|s| s.to_string())
+        .collect();
+    let mut tools: Vec<serde_json::Value> = names
+        .iter()
+        .map(|name| match state.runtime.tools.get(name) {
+            Ok(t) => {
+                let m = t.meta();
+                serde_json::json!({
+                    "name": m.name,
+                    "version": m.version,
+                    "effect_class": m.effect_class,
+                    "risk_class": m.risk_class,
+                })
+            }
+            Err(_) => serde_json::json!({ "name": name }),
+        })
+        .collect();
+    tools.sort_by(|a, b| {
+        a["name"]
+            .as_str()
+            .unwrap_or("")
+            .cmp(b["name"].as_str().unwrap_or(""))
+    });
+    Json(serde_json::json!({ "count": tools.len(), "tools": tools }))
 }
 
 async fn ready(State(state): State<Arc<AppState>>) -> impl IntoResponse {

--- a/thymos/crates/thymos-server/tests/e2e.rs
+++ b/thymos/crates/thymos-server/tests/e2e.rs
@@ -52,6 +52,25 @@ async fn health_check() {
 }
 
 #[tokio::test]
+async fn tools_lists_registered_contracts_with_effect_class() {
+    let server = test_server(test_state());
+    let resp = server.get("/tools").await;
+    resp.assert_status_ok();
+    let body: Value = resp.json();
+    let tools = body["tools"].as_array().expect("tools array");
+    assert!(!tools.is_empty(), "runtime registers tools");
+    assert_eq!(body["count"], tools.len());
+    // Every entry carries the governed effect ceiling.
+    for t in tools {
+        assert!(t["name"].is_string());
+        assert!(t["effect_class"].is_string(), "each tool is tagged with an effect class");
+    }
+    // A known read tool is present and classified at the read ceiling.
+    let kv_get = tools.iter().find(|t| t["name"] == "kv_get").expect("kv_get registered");
+    assert_eq!(kv_get["effect_class"], "read");
+}
+
+#[tokio::test]
 async fn ready_check() {
     let server = test_server(test_state());
     let resp = server.get("/ready").await;


### PR DESCRIPTION
## Why

A pass to make the desktop app's tools/headers actually connected, add standard AI-chat affordances, surface what's unique to thymos, and sharpen the visuals.

## Wiring fixes (things that were not connected)

- **Tools tab was dead** — it called a nonexistent `/marketplace/search` endpoint, so it always errored. Now there's a real **`GET /tools`** on `thymos-server` that lists the runtime's **registered tool contracts** with the **effect class + risk class** the governor enforces. The tab renders each with a colour-coded **effect-ceiling badge** (pure ≤ read ≤ write ≤ external ≤ irreversible) — a thymos-unique signal you won't see in a generic chat app.
- **Backups tab** now shows the **real on-disk ledger path** via the existing `ledger_path` Tauri command, with a copy button (was static text).

## Chat UX (ChatGPT / Claude conventions)

- **Multiline composer**: `Enter` sends, `Shift+Enter` newline, auto-growing textarea.
- **User-message bubbles** carrying their grant/skill context.
- Live **"governing…" working indicator** (pulsing dots) while a run is in flight.
- **Regenerate** — re-run the last task on a fresh trajectory/writ.
- Kept Stop + Copy.

## Unique to thymos

The governance spine is the differentiator, so it's surfaced rather than hidden: per-tool effect ceilings, capability **grant** chips on the composer, the intent → proposal → commit verdict feed, and inline **replay ✓ verified** in Audit.

## Visuals

Framed gradient **logo box**, sharper **gradient/tech buttons** with hover glow + crisp corners, a faint **grid background** with radial glows, refined tabs, and the effect-class badges.

## Verified

- `GET /tools` covered by a new e2e test (asserts contracts are returned tagged with `effect_class`; `kv_get` → `read`). `cargo test -p thymos-server` green; `clippy` clean.
- `main.js` / `viz.js` pass `node --check`.

## Not verified here

The desktop app is a **separate Tauri workspace** needing GTK/WebKit libs absent in this sandbox, so it isn't `tauri build`-compiled here — only the release pipeline's desktop job builds it on real OS runners. The frontend is plain HTML/CSS/JS (no build step); the new server endpoint is fully compiled + tested.

https://claude.ai/code/session_01BTiNYcDGfvthQMJwfCgBjY

---
_Generated by [Claude Code](https://claude.ai/code/session_01BTiNYcDGfvthQMJwfCgBjY)_