### PR TITLE
feat(site): per-platform downloads + de-box header logo & hero pill

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2260,3 +2260,78 @@ code {
     transition: none !important;
   }
 }
+
+/* Hero download cluster (per-platform) */
+.thymos-download {
+  margin-top: 26px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-width: 560px;
+}
+.thymos-download-primary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  align-self: flex-start;
+  gap: 10px;
+  padding: 14px 26px;
+  border-radius: 14px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  text-decoration: none;
+  color: #06101f;
+  background: linear-gradient(180deg, #9ec1ff, #6f9bff);
+  border: 1px solid rgba(119, 169, 255, 0.6);
+  box-shadow: 0 18px 44px rgba(64, 105, 167, 0.34);
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+.thymos-download-primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 24px 56px rgba(64, 105, 167, 0.42);
+}
+.thymos-download-plats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.thymos-plat {
+  display: inline-flex;
+  align-items: center;
+  padding: 8px 16px;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  text-decoration: none;
+  color: var(--muted-strong);
+  border: 1px solid rgba(119, 169, 255, 0.24);
+  background: rgba(119, 169, 255, 0.08);
+  transition: color 0.15s ease, border-color 0.15s ease, background 0.15s ease;
+}
+.thymos-plat:hover {
+  color: var(--text);
+  border-color: rgba(119, 169, 255, 0.5);
+  background: rgba(119, 169, 255, 0.14);
+}
+.thymos-download-note {
+  font-size: 0.84rem;
+  color: var(--muted);
+  line-height: 1.55;
+  margin: 2px 0 0;
+}
+.thymos-download-note code {
+  font-size: 0.8rem;
+  padding: 1px 6px;
+  border-radius: 5px;
+  background: rgba(119, 169, 255, 0.1);
+  border: 1px solid rgba(119, 169, 255, 0.2);
+}
+
+/* Top bar: no card box around the logo — let it float on the page */
+.thymos-header {
+  border: none;
+  background: none;
+  box-shadow: none;
+  -webkit-backdrop-filter: none;
+  backdrop-filter: none;
+}
+.thymos-header::before { display: none; }

--- a/src/components/marketing/ThymosLanding.tsx
+++ b/src/components/marketing/ThymosLanding.tsx
@@ -179,11 +179,6 @@ export function ThymosLanding() {
 
         <section className="thymos-hero" id="top">
           <div className="thymos-hero-copy">
-            <div className="thymos-pill thymos-reveal thymos-delay-1">
-              <span className="thymos-pill-dot" />
-              Unified AI execution runtime
-            </div>
-
             <h1 className="thymos-reveal thymos-delay-2">{siteConfig.headline}</h1>
             <p className="thymos-hero-lede thymos-reveal thymos-delay-3">{siteConfig.tagline}</p>
             <p className="thymos-hero-subcopy thymos-reveal thymos-delay-4">
@@ -210,6 +205,37 @@ export function ThymosLanding() {
               >
                 Open the wiki
               </a>
+            </div>
+
+            <div className="thymos-download thymos-reveal thymos-delay-5">
+              <a
+                className="thymos-download-primary"
+                href={siteConfig.releasesUrl}
+                target="_blank"
+                rel="noreferrer"
+              >
+                ⬇ Download OpenThymos
+              </a>
+              <div className="thymos-download-plats">
+                {["macOS", "Linux", "Windows"].map((plat) => (
+                  <a
+                    key={plat}
+                    className="thymos-plat"
+                    href={siteConfig.releasesUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    {plat}
+                  </a>
+                ))}
+              </div>
+              <p className="thymos-download-note">
+                CLI + runtime for every platform — no Rust, no compile. One line:{" "}
+                <code>curl -fsSL …/scripts/get.sh | sh</code>. The desktop app
+                (chat, Mind view, audit) builds from source today; signed{" "}
+                <code>.dmg</code> / <code>.msi</code> / <code>.AppImage</code> ship
+                with the next release.
+              </p>
             </div>
 
             <div className="thymos-launch-notes thymos-reveal thymos-delay-6">

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -50,5 +50,7 @@ export const siteConfig = {
   issuesUrl: `${githubUrl}/issues`,
   readmeUrl: `${githubUrl}#readme`,
   wikiUrl: `${githubUrl}/wiki`,
+  releasesUrl: `${githubUrl}/releases/latest`,
+  getScriptUrl: `${githubUrl}/blob/main/scripts/get.sh`,
   org: "Exponet Labs",
 };


### PR DESCRIPTION
Pages landing page polish:
- **Download cluster** in the hero — primary **Download OpenThymos** + **macOS / Linux / Windows** chips → releases/latest, plus the curl one-liner and a desktop-app note.
- **Removed the text-pill box** above the title.
- **Removed the card box around the top-left logo** (header border/background/shadow/::before) so the mark floats.

Verified: `npm run site:check` passes (Next.js build + docs check, 58 files).

Note: actual desktop/CLI **screenshots** still need to be captured and dropped into `public/` — flagged, not faked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)