### PR TITLE
feat(server): MCP Stage 2 — connect MCP servers as governed tools

### DIFF
--- a/docs/rfcs/user-extensibility.md
+++ b/docs/rfcs/user-extensibility.md
@@ -81,11 +81,14 @@ server's tools become governed Thymos tools (databases, browsers, SaaS, cloud).
 }
 ```
 
-- **Finish:** a `THYMOS_MCP_CONFIG` (path) loaded at startup that calls
-  `McpBridge::spawn_all` per server and registers the discovered tools, tagging
-  each with the **operator-declared effect class** for that server (a user
-  can't let an MCP tool claim a lower effect than the operator assigned). Add a
-  desktop **Tools → Connect MCP server** form.
+- **Shipped (server-side):** `THYMOS_MCP_CONFIG` (a JSON file
+  `{ "servers": { "<name>": ["uvx", "<pkg>"], … } }`) is loaded at startup;
+  each server is spawned via `register_mcp_server` and its tools registered,
+  defaulting to effect class **External** (a writ must grant External for any to
+  run). A server that can't spawn is logged and skipped — it never blocks
+  startup. **Remaining:** a desktop **Tools → Connect MCP server** form, and
+  per-server operator-assigned effect ceiling (currently the safe External
+  default).
 - **Stays governed:** an MCP tool is a tool — it runs only under a writ that
   grants its scope + effect, every call commits to the ledger, replay sees it.
   MCP servers are subprocesses, so they inherit the existing process-isolation

--- a/thymos/crates/thymos-server/src/lib.rs
+++ b/thymos/crates/thymos-server/src/lib.rs
@@ -520,10 +520,7 @@ fn build_runtime(
     tools.register(TestRunTool::default());
 
     load_programmable_capabilities(&mut tools, tool_manifest_dirs);
-
-    // To register MCP server tools at startup:
-    //   tools.register_mcp_server("my-server", &["uvx", "my-mcp-server"])
-    //       .expect("spawn MCP server");
+    load_mcp_servers(&mut tools);
 
     let policy = PolicyEngine::new().with(WritAuthorityPolicy);
     Arc::new(Runtime::new(ledger, tools, policy))
@@ -535,6 +532,51 @@ fn load_programmable_capabilities(tools: &mut ToolRegistry, tool_manifest_dirs: 
             .load_manifest_dir(FsPath::new(dir))
             .unwrap_or_else(|e| panic!("load tool manifests from {dir}: {e}"));
         eprintln!("capabilities: loaded {count} manifest tool(s) from {dir}");
+    }
+}
+
+/// Connect MCP servers listed in `THYMOS_MCP_CONFIG` (a JSON file:
+/// `{ "servers": { "<name>": ["uvx", "<pkg>"], ... } }`). Each server's tools are
+/// registered as **governed** Thymos tools (default effect class `External`, so a
+/// writ must grant External for any of them to run; every call commits to the
+/// ledger). Failure to spawn a server is logged and skipped — a missing or broken
+/// MCP server never prevents the runtime from starting.
+fn load_mcp_servers(tools: &mut ToolRegistry) {
+    let Ok(path) = std::env::var("THYMOS_MCP_CONFIG") else {
+        return;
+    };
+    if path.trim().is_empty() {
+        return;
+    }
+    let content = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("mcp: could not read THYMOS_MCP_CONFIG {path}: {e}");
+            return;
+        }
+    };
+    #[derive(serde::Deserialize)]
+    struct McpConfig {
+        #[serde(default)]
+        servers: std::collections::BTreeMap<String, Vec<String>>,
+    }
+    let cfg: McpConfig = match serde_json::from_str(&content) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("mcp: invalid config {path}: {e}");
+            return;
+        }
+    };
+    for (name, command) in cfg.servers {
+        if command.is_empty() {
+            eprintln!("mcp: skip '{name}': empty command");
+            continue;
+        }
+        let cmd_refs: Vec<&str> = command.iter().map(String::as_str).collect();
+        match tools.register_mcp_server(&name, &cmd_refs) {
+            Ok(n) => eprintln!("mcp: connected '{name}' — {n} governed tool(s)"),
+            Err(e) => eprintln!("mcp: skip '{name}': {e}"),
+        }
     }
 }
 


### PR DESCRIPTION
Makes **"connect any tool, all governed"** real (RFC #72, Stage 2).

`THYMOS_MCP_CONFIG` (a JSON file `{ "servers": { "<name>": ["uvx","<pkg>"], ... } }`) is loaded at startup; each MCP server is spawned and its tools registered via `register_mcp_server`. They're governed like native tools — default effect class **External** (a writ must grant External for any to run; every call commits to the ledger).

**Safe by construction:** a server that can't spawn is logged and **skipped** — a missing/broken MCP server never blocks startup. Verified: server compiles; a bogus server config is skipped and `/health` still serves.

Stage-2 remainder (follow-ups): the desktop **Connect MCP server** form (stacks after #73 to avoid host-file conflicts) and per-server operator-assigned effect ceiling (currently the safe External default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)