### PR TITLE
feat(desktop): provider/model management — live model discovery + test connection

### DIFF
--- a/thymos/clients/desktop/src-tauri/Cargo.toml
+++ b/thymos/clients/desktop/src-tauri/Cargo.toml
@@ -21,6 +21,9 @@ tauri-build = { version = "2", features = [] }
 tauri = { version = "2", features = [] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+# Light blocking HTTP client for host-side model discovery + connection tests
+# (the webview's CSP can't reach provider URLs; the host does it locally).
+ureq = { version = "2", features = ["json", "tls"] }
 
 [features]
 # Tauri custom protocol assets in production builds.

--- a/thymos/clients/desktop/src-tauri/src/lib.rs
+++ b/thymos/clients/desktop/src-tauri/src/lib.rs
@@ -217,6 +217,73 @@ fn start_runtime(app: tauri::AppHandle, state: State<Supervisor>) -> Result<Stri
     Ok("started".into())
 }
 
+/// Build the `/models` request for a provider — the host makes this call
+/// locally (the webview's CSP can't reach provider URLs), with the stored key
+/// applied as the right auth header. OpenAI-compatible by default; Anthropic
+/// uses `x-api-key` + a version header.
+fn models_request(provider: &str, base_url: &str, api_key: &str) -> ureq::Request {
+    let anthropic = provider.eq_ignore_ascii_case("anthropic");
+    let base = if !base_url.trim().is_empty() {
+        base_url.trim().trim_end_matches('/').to_string()
+    } else if anthropic {
+        "https://api.anthropic.com/v1".to_string()
+    } else {
+        "https://api.openai.com/v1".to_string()
+    };
+    let mut req = ureq::get(&format!("{base}/models"))
+        .timeout(std::time::Duration::from_secs(10));
+    if anthropic {
+        if !api_key.is_empty() {
+            req = req.set("x-api-key", api_key);
+        }
+        req = req.set("anthropic-version", "2023-06-01");
+    } else if !api_key.is_empty() {
+        req = req.set("Authorization", &format!("Bearer {api_key}"));
+    }
+    req
+}
+
+/// Test that a provider is reachable with the stored credentials (no secret
+/// crosses to the webview — the host reads it and reports only the result).
+#[tauri::command]
+fn test_provider(app: tauri::AppHandle, provider: String, base_url: String) -> Result<String, String> {
+    let cfg = load_provider_config(&app);
+    match models_request(&provider, &base_url, &cfg.api_key).call() {
+        Ok(resp) => {
+            let v: serde_json::Value = resp.into_json().unwrap_or(serde_json::json!({}));
+            let n = v.get("data").and_then(|d| d.as_array()).map(|a| a.len()).unwrap_or(0);
+            Ok(format!("reachable — {n} models"))
+        }
+        Err(ureq::Error::Status(code, _)) => Err(format!("HTTP {code} — check the key / base URL")),
+        Err(e) => Err(format!("not reachable: {e}")),
+    }
+}
+
+/// Discover the models a provider offers (OpenAI-compatible `/models`; Ollama,
+/// LM Studio, vLLM, etc. all serve this). Returns the model ids.
+#[tauri::command]
+fn discover_models(app: tauri::AppHandle, provider: String, base_url: String) -> Result<Vec<String>, String> {
+    let cfg = load_provider_config(&app);
+    let resp = models_request(&provider, &base_url, &cfg.api_key)
+        .call()
+        .map_err(|e| match e {
+            ureq::Error::Status(c, _) => format!("HTTP {c} — check the key / base URL"),
+            other => format!("not reachable: {other}"),
+        })?;
+    let v: serde_json::Value = resp.into_json().map_err(|e| e.to_string())?;
+    let mut models: Vec<String> = v
+        .get("data")
+        .and_then(|d| d.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|m| m.get("id").and_then(|i| i.as_str()).map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+    models.sort();
+    Ok(models)
+}
+
 /// Absolute path to the durable ledger the supervised runtime writes to. The
 /// Backups tab uses this to copy/verify the real on-disk chain.
 #[tauri::command]
@@ -326,6 +393,8 @@ pub fn run() {
             ledger_path,
             get_provider_config,
             set_provider_config,
+            test_provider,
+            discover_models,
             save_tool,
             list_tool_manifests,
             delete_tool_manifest

--- a/thymos/clients/desktop/src/index.html
+++ b/thymos/clients/desktop/src/index.html
@@ -163,14 +163,17 @@
               <option value="mock">Mock — offline, deterministic</option>
             </datalist>
           </label>
-          <label>Model <span class="dim">(blank = provider default)</span>
-            <input id="pfModel" autocomplete="off" placeholder="e.g. claude-sonnet-4-6 · llama3.2 · gpt-4o" /></label>
+          <label>Model <span class="dim">(blank = provider default · or Discover for the live list)</span>
+            <input id="pfModel" list="modelList" autocomplete="off" placeholder="e.g. claude-sonnet-4-6 · llama3.2 · gpt-4o" />
+            <datalist id="modelList"></datalist></label>
           <label>Base URL <span class="dim">(OpenAI-compatible / self-hosted — optional)</span>
             <input id="pfBaseUrl" autocomplete="off" placeholder="e.g. http://localhost:11434/v1" /></label>
           <label>API key <span class="dim">(stored locally on this machine; local models need none)</span>
             <input id="pfKey" type="password" autocomplete="off" placeholder="leave blank to keep current key" /></label>
           <div class="provider-actions">
             <button type="submit">Save &amp; restart runtime</button>
+            <button type="button" id="pfTest" class="ghost">Test connection</button>
+            <button type="button" id="pfDiscover" class="ghost">Discover models</button>
             <span id="pfStatus" class="dim"></span>
           </div>
         </form>

--- a/thymos/clients/desktop/src/main.js
+++ b/thymos/clients/desktop/src/main.js
@@ -604,6 +604,41 @@ $("providerForm").addEventListener("submit", async (e) => {
   }
 });
 
+// Resolve the base URL: the typed field, else the provider's preset default.
+function resolveBaseUrl() {
+  const url = $("pfBaseUrl").value.trim();
+  if (url) return url;
+  const p = $("pfProvider").value.trim().toLowerCase();
+  return (typeof PRESETS !== "undefined" && PRESETS[p] && PRESETS[p].url) || "";
+}
+
+// Test connection — host pings the provider's /models with the SAVED key.
+$("pfTest")?.addEventListener("click", async () => {
+  if (!invoke) return;
+  const provider = $("pfProvider").value.trim();
+  if (!provider) { $("pfStatus").textContent = "pick a provider first"; return; }
+  $("pfStatus").textContent = "testing…";
+  try {
+    const r = await invoke("test_provider", { provider, baseUrl: resolveBaseUrl() });
+    $("pfStatus").textContent = "✓ " + r;
+  } catch (e) { $("pfStatus").textContent = "✕ " + e + " (Save first if you changed the key)"; }
+});
+
+// Discover models — populate the Model field's list with the provider's real models.
+$("pfDiscover")?.addEventListener("click", async () => {
+  if (!invoke) return;
+  const provider = $("pfProvider").value.trim();
+  if (!provider) { $("pfStatus").textContent = "pick a provider first"; return; }
+  $("pfStatus").textContent = "discovering models…";
+  try {
+    const models = await invoke("discover_models", { provider, baseUrl: resolveBaseUrl() });
+    $("modelList").innerHTML = models.map((m) => `<option value="${escapeHtml(m)}"></option>`).join("");
+    $("pfStatus").textContent = models.length
+      ? `${models.length} models found — pick one in Model`
+      : "no models returned";
+  } catch (e) { $("pfStatus").textContent = "✕ " + e + " (Save the key first if needed)"; }
+});
+
 /* ---------- tools: the runtime's governed tool contracts ---------- */
 // Effect class → the ceiling the governor enforces. This is the thymos-unique
 // signal: every tool is tagged with the maximum effect it may ever produce.


### PR DESCRIPTION
First slice of **full provider/model management**.

The host (the webview's CSP can't reach provider URLs) now talks to providers locally via a light blocking HTTP client (`ureq`):
- **`test_provider`** — pings the provider's `/models` with the *stored* key; reports reachable + model count, or a clear HTTP error. The secret never crosses to the UI.
- **`discover_models`** — returns the provider's **real** model ids (OpenAI-compatible `/models` → OpenAI, Ollama, LM Studio, vLLM, Groq, OpenRouter, …; Anthropic via `x-api-key` + version header).
- **UI** — Providers form gets **Test connection** + **Discover models**; discovered models fill the Model field's autocomplete (**real models only, no hardcoded fakes**; manual entry still works).

Host `cargo check` clean; JS valid. Follow-ups (next slices): per-chat / per-skill model selection, custom HTTP providers, capability flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)