### PR TITLE
feat(desktop): Stage 1 — add custom governed tools from the UI

### DIFF
--- a/thymos/clients/desktop/src-tauri/src/lib.rs
+++ b/thymos/clients/desktop/src-tauri/src/lib.rs
@@ -199,9 +199,16 @@ fn start_runtime(app: tauri::AppHandle, state: State<Supervisor>) -> Result<Stri
         .map_err(|e| format!("create app data dir {}: {e}", data_dir.display()))?;
     let ledger_path = data_dir.join("ledger.db");
 
+    // User-defined governed tools: the runtime loads JSON manifests from this
+    // dir (`ToolManifest`), registering each as a first-class tool bound by its
+    // declared effect class. The desktop's Add-tool form writes manifests here.
+    let tools_dir = data_dir.join("tools");
+    let _ = std::fs::create_dir_all(&tools_dir);
+
     let bin = server_binary();
     let mut cmd = Command::new(&bin);
     cmd.env("THYMOS_LEDGER_PATH", &ledger_path);
+    cmd.env("THYMOS_TOOL_MANIFEST_DIRS", &tools_dir);
     apply_provider_env(&mut cmd, &load_provider_config(&app));
     let child = cmd
         .spawn()
@@ -219,6 +226,71 @@ fn ledger_path(app: tauri::AppHandle) -> Result<String, String> {
         .app_data_dir()
         .map_err(|e| format!("resolve app data dir: {e}"))?;
     Ok(dir.join("ledger.db").to_string_lossy().into_owned())
+}
+
+/// Directory holding the user's custom tool manifests (loaded by the runtime via
+/// `THYMOS_TOOL_MANIFEST_DIRS`).
+fn tools_dir(app: &tauri::AppHandle) -> Result<PathBuf, String> {
+    let dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("resolve app data dir: {e}"))?
+        .join("tools");
+    std::fs::create_dir_all(&dir).map_err(|e| format!("create tools dir: {e}"))?;
+    Ok(dir)
+}
+
+/// Persist a custom tool manifest as `<name>.json`. The runtime validates and
+/// registers it on next start; an invalid manifest is skipped by the loader, so
+/// this only does light shape checks (a non-empty, file-safe `name`). The tool
+/// then runs under the same governance as any native tool — its declared
+/// `effect_class` is enforced by the compiler before it can execute.
+#[tauri::command]
+fn save_tool(app: tauri::AppHandle, manifest: serde_json::Value) -> Result<String, String> {
+    let name = manifest
+        .get("name")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .trim()
+        .to_string();
+    if name.is_empty() || !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+        return Err("tool name must be non-empty and use only letters, digits, or _".into());
+    }
+    let path = tools_dir(&app)?.join(format!("{name}.json"));
+    let json = serde_json::to_string_pretty(&manifest).map_err(|e| e.to_string())?;
+    std::fs::write(&path, json).map_err(|e| format!("write {}: {e}", path.display()))?;
+    Ok(path.to_string_lossy().into_owned())
+}
+
+/// List the names of the user's saved tool manifests.
+#[tauri::command]
+fn list_tool_manifests(app: tauri::AppHandle) -> Result<Vec<String>, String> {
+    let dir = tools_dir(&app)?;
+    let mut names = Vec::new();
+    for entry in std::fs::read_dir(&dir).map_err(|e| e.to_string())?.flatten() {
+        let p = entry.path();
+        if p.extension().and_then(|e| e.to_str()) == Some("json") {
+            if let Some(stem) = p.file_stem().and_then(|s| s.to_str()) {
+                names.push(stem.to_string());
+            }
+        }
+    }
+    names.sort();
+    Ok(names)
+}
+
+/// Delete a saved tool manifest by name. Takes effect on the next runtime start.
+#[tauri::command]
+fn delete_tool_manifest(app: tauri::AppHandle, name: String) -> Result<(), String> {
+    let safe = name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_');
+    if !safe {
+        return Err("invalid tool name".into());
+    }
+    let path = tools_dir(&app)?.join(format!("{name}.json"));
+    if path.exists() {
+        std::fs::remove_file(&path).map_err(|e| format!("delete {}: {e}", path.display()))?;
+    }
+    Ok(())
 }
 
 #[tauri::command]
@@ -253,7 +325,10 @@ pub fn run() {
             runtime_running,
             ledger_path,
             get_provider_config,
-            set_provider_config
+            set_provider_config,
+            save_tool,
+            list_tool_manifests,
+            delete_tool_manifest
         ])
         .on_window_event(|window, event| {
             // Don't orphan the runtime when the app window closes.

--- a/thymos/clients/desktop/src/index.html
+++ b/thymos/clients/desktop/src/index.html
@@ -255,6 +255,58 @@
           against the writ (Pure ≤ Read ≤ Write ≤ External ≤ Irreversible)
           <b>before</b> it runs — a tool can never exceed its class.
         </p>
+
+        <details class="addtool">
+          <summary><b>＋ Add a custom tool</b> — declare a governed tool (no code)</summary>
+          <form id="toolForm" class="card provider-form">
+            <div class="row2">
+              <label>Name <input id="tlName" placeholder="deploy_staging" autocomplete="off" /></label>
+              <label>Version <input id="tlVersion" placeholder="1.0.0" value="1.0.0" autocomplete="off" /></label>
+            </div>
+            <label>Description
+              <input id="tlDesc" placeholder="Deploy the current build to staging" autocomplete="off" /></label>
+            <div class="row2">
+              <label>Effect class
+                <select id="tlEffect" title="The most authority this tool may ever exert. Enforced by the governor.">
+                  <option value="read">read — looks only</option>
+                  <option value="write">write — changes local state</option>
+                  <option value="external">external — calls out (HTTP, etc.)</option>
+                  <option value="irreversible">irreversible — can't be undone (needs approval)</option>
+                  <option value="pure">pure — no effect</option>
+                </select>
+              </label>
+              <label>Risk
+                <select id="tlRisk">
+                  <option value="low">low</option>
+                  <option value="medium">medium</option>
+                  <option value="high">high</option>
+                  <option value="critical">critical</option>
+                </select>
+              </label>
+            </div>
+            <label>Executor
+              <select id="tlKind">
+                <option value="shell">shell — run a command ({arg} placeholders)</option>
+                <option value="http">http — call a URL ({arg} placeholders)</option>
+              </select>
+            </label>
+            <label id="tlCmdRow">Command template
+              <input id="tlCmd" placeholder="./deploy.sh {ref}" autocomplete="off" /></label>
+            <label id="tlUrlRow" hidden>URL template
+              <input id="tlUrl" placeholder="https://api.example.com/{path}" autocomplete="off" /></label>
+            <label>Input schema (JSON)
+              <textarea id="tlSchema" rows="3" spellcheck="false">{ "type": "object", "properties": { "ref": { "type": "string" } } }</textarea></label>
+            <div class="addtool-actions">
+              <button type="submit" id="tlSave">Add tool</button>
+              <span id="tlStatus" class="note"></span>
+            </div>
+            <p class="note">
+              The tool is governed exactly like a native one — its effect class is
+              enforced <b>before</b> it can run, every call is recorded on the
+              ledger, and an <b>irreversible</b> tool waits for your approval.
+            </p>
+          </form>
+        </details>
       </section>
 
       <!-- AUDIT: ledger entries + replay verdict for a run -->

--- a/thymos/clients/desktop/src/main.js
+++ b/thymos/clients/desktop/src/main.js
@@ -630,6 +630,62 @@ async function loadTools() {
 }
 $("refreshTools").addEventListener("click", loadTools);
 
+/* ---------- add a custom tool (governed manifest) ---------- */
+// Toggle shell vs http executor fields.
+$("tlKind")?.addEventListener("change", () => {
+  const http = $("tlKind").value === "http";
+  $("tlCmdRow").hidden = http;
+  $("tlUrlRow").hidden = !http;
+});
+
+$("toolForm")?.addEventListener("submit", async (e) => {
+  e.preventDefault();
+  if (!invoke) return;
+  const status = $("tlStatus");
+  const name = $("tlName").value.trim();
+  const kind = $("tlKind").value;
+  // Validation — fail clearly, never write an invalid manifest.
+  if (!/^[a-z][a-z0-9_]*$/.test(name)) {
+    status.textContent = "name must be lower_snake_case (letters, digits, _)"; return;
+  }
+  let schema;
+  try { schema = JSON.parse($("tlSchema").value); }
+  catch (_) { status.textContent = "input schema must be valid JSON"; return; }
+  const exec = kind === "http"
+    ? { kind: "http", url_template: $("tlUrl").value.trim(), method: "GET" }
+    : { kind: "shell", command_template: $("tlCmd").value.trim() };
+  const target = kind === "http" ? exec.url_template : exec.command_template;
+  if (!target) { status.textContent = `${kind === "http" ? "URL" : "command"} template is required`; return; }
+
+  const manifest = {
+    name,
+    version: $("tlVersion").value.trim() || "1.0.0",
+    description: $("tlDesc").value.trim(),
+    effect_class: $("tlEffect").value,
+    risk_class: $("tlRisk").value,
+    input_schema: schema,
+    executor: exec,
+  };
+  status.textContent = "saving…";
+  try {
+    await invoke("save_tool", { manifest });
+    // The runtime loads manifests at startup, so restart to register it.
+    const wasRunning = await invoke("runtime_running").catch(() => false);
+    if (wasRunning) await invoke("stop_runtime").catch(() => {});
+    await invoke("start_runtime").catch(() => {});
+    for (let i = 0; i < 20; i++) {
+      await new Promise((r) => setTimeout(r, 400));
+      await refreshStatus();
+      if ($("dot").classList.contains("dot-on")) break;
+    }
+    await loadTools();
+    status.textContent = `✓ added “${name}” — now governed by the runtime`;
+    $("tlName").value = "";
+  } catch (err) {
+    status.textContent = "could not add tool: " + err;
+  }
+});
+
 /* ---------- backups: the real on-disk ledger file ---------- */
 async function loadBackups() {
   const pathEl = $("ledgerPath");

--- a/thymos/clients/desktop/src/styles.css
+++ b/thymos/clients/desktop/src/styles.css
@@ -335,3 +335,15 @@ button.full { width: 100%; }
 .chat-defaults .grants { display: flex; flex-wrap: wrap; gap: 4px; align-items: center; }
 .chat-main { display: flex; flex-direction: column; min-width: 0; }
 .chat-main .feed { flex: 1; max-height: none; }
+
+/* Add-custom-tool form */
+.addtool { margin-top: 14px; }
+.addtool summary { cursor: pointer; color: var(--cyan); padding: 6px 0; }
+.row2 { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
+.addtool-actions { display: flex; align-items: center; gap: 12px; }
+#toolForm label { display: flex; flex-direction: column; gap: 4px; font-size: 12.5px; color: var(--muted); margin-top: 8px; }
+#toolForm input, #toolForm select, #toolForm textarea {
+  background: var(--panel-2); border: 1px solid var(--line); color: var(--text);
+  border-radius: var(--radius-sm); padding: 7px 9px; font-size: 13px;
+}
+#toolForm textarea { font-family: ui-monospace, Menlo, monospace; }


### PR DESCRIPTION
First slice of user-extensibility (RFC #72): let users **add a custom tool from the desktop, no code** — and keep it fully governed.

**Host:** `start_runtime` sets `THYMOS_TOOL_MANIFEST_DIRS=app-data/tools` (runtime loads user `ToolManifest`s); new commands `save_tool` / `list_tool_manifests` / `delete_tool_manifest`.

**UI:** Tools tab → **Add a custom tool** form — name, effect class (read/write/external/irreversible/pure), risk, shell/http executor with `{arg}` templates, JSON input schema — with client-side validation. Save writes the manifest and restarts the runtime to register it.

**Stays governed:** declared effect class is enforced by the compiler *before* the tool runs; every call commits to the ledger; an irreversible tool waits for approval.

Verified: server logs `loaded 1 manifest tool(s)` from the dir; host `cargo check` clean; JS valid; CLI+server build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)