### PR TITLE
feat(desktop): adopt running server + docs on CLI⇄desktop linkage

### DIFF
--- a/docs/using-cli-and-desktop.md
+++ b/docs/using-cli-and-desktop.md
@@ -1,0 +1,108 @@
+# Using the terminal and the desktop together (with a real AI)
+
+OpenThymos has two human surfaces — the **CLI** (`thymos`) and the **desktop
+app** — and they are *not* separate apps with separate state. They are both
+**clients of one `thymos-server`**. Whoever owns `http://localhost:3001` owns the
+runtime, the provider/key, and the durable ledger; both surfaces read and drive
+*the same* truth.
+
+This is verifiable: start a run in the terminal (`thymos run "…"`) and it appears
+in the desktop's **Runs** tab; approve a suspended run from the desktop and the
+terminal's `thymos audit` shows who approved it. Same ledger, same runs, same
+verdicts.
+
+---
+
+## 1. One runtime, two surfaces
+
+```
+        ┌────────────────────────────────────────────┐
+        │            thymos-server  :3001             │
+        │   runtime · provider/key · DURABLE ledger   │
+        └──────────────▲──────────────────▲───────────┘
+                       │ HTTP/SSE          │ HTTP/SSE
+              ┌────────┴───────┐   ┌───────┴────────┐
+              │   Desktop app  │   │  CLI  (thymos) │
+              │  (webview)     │   │  THYMOS_URL→3001│
+              └────────────────┘   └────────────────┘
+```
+
+- The CLI defaults to `http://localhost:3001` (override with `--url` or
+  `THYMOS_URL`).
+- The desktop **adopts** a server already listening on 3001 instead of starting
+  a second one. So either of these works, and the *other* surface just joins:
+  - **Open the desktop app** → it starts the server (with a durable ledger in the
+    OS app-data dir) → then run `thymos …` in a terminal and it's the same runtime.
+  - **Start `thymos-server` yourself** → open the desktop app → it adopts your
+    server.
+- **Rule of thumb:** one server owns 3001. Don't run two; they'd both want the
+  port. Let one own it and point everything else at it.
+
+---
+
+## 2. Connect a real model (both surfaces inherit it)
+
+The provider and API key are **server-side** — set once, used by every surface.
+
+- **Desktop:** Providers tab → pick a provider (Claude, OpenAI, Ollama / LM
+  Studio local, or any OpenAI-compatible adapter) → paste a key → it restarts the
+  runtime with that provider. `thymos run …` in a terminal now uses the same model.
+- **CLI / manual server:** start the server with a key in its environment, e.g.
+  `ANTHROPIC_API_KEY=sk-… thymos-server`. The desktop adopts it and chats use it.
+
+Keys never cross to the model with authority and never leave your machine; only
+the provider *name* crosses the wire. `GET /health` (status bar in the app,
+`thymos health` in the terminal) reports `cognition_live: true` once a real model
+is wired (and `mock` until then — same deterministic mock on both surfaces).
+
+---
+
+## 3. How the agent responds to an action
+
+With a real model, a task runs the governed loop — **the same on both surfaces**,
+because it's the same runtime:
+
+1. **You** send a task (desktop chat, or `thymos run "…"`).
+2. **Cognition proposes.** The model emits *intents* (tool calls). It never
+   executes anything itself — it has no execution authority by type.
+3. **The runtime governs each intent** → a verdict:
+   - **✓ permit** — within the writ's scope, effect ceiling, budget, time window,
+     and policy. The tool runs; a **commit** lands on the ledger.
+   - **✕ deny** — out of scope / over budget / policy `Deny`. Recorded as a
+     *rejection*; nothing executes.
+   - **⏸ require-approval** — irreversible or policy-flagged. The run **suspends**
+     and waits for a human.
+4. **You see it stream** as it happens: `◆ intent  ▸ proposal  ✓ commit`
+   (or `✕ rejected`, `⏸ suspended`), then the final answer.
+5. **Approvals are cross-surface.** A suspended run can be cleared from *either*
+   side and the other sees it:
+   - Desktop: the **Approve / Deny** card.
+   - Terminal: `thymos approve <run-id> <channel>` (add `--deny` to refuse).
+6. **Everything is on the shared ledger.** Inspect the same trail from either
+   surface — the desktop **Audit** tab or `thymos audit <run-id>` — and verify it
+   with `thymos replay <run-id>` (or the app's replay badge). Replay re-folds the
+   ledger independently; it never calls the model or re-runs a tool.
+
+So the agent's "response to an action" is always: **propose → the runtime decides
+→ the result + verdict are recorded and streamed back.** It cannot act outside a
+permitted, recorded proposal — that's the guarantee, and it holds identically
+whether you drove the run from the terminal or the app.
+
+---
+
+## 4. Quick recipe
+
+```bash
+# Terminal A — own the runtime with a real model + a durable ledger
+ANTHROPIC_API_KEY=sk-… THYMOS_LEDGER_PATH=~/.thymos/ledger.db thymos-server
+
+# Open the desktop app — it ADOPTS the server above (shared runtime + ledger).
+
+# Terminal B — drive the same runtime; the app shows these runs live
+thymos run "map this repo and open a PR" --follow --scopes fs_read,grep
+thymos audit <run-id>     # the full governance trail (same as the app's Audit tab)
+thymos replay <run-id>    # verify the ledger folds to its world
+```
+
+The desktop app and the CLI are windows onto one governed runtime — pick whichever
+fits the moment; the runs, the ledger, the approvals, and the proof are shared.

--- a/thymos/clients/desktop/src-tauri/src/lib.rs
+++ b/thymos/clients/desktop/src-tauri/src/lib.rs
@@ -172,6 +172,21 @@ fn start_runtime(app: tauri::AppHandle, state: State<Supervisor>) -> Result<Stri
         }
     }
 
+    // If a Thymos server is already listening on 3001 — one you started in the
+    // terminal, or a prior session — adopt it instead of spawning a conflicting
+    // one. This is what lets the CLI and the desktop share a single runtime +
+    // ledger: whoever owns the port owns the truth, and both surfaces are clients
+    // of it. We only kill servers we ourselves spawned (window-close handler); an
+    // adopted one is left running.
+    if std::net::TcpStream::connect_timeout(
+        &([127, 0, 0, 1], 3001).into(),
+        std::time::Duration::from_millis(300),
+    )
+    .is_ok()
+    {
+        return Ok("adopted-existing".into());
+    }
+
     // Pin a durable, per-user ledger so runs, audit trails, and backups persist
     // across restarts — this is what makes the app a real client of a real,
     // permanent Thymos ledger rather than an ephemeral session. The hash-chained


### PR DESCRIPTION
Makes "use the terminal and the desktop together" correct and documented.

**Code:** the desktop now **adopts** a Thymos server already listening on :3001 (CLI-started or a prior session) instead of spawning a conflicting one — so both surfaces share one runtime, durable ledger, provider/key, and approval queue. We still only kill servers we spawned ourselves.

**Docs:** `docs/using-cli-and-desktop.md` — one-runtime/two-surfaces model (verified: a terminal `thymos run` shows in the app's Runs), connecting a real model once for both, **how the agent responds to each action** (propose → govern → permit/deny/suspend → commit → replay), cross-surface approvals, and the one-server rule.

Verified: desktop host `cargo check` clean; docs validator passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)