### PR TITLE
fix(ci): live-provider test skips on blank key (unblocks main)

### DIFF
--- a/thymos/crates/thymos-runtime/tests/live_provider.rs
+++ b/thymos/crates/thymos-runtime/tests/live_provider.rs
@@ -80,10 +80,18 @@ fn root_writ() -> Writ {
 #[test]
 #[ignore = "live LLM integration — set ANTHROPIC_API_KEY and run with --ignored"]
 fn live_anthropic_closes_the_loop_and_commits() {
-    if std::env::var("ANTHROPIC_API_KEY").is_err() {
+    // Skip cleanly when the key is missing *or blank*. An unset GitHub Actions
+    // secret expands to an empty string (Ok("")), not an error — so an
+    // `is_err()`-only guard would run the test with a blank key and fail the
+    // live call. Treat empty/whitespace as "not set" and skip (pass), per the
+    // gated-test rule: never fake a green, never a false red.
+    if std::env::var("ANTHROPIC_API_KEY")
+        .map(|k| k.trim().is_empty())
+        .unwrap_or(true)
+    {
         eprintln!(
-            "SKIP live_anthropic_closes_the_loop_and_commits: ANTHROPIC_API_KEY not set. \
-             Export a key to run this test for real."
+            "SKIP live_anthropic_closes_the_loop_and_commits: ANTHROPIC_API_KEY not set \
+             (or empty — e.g. an unset CI secret). Export a real key to run this for real."
         );
         return;
     }


### PR DESCRIPTION
## Why main is red
The `Live provider (gated)` job failed on **every push to main**. An unset GitHub secret expands to an **empty string**, so `ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}` set the env var to `""`. The test's skip guard used `is_err()`, but `env::var` returns `Ok("")` for an empty value — so it didn't skip, ran the live loop with a blank key, the API call failed, and `.expect("live agent run")` panicked.

## Fix
The guard now treats **missing OR blank** as "not set" and skips cleanly (prints SKIP, passes) — per the gated-test rule (never a false red, never a faked green). With a real key it runs for real, unchanged.

## Verified
Locally skips+passes both with the key **unset** and set to **`""`** (the exact CI condition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)