### PR TITLE
feat(desktop): one-click starter templates for skills + tools

### DIFF
--- a/thymos/clients/desktop/src/index.html
+++ b/thymos/clients/desktop/src/index.html
@@ -207,6 +207,12 @@
 
         <form id="skillForm" class="card provider-form">
           <h3>Create / tune a skill</h3>
+          <div class="starter-row">
+            <span class="starter-label">Start from a template:</span>
+            <button type="button" class="chip" data-skill="repo-reader">Repo reader</button>
+            <button type="button" class="chip" data-skill="web-research">Web researcher</button>
+            <button type="button" class="chip" data-skill="safe-editor">Safe editor</button>
+          </div>
           <label>Name <input id="skName" autocomplete="off" placeholder="diff-review" /></label>
           <label>Title <span class="dim">(optional)</span>
             <input id="skTitle" autocomplete="off" placeholder="Review a code diff" /></label>
@@ -259,6 +265,11 @@
         <details class="addtool">
           <summary><b>＋ Add a custom tool</b> — declare a governed tool (no code)</summary>
           <form id="toolForm" class="card provider-form">
+            <div class="starter-row">
+              <span class="starter-label">Start from a template:</span>
+              <button type="button" class="chip" data-tool="shell">Shell command</button>
+              <button type="button" class="chip" data-tool="http">HTTP request</button>
+            </div>
             <div class="row2">
               <label>Name <input id="tlName" placeholder="deploy_staging" autocomplete="off" /></label>
               <label>Version <input id="tlVersion" placeholder="1.0.0" value="1.0.0" autocomplete="off" /></label>

--- a/thymos/clients/desktop/src/main.js
+++ b/thymos/clients/desktop/src/main.js
@@ -768,6 +768,49 @@ $("skClear")?.addEventListener("click", () => {
   $("skStatus").textContent = "";
 });
 
+// One-click starter templates — prefill a working example so users don't start
+// from a blank technical form. They can tweak then save.
+const SKILL_TEMPLATES = {
+  "repo-reader": { name: "repo-reader", title: "Read & summarize a repo",
+    instructions: "Explore the repository read-only and summarize what you find. Do not modify anything.",
+    tools: "fs.read, grep", read: true, write: false, external: false, irrev: false },
+  "web-research": { name: "web-research", title: "Research on the web",
+    instructions: "Research the question using HTTP and cite your sources.",
+    tools: "http", read: true, write: false, external: true, irrev: false },
+  "safe-editor": { name: "safe-editor", title: "Edit code safely",
+    instructions: "Make minimal, well-explained edits. Always read a file before you change it.",
+    tools: "fs.read, fs.patch, grep", read: true, write: true, external: false, irrev: false },
+};
+document.querySelectorAll("#skillForm .starter-row .chip").forEach((b) =>
+  b.addEventListener("click", () => {
+    const t = SKILL_TEMPLATES[b.dataset.skill];
+    if (!t) return;
+    $("skName").value = t.name; $("skTitle").value = t.title;
+    $("skInstr").value = t.instructions; $("skTools").value = t.tools;
+    $("skRead").checked = t.read; $("skWrite").checked = t.write;
+    $("skExternal").checked = t.external; $("skIrrev").checked = t.irrev;
+    $("skStatus").textContent = "template loaded — tweak and Save";
+  }));
+
+const TOOL_TEMPLATES = {
+  shell: { name: "run_script", desc: "Run a shell command", effect: "write", risk: "medium",
+    kind: "shell", cmd: "./script.sh {arg}", url: "",
+    schema: '{ "type": "object", "properties": { "arg": { "type": "string" } } }' },
+  http: { name: "call_api", desc: "Call an HTTP API", effect: "external", risk: "medium",
+    kind: "http", cmd: "", url: "https://api.example.com/{path}",
+    schema: '{ "type": "object", "properties": { "path": { "type": "string" } } }' },
+};
+document.querySelectorAll("#toolForm .starter-row .chip").forEach((b) =>
+  b.addEventListener("click", () => {
+    const t = TOOL_TEMPLATES[b.dataset.tool];
+    if (!t) return;
+    $("tlName").value = t.name; $("tlDesc").value = t.desc;
+    $("tlEffect").value = t.effect; $("tlRisk").value = t.risk;
+    $("tlKind").value = t.kind; $("tlKind").dispatchEvent(new Event("change"));
+    $("tlCmd").value = t.cmd; $("tlUrl").value = t.url; $("tlSchema").value = t.schema;
+    $("tlStatus").textContent = "template loaded — tweak and Add tool";
+  }));
+
 $("skillForm")?.addEventListener("submit", async (e) => {
   e.preventDefault();
   const name = $("skName").value.trim();

--- a/thymos/clients/desktop/src/styles.css
+++ b/thymos/clients/desktop/src/styles.css
@@ -347,3 +347,12 @@ button.full { width: 100%; }
   border-radius: var(--radius-sm); padding: 7px 9px; font-size: 13px;
 }
 #toolForm textarea { font-family: ui-monospace, Menlo, monospace; }
+
+/* One-click starter templates for skill/tool forms */
+.starter-row { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin-bottom: 10px; }
+.starter-label { font-size: 12px; color: var(--muted); }
+.starter-row .chip {
+  background: var(--panel-2); border: 1px solid var(--line-2); color: var(--text);
+  border-radius: 999px; padding: 5px 12px; font-size: 12px; cursor: pointer; box-shadow: none;
+}
+.starter-row .chip:hover { border-color: var(--violet); background: var(--panel-3); transform: none; }


### PR DESCRIPTION
Makes skill/tool creation easier to work around — each form gets **Start from a template** chips that prefill a working example to tweak + save:
- **Skills:** Repo reader · Web researcher · Safe editor
- **Tools:** Shell command · HTTP request

Frontend only; governance unchanged (saved skills still narrow; saved tools still bound by effect class). `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)