### PR TITLE
fix(ci): live-provider job must skip on an empty key (unbreak main)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -91,5 +91,12 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
+          # GitHub injects an *empty* env var when the secret is unset, so guard
+          # on emptiness here — otherwise the test sees `Ok("")`, not an error,
+          # and would call the API with no key (401). No key → nothing to prove.
+          if [ -z "$ANTHROPIC_API_KEY" ]; then
+            echo "SKIP live-provider: ANTHROPIC_API_KEY secret not set."
+            exit 0
+          fi
           cargo test -p thymos-runtime --test live_provider \
             -- --ignored --nocapture

--- a/thymos/crates/thymos-runtime/tests/live_provider.rs
+++ b/thymos/crates/thymos-runtime/tests/live_provider.rs
@@ -80,7 +80,13 @@ fn root_writ() -> Writ {
 #[test]
 #[ignore = "live LLM integration — set ANTHROPIC_API_KEY and run with --ignored"]
 fn live_anthropic_closes_the_loop_and_commits() {
-    if std::env::var("ANTHROPIC_API_KEY").is_err() {
+    // Treat an empty value as unset: CI runners inject an empty env var when the
+    // secret is absent, so `is_err()` alone would let the test run keyless.
+    if std::env::var("ANTHROPIC_API_KEY")
+        .ok()
+        .filter(|k| !k.trim().is_empty())
+        .is_none()
+    {
         eprintln!(
             "SKIP live_anthropic_closes_the_loop_and_commits: ANTHROPIC_API_KEY not set. \
              Export a key to run this test for real."


### PR DESCRIPTION
## Problem

`main`'s **Rust** workflow has been red on every push since #63 merged (the `chore(ci,docs)` PR and the desktop #64 merge both show it). Only the new **`Live provider (gated)`** job failed — `build` and `Postgres ledger (live)` stayed green, so no product code is at fault.

Root cause: GitHub Actions injects `ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}` as an **empty string** when the secret doesn't exist. The test only skipped on `env::var(...).is_err()` (truly unset), so with `Ok("")` it ran for real and hit:

```
anthropic API error 401 Unauthorized: x-api-key header is required
```

This job is gated to `push` events, so PR checks (where it's skipped) never caught it — it only fired after merge to `main`. My miss in #63.

## Fix (belt-and-suspenders)

1. **Workflow**: guard the step on `[ -z "$ANTHROPIC_API_KEY" ]` → prints SKIP and `exit 0` when empty.
2. **Test**: treat an empty value as unset (`.filter(|k| !k.trim().is_empty())`), matching the documented "skip cleanly when the resource is absent" contract.

Either fix alone is sufficient; both make it robust locally and in CI.

## Verified

```
ANTHROPIC_API_KEY="" cargo test -p thymos-runtime --test live_provider -- --ignored
→ SKIP … ; test result: ok. 1 passed
```
`rust.yml` is valid YAML. When the secret IS set, the real test runs unchanged.

https://claude.ai/code/session_01BTiNYcDGfvthQMJwfCgBjY

---
_Generated by [Claude Code](https://claude.ai/code/session_01BTiNYcDGfvthQMJwfCgBjY)_