### PR TITLE
chore(release): v0.7.0 — version bump + README download button

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="./thymos/thymosG.PNG" alt="OpenThymos" width="325" />
 
-[](https://github.com/gryszzz/open-thymos/releases/latest) [![Star on GitHub](https://img.shields.io/badge/⭐_Star-on_GitHub-yellow?style=for-the-badge)](https://github.com/gryszzz/open-thymos) [![License](https://img.shields.io/badge/License-Apache_2.0-blue?style=for-the-badge)](LICENSE) ![Rust](https://img.shields.io/badge/Rust-Execution_Runtime-orange?style=for-the-badge&logo=rust)
+[![Download](https://img.shields.io/github/v/release/gryszzz/open-thymos?style=for-the-badge&label=⬇%20Download&color=7c5cff)](https://github.com/gryszzz/open-thymos/releases/latest) [![Star on GitHub](https://img.shields.io/badge/⭐_Star-on_GitHub-yellow?style=for-the-badge)](https://github.com/gryszzz/open-thymos) [![License](https://img.shields.io/badge/License-Apache_2.0-blue?style=for-the-badge)](LICENSE) ![Rust](https://img.shields.io/badge/Rust-Execution_Runtime-orange?style=for-the-badge&logo=rust)
 
 <div align="center">
 <table>
@@ -13,10 +13,14 @@
 
 <img src="docs/img/desktop-mind.png" alt="OpenThymos Desktop — the Mind reasoning view" width="420" />
 
-Immersive, **local-first** GUI — chat, live runs, the 3D **Mind** reasoning view,
-audit + replay. Connect any model; your keys never leave your machine.
+Immersive, **local-first** GUI — chat, multi-skill runtime, live runs, the 3D
+**Mind** reasoning view, audit + replay. Connect **any model** (Claude, OpenAI,
+Ollama / LM Studio, any OpenAI-compatible adapter); your keys never leave your
+machine.
 
-[![Get the Desktop app](https://img.shields.io/badge/▶_Get_Desktop_App-7c5cff?style=for-the-badge&labelColor=1c1738)](docs/rfcs/desktop-app.md)
+[![Download the Desktop app](https://img.shields.io/badge/⬇_Download_Desktop_App-7c5cff?style=for-the-badge&labelColor=1c1738)](https://github.com/gryszzz/open-thymos/releases/latest)
+
+<sub>macOS `.dmg` · Windows `.msi` · Linux `.AppImage` — unsigned; one-time "Open anyway".<br/>Or build from source (below).</sub>
 
 
 

--- a/thymos/Cargo.lock
+++ b/thymos/Cargo.lock
@@ -2699,7 +2699,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-cli"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "axum 0.8.9",
  "clap",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-client"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "axum-test",
  "reqwest",
@@ -2733,7 +2733,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-cognition"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -2747,7 +2747,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-compiler"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2758,7 +2758,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "blake3",
  "ed25519-dalek",
@@ -2771,7 +2771,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-ledger"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "blake3",
  "deadpool-postgres",
@@ -2787,7 +2787,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-marketplace"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "blake3",
  "hex",
@@ -2800,7 +2800,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-policy"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2809,7 +2809,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-runtime"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "serde",
@@ -2826,7 +2826,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-server"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2859,7 +2859,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-tools"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "blake3",
  "reqwest",
@@ -2872,7 +2872,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-worker"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "serde_json",
  "thymos-tools",

--- a/thymos/Cargo.toml
+++ b/thymos/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 license = "Apache-2.0"
 rust-version = "1.80"

--- a/thymos/clients/desktop/package.json
+++ b/thymos/clients/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thymos-desktop",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "description": "OpenThymos Desktop — governed-cognition runtime, install once.",
   "scripts": {

--- a/thymos/clients/desktop/src-tauri/Cargo.toml
+++ b/thymos/clients/desktop/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "thymos-desktop"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "OpenThymos Desktop — a governed-cognition client that supervises a local runtime."

--- a/thymos/clients/desktop/src-tauri/tauri.conf.json
+++ b/thymos/clients/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenThymos",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "identifier": "com.openthymos.desktop",
   "build": {
     "frontendDist": "../src"


### PR DESCRIPTION
Preps the **stable v0.7.0 release** (the desktop app + everything since v0.5.0: multi-skill runtime, MCP tools, provider/model management + discovery, inspectable Mind graph, Advanced Mode, custom tools).

- Bumps workspace + desktop to **0.7.0** (Cargo / tauri.conf / package.json + lockfile).
- README: **restores the Download badge** (it was blank) and points the **Desktop-app CTA → releases/latest** (`.dmg`/`.msi`/`.AppImage`, unsigned; build-from-source fallback noted).

**After merge**, tagging `v0.7.0` triggers `release.yml`: CLI binaries + GHCR image + the desktop-installer job + the GitHub Release. (CLI binaries are guaranteed; the desktop installer job is `continue-on-error` on its first real run, so it can't block the release.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)