### PR TITLE
feat(skills): multi-skill runtime — combine multiple skills per chat (governed)

### DIFF
--- a/thymos/clients/desktop/src/index.html
+++ b/thymos/clients/desktop/src/index.html
@@ -55,11 +55,12 @@
                  chosen per message. -->
             <div class="chat-defaults">
               <div class="def-title">This model can…</div>
-              <label class="def">Skill
-                <select id="defaultSkill" title="Bound to every chat on this model (narrows authority). Saved.">
-                  <option value="">none</option>
-                </select>
-              </label>
+              <div class="def">
+                <span>Skills <span class="dim">(combine any — they only narrow)</span></span>
+                <div id="skillChips" class="skill-chips" title="Active skills for this chat. Multiple combine: their tools union, their limits AND. Saved per chat.">
+                  <span class="hint sk-empty">no skills yet</span>
+                </div>
+              </div>
               <div class="grants" id="grants" title="Default writ scope for this model — the runtime rejects anything not granted. Saved.">
                 <span class="grant-label">grant</span>
                 <button type="button" class="chip on" data-scope="fs_read">fs_read</button>

--- a/thymos/clients/desktop/src/main.js
+++ b/thymos/clients/desktop/src/main.js
@@ -131,7 +131,7 @@ let activeRunId = null;
 // chat on this model inherits them. Empty grant selection lets the server grant
 // `*` (all tools).
 const GRANTS_KEY = "thymos.grants.v1";
-const SKILL_KEY = "thymos.defaultSkill.v1";
+const SKILLS_KEY = "thymos.skills.v1"; // array of active skill names (multi-skill)
 document.querySelectorAll("#grants .chip").forEach((chip) =>
   chip.addEventListener("click", () => {
     chip.classList.toggle("on");
@@ -140,7 +140,16 @@ document.querySelectorAll("#grants .chip").forEach((chip) =>
 function selectedScopes() {
   return [...document.querySelectorAll("#grants .chip.on")].map((c) => c.dataset.scope);
 }
-// Restore saved grants + default skill (called at boot and after skills load).
+// Active skills for the chat — multiple can be on at once; they combine (the
+// runtime unions their tools and ANDs their limits, so authority only narrows).
+function selectedSkills() {
+  return [...document.querySelectorAll("#skillChips .chip.on")].map((c) => c.dataset.skill);
+}
+function savedSkills() {
+  try { const a = JSON.parse(localStorage.getItem(SKILLS_KEY) || "[]"); return Array.isArray(a) ? a : []; }
+  catch (_) { return []; }
+}
+// Restore saved grants + active skills (called at boot and after skills load).
 function restoreDefaults() {
   try {
     const saved = JSON.parse(localStorage.getItem(GRANTS_KEY) || "null");
@@ -149,11 +158,9 @@ function restoreDefaults() {
         c.classList.toggle("on", saved.includes(c.dataset.scope)));
     }
   } catch (_) {}
-  const sk = $("defaultSkill");
-  if (sk) {
-    try { const v = localStorage.getItem(SKILL_KEY); if (v !== null) sk.value = v; } catch (_) {}
-    sk.onchange = () => { try { localStorage.setItem(SKILL_KEY, sk.value); } catch (_) {} };
-  }
+  const on = savedSkills();
+  document.querySelectorAll("#skillChips .chip").forEach((c) =>
+    c.classList.toggle("on", on.includes(c.dataset.skill)));
 }
 
 // Toggle Send/Stop + a live "working" pulse while a run is in flight. The input
@@ -355,8 +362,8 @@ async function startRun(task) {
   if (!task || activeRunId) return;
   const welcome = feed.querySelector(".welcome");
   if (welcome) welcome.remove();
-  // Authority comes from the saved model defaults (left rail), not per chat.
-  const skill = $("defaultSkill")?.value || "";
+  // Authority comes from the active skills + grants in the left rail.
+  const skills = selectedSkills();
   const scopes = selectedScopes();
   lastTask = task;
   pushBubble(task);
@@ -364,7 +371,7 @@ async function startRun(task) {
   setBusy(true);
   try {
     const body = { task };
-    if (skill) body.skill = skill;
+    if (skills.length) body.skills = skills;
     if (scopes.length) body.tool_scopes = scopes;
     const { run_id } = await postJSON("/runs", body);
     activeRunId = run_id;
@@ -706,7 +713,7 @@ async function loadBackups() {
 /* ---------- skills: author + tune authority-narrowing templates ---------- */
 async function loadSkills() {
   const el = $("skillsList");
-  const sel = $("defaultSkill");
+  const chipsEl = $("skillChips");
   try {
     const res = await getJSON("/skills");
     const skills = res.skills || [];
@@ -726,13 +733,27 @@ async function loadSkills() {
         el.appendChild(div);
       });
     }
-    if (sel) {
-      sel.innerHTML =
-        '<option value="">none</option>' +
-        skills
-          .map((s) => `<option value="${escapeHtml(s.name)}">${escapeHtml(s.name)} (v${s.version})</option>`)
-          .join("");
-      restoreDefaults(); // reselect the saved default skill for this model
+    // Multi-select skill chips: any combination can be active at once.
+    if (chipsEl) {
+      if (!skills.length) {
+        chipsEl.innerHTML = "<span class='hint sk-empty'>no skills yet</span>";
+      } else {
+        chipsEl.innerHTML = "";
+        skills.forEach((s) => {
+          const chip = document.createElement("button");
+          chip.type = "button";
+          chip.className = "chip";
+          chip.dataset.skill = s.name;
+          chip.title = `${s.title || s.name} — narrows authority. Click to toggle.`;
+          chip.textContent = `✦ ${s.name}`;
+          chip.addEventListener("click", () => {
+            chip.classList.toggle("on");
+            try { localStorage.setItem(SKILLS_KEY, JSON.stringify(selectedSkills())); } catch (_) {}
+          });
+          chipsEl.appendChild(chip);
+        });
+      }
+      restoreDefaults(); // re-activate the saved set of skills
     }
   } catch (e) {
     el.innerHTML = `<div class='hint'>could not load skills: ${e}</div>`;

--- a/thymos/clients/desktop/src/styles.css
+++ b/thymos/clients/desktop/src/styles.css
@@ -356,3 +356,16 @@ button.full { width: 100%; }
   border-radius: 999px; padding: 5px 12px; font-size: 12px; cursor: pointer; box-shadow: none;
 }
 .starter-row .chip:hover { border-color: var(--violet); background: var(--panel-3); transform: none; }
+
+/* Multi-select skill chips (active skills combine) */
+.skill-chips { display: flex; flex-wrap: wrap; gap: 6px; }
+.skill-chips .chip {
+  background: var(--panel-2); border: 1px solid var(--line-2); color: var(--muted);
+  border-radius: 999px; padding: 4px 11px; font-size: 12px; cursor: pointer; box-shadow: none;
+}
+.skill-chips .chip:hover { border-color: var(--violet); color: var(--text); transform: none; }
+.skill-chips .chip.on {
+  background: linear-gradient(180deg, rgba(124,92,255,.9), rgba(90,63,214,.9));
+  border-color: var(--violet); color: #fff;
+}
+.sk-empty { font-size: 12px; }

--- a/thymos/crates/thymos-runtime/src/agent_async.rs
+++ b/thymos/crates/thymos-runtime/src/agent_async.rs
@@ -57,7 +57,7 @@ pub async fn run_agent_streaming<L: LedgerStore>(
     event_tx: broadcast::Sender<CognitionEvent>,
     approval_requester: Option<ApprovalRequester>,
     trace_tx: Option<AgentEventCallback>,
-    bound_skill: Option<thymos_core::skill::SkillDef>,
+    bound_skills: Vec<thymos_core::skill::SkillDef>,
     skill_params: Vec<(String, String)>,
 ) -> Result<AgentRunSummary> {
     // Seed the trajectory from the writ id (unique per run via the writ's
@@ -67,14 +67,14 @@ pub async fn run_agent_streaming<L: LedgerStore>(
     let run = runtime.create_run(task, writ.id.0.as_bytes())?;
     let trajectory_id = run.trajectory_id();
 
-    // Record a bound skill at seq 1, immediately after the genesis root, so the
-    // provenance sits with the run's start; replay verifies it inline. The
-    // narrowing itself already happened via the signed `writ`. Soft-fail: a
-    // provenance write must not abort an otherwise-authorized run.
-    if let Some(skill) = bound_skill {
+    // Record each bound skill right after the genesis root, so the provenance of
+    // every skill that narrowed this run sits with its start; replay verifies it
+    // inline. The narrowing itself already happened via the signed `writ`.
+    // Soft-fail: a provenance write must not abort an otherwise-authorized run.
+    for skill in bound_skills {
         let _ = runtime
             .ledger
-            .append_skill_bound(trajectory_id, skill, skill_params);
+            .append_skill_bound(trajectory_id, skill, skill_params.clone());
     }
 
     emit_event(

--- a/thymos/crates/thymos-server/src/lib.rs
+++ b/thymos/crates/thymos-server/src/lib.rs
@@ -441,7 +441,14 @@ pub struct CreateRunRequest {
     /// budget min); it can never widen authority.
     #[serde(default)]
     pub skill: Option<String>,
-    /// Param overrides for the bound skill (`[[key, value], …]`).
+    /// Multiple skills to bind together (by `name` or content-id). They combine
+    /// safely: instructions concatenate, tool scopes UNION (then ∩ the writ),
+    /// effect ceilings AND, budgets min — so the result is always a strict
+    /// subset of the writ, never a widening. `skill` (singular) is merged in for
+    /// back-compat.
+    #[serde(default)]
+    pub skills: Vec<String>,
+    /// Param overrides for the bound skill(s) (`[[key, value], …]`).
     #[serde(default)]
     pub skill_params: Vec<(String, String)>,
 }
@@ -1358,7 +1365,7 @@ async fn resume_run(
             cognition_tx,
             Some(approval_requester),
             Some(trace_tx),
-            None,
+            Vec::new(), // resumed run: no skill provenance
             Vec::new(),
         )
         .await;
@@ -1527,10 +1534,22 @@ async fn create_run(
 
     // Resolve an optional bound skill. It NARROWS authority (never widens) and
     // prepends its instructions to the task.
-    let bound_skill = match req.skill.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
-        None => None,
-        Some(name_or_id) => match state.skills.resolve(name_or_id) {
-            Some(s) => Some(s),
+    // Resolve every requested skill: the singular `skill` plus `skills`, deduped
+    // by name. Unknown skill ⇒ 400.
+    let mut skill_names: Vec<String> = Vec::new();
+    if let Some(s) = req.skill.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+        skill_names.push(s.to_string());
+    }
+    for s in &req.skills {
+        let s = s.trim();
+        if !s.is_empty() && !skill_names.iter().any(|n| n == s) {
+            skill_names.push(s.to_string());
+        }
+    }
+    let mut bound_skills: Vec<thymos_core::skill::SkillDef> = Vec::new();
+    for name_or_id in &skill_names {
+        match state.skills.resolve(name_or_id) {
+            Some(s) => bound_skills.push(s),
             None => {
                 return (
                     StatusCode::BAD_REQUEST,
@@ -1538,10 +1557,10 @@ async fn create_run(
                 )
                     .into_response()
             }
-        },
-    };
-    // Validate enum params against the skill's declared choices.
-    if let Some(s) = &bound_skill {
+        }
+    }
+    // Validate enum params against every bound skill's declared choices.
+    for s in &bound_skills {
         for (k, v) in &req.skill_params {
             if let Some(p) = s.params.iter().find(|p| &p.key == k) {
                 if !p.accepts(v) {
@@ -1558,13 +1577,15 @@ async fn create_run(
     }
 
     let run_id = uuid::Uuid::new_v4().to_string();
-    let task = match &bound_skill {
-        Some(s) => format!(
-            "{}\n\n---\nTask: {}",
-            s.render_instructions(&req.skill_params),
-            req.task
-        ),
-        None => req.task.clone(),
+    // Prepend every bound skill's instructions, then the task.
+    let task = if bound_skills.is_empty() {
+        req.task.clone()
+    } else {
+        let instrs: Vec<String> = bound_skills
+            .iter()
+            .map(|s| s.render_instructions(&req.skill_params))
+            .collect();
+        format!("{}\n\n---\nTask: {}", instrs.join("\n\n"), req.task)
     };
 
     let user_id = if let Some(axum::Extension(claims)) = &jwt_claims {
@@ -1601,26 +1622,34 @@ async fn create_run(
         usd_millicents: 0,
     };
     let base_ceiling = EffectCeiling::read_write_local();
-    // Apply skill narrowing — strictly an intersection, so authority can only
-    // shrink: tools = (requested ∩ skill allow-list), ceiling = AND, budget = min.
-    let (scopes, budget, effect_ceiling) = match &bound_skill {
-        None => (base_scopes, base_budget, base_ceiling),
-        Some(s) => {
-            let scopes = if s.tools.is_empty() {
-                base_scopes
-            } else {
-                s.tools
-                    .iter()
-                    .filter(|st| base_scopes.iter().any(|rs| rs.covers(st)))
-                    .cloned()
-                    .collect()
-            };
-            (
-                scopes,
-                s.cap_budget(&base_budget),
-                s.cap_ceiling(&base_ceiling),
-            )
+    // Combine all bound skills — the result is always a STRICT SUBSET of the
+    // writ, never a widening: tool scopes = (⋃ skills' allow-lists) ∩ requested
+    // base; effect ceiling = AND across skills; budget = min across skills. A
+    // skill with an empty tool list adds no extra tool limit (keeps the base).
+    let (scopes, budget, effect_ceiling) = if bound_skills.is_empty() {
+        (base_scopes, base_budget, base_ceiling)
+    } else {
+        let any_unrestricted = bound_skills.iter().any(|s| s.tools.is_empty());
+        let scopes: Vec<ToolPattern> = if any_unrestricted {
+            base_scopes.clone()
+        } else {
+            // Union of every skill's allow-listed tools, kept only where the
+            // requested base already covers them (so ⊆ base ⊆ writ). Duplicate
+            // patterns are harmless (they don't widen authority).
+            bound_skills
+                .iter()
+                .flat_map(|s| s.tools.iter())
+                .filter(|st| base_scopes.iter().any(|rs| rs.covers(st)))
+                .cloned()
+                .collect()
+        };
+        let mut budget = base_budget;
+        let mut ceiling = base_ceiling;
+        for s in &bound_skills {
+            budget = s.cap_budget(&budget);
+            ceiling = s.cap_ceiling(&ceiling);
         }
+        (scopes, budget, ceiling)
     };
 
     let writ = match Writ::sign(
@@ -1710,7 +1739,7 @@ async fn create_run(
     let state2 = state.clone();
     let run_id2 = run_id.clone();
     let task2 = task.clone();
-    let bound_skill2 = bound_skill.clone();
+    let bound_skills2 = bound_skills.clone();
     let skill_params2 = req.skill_params.clone();
 
     tokio::spawn(async move {
@@ -1770,7 +1799,7 @@ async fn create_run(
             cognition_tx,
             Some(approval_requester),
             Some(trace_tx),
-            bound_skill2.clone(),
+            bound_skills2.clone(),
             skill_params2.clone(),
         );
 


### PR DESCRIPTION
First working slice of the desktop spec: **multiple active skills at once**, governed.

**Safe by construction** — combining skills only *shrinks* relative to the writ: tool scopes **union** then **∩ requested base**, effect ceilings **AND**, budgets **min**, instructions concatenated. Always a strict subset of the writ.

**Backend:** `CreateRunRequest.skills: [...]` (keeps `skill` for back-compat); binding folds all skills; `run_agent_streaming` takes `Vec<SkillDef>` and writes a `skill_bound` ledger entry per skill (provenance).

**Desktop:** single skill picker → **multi-select chips** in the chat rail; active set persists locally; chat sends `skills: [...]`.

**Verified:** `skill_narrowing` example still proves effective authority ⊊ writ + replay verifies skill hashes + tampered skill rejected; server + runtime compile clean; JS valid.

(Independent of #77 templates — cherry-picked onto main cleanly.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)