### PR TITLE
feat(desktop): clean chat rail + framework context (Audit/Runs/Mind) + live Backups state

### DIFF
--- a/thymos/clients/desktop/src/index.html
+++ b/thymos/clients/desktop/src/index.html
@@ -57,17 +57,11 @@
             <!-- Authority is configured ONCE here and saved to this model, not
                  chosen per message. -->
             <div class="chat-defaults">
-              <div class="def-title">This model can…</div>
-              <label class="def">Model <span class="dim">(this chat · blank = default)</span>
-                <input id="chatModel" list="modelList" autocomplete="off" placeholder="e.g. llama3.2 · gpt-4o" />
-              </label>
-              <div class="def">
-                <span>Skills <span class="dim">(combine any — they only narrow)</span></span>
-                <div id="skillChips" class="skill-chips" title="Active skills for this chat. Multiple combine: their tools union, their limits AND. Saved per chat.">
-                  <span class="hint sk-empty">no skills yet</span>
-                </div>
-              </div>
-              <div class="grants" id="grants" title="Default writ scope for this model — the runtime rejects anything not granted. Saved.">
+              <!-- Per-chat model override (advanced) + active skill chips — both
+                   appear only when in use, keeping the rail clean. -->
+              <input id="chatModel" class="adv-only" list="modelList" autocomplete="off" placeholder="model override (blank = default)" />
+              <div id="skillChips" class="skill-chips" title="Active skills — combine any; they only narrow authority."></div>
+              <div class="grants" id="grants" title="What this chat is allowed to do — the writ scope. The runtime rejects anything not granted.">
                 <span class="grant-label">grant</span>
                 <button type="button" class="chip on" data-scope="fs_read">fs_read</button>
                 <button type="button" class="chip on" data-scope="grep">grep</button>
@@ -113,6 +107,12 @@
             <button id="mindLoad" class="ghost">Visualize</button>
           </div>
         </div>
+        <p class="tab-intro">
+          A live map of the run's reasoning — each node is a real ledger entry
+          (intent, proposal, commit, rejection, suspension), wired in the order
+          they happened. It's the <b>Intent → Proposal → Commit</b> spine made
+          visible; click any node to see exactly what it was.
+        </p>
         <div class="mind-stage">
           <div id="mindCanvas" class="mind-canvas"></div>
           <div id="mindTip" class="mind-tip" hidden></div>
@@ -134,6 +134,12 @@
           <h2>Runs</h2>
           <button class="ghost" id="refreshRuns">Refresh</button>
         </div>
+        <p class="tab-intro">
+          Every message you send is a <b>governed run</b> — a trajectory of
+          intents → proposals → commits recorded on the ledger. Each row shows
+          what the agent did and how it ended; open one to see its full audit
+          trail and replay it.
+        </p>
         <div id="runsList" class="list"></div>
       </section>
 
@@ -340,8 +346,15 @@
       <!-- AUDIT: ledger entries + replay verdict for a run -->
       <section class="panel" id="tab-audit">
         <div class="panel-head"><h2>Audit</h2></div>
+        <p class="tab-intro">
+          The complete, tamper-evident record of what the agent did — every
+          <b>intent</b> the model proposed, the runtime's <b>verdict</b> (permit /
+          deny / needs-approval), and every <b>commit</b> that changed state, under
+          which signed authority. <b>Replay</b> independently re-folds the ledger to
+          prove it's intact (it never re-runs a tool or calls the model).
+        </p>
         <form id="auditForm" class="inline-form">
-          <input id="auditRunId" placeholder="run id" />
+          <input id="auditRunId" placeholder="run id (blank = latest)" />
           <button type="submit">Load trail</button>
         </form>
         <div id="replayBadge"></div>
@@ -350,7 +363,14 @@
 
       <!-- BACKUPS: thin — explained honestly, no fake one-click yet -->
       <section class="panel" id="tab-backups">
-        <div class="panel-head"><h2>Backups</h2></div>
+        <div class="panel-head"><h2>Backups &amp; state</h2>
+          <button type="button" class="ghost" id="refreshBackups">Refresh</button></div>
+        <p class="tab-intro">
+          A live snapshot of your local runtime and the ledger it writes to —
+          the single hash-chained file that holds every governed action. Copy it
+          anywhere to back up; integrity is re-verifiable by replay.
+        </p>
+        <div id="backupState" class="card state-card"></div>
         <div class="card">
           <p>
             The ledger is a single content-addressed, hash-chained SQLite file.

--- a/thymos/clients/desktop/src/main.js
+++ b/thymos/clients/desktop/src/main.js
@@ -791,7 +791,34 @@ $("toolForm")?.addEventListener("submit", async (e) => {
 });
 
 /* ---------- backups: the real on-disk ledger file ---------- */
+$("refreshBackups")?.addEventListener("click", loadBackups);
+
 async function loadBackups() {
+  // Live snapshot of the runtime + ledger, as of now.
+  const stateEl = $("backupState");
+  if (stateEl) {
+    let health = null, runs = 0;
+    try { health = await getJSON("/health"); } catch (_) {}
+    try {
+      const r = await getJSON("/runs");
+      const list = Array.isArray(r) ? r : r.runs || [];
+      runs = (Array.isArray(r) ? r : r).total ?? list.length ?? 0;
+    } catch (_) {}
+    const now = new Date().toLocaleTimeString();
+    if (health) {
+      stateEl.innerHTML =
+        `<div class="state-grid">` +
+        `<span class="dim">runtime</span><span><span class="badge ok">live</span></span>` +
+        `<span class="dim">provider</span><span>${escapeHtml(health.default_provider)} ` +
+        `<span class="badge ${health.cognition_live ? "ok" : "bad"}">${health.cognition_live ? "real model" : "mock"}</span></span>` +
+        `<span class="dim">ledger</span><span>${escapeHtml(health.ledger)}</span>` +
+        `<span class="dim">runs recorded</span><span>${runs}</span>` +
+        `<span class="dim">mode</span><span>${escapeHtml(health.mode)}</span>` +
+        `</div><div class="state-asof">as of ${now}</div>`;
+    } else {
+      stateEl.innerHTML = `<div class="hint">Runtime not running — press <b>Start runtime</b> (top right).</div>`;
+    }
+  }
   const pathEl = $("ledgerPath");
   if (!pathEl) return;
   if (!invoke) { pathEl.textContent = "available in the desktop app"; return; }
@@ -806,6 +833,7 @@ async function loadBackups() {
     };
   } catch (e) { pathEl.textContent = "could not resolve ledger path: " + e; }
 }
+$("refreshBackups")?.addEventListener("click", loadBackups);
 
 /* ---------- skills: author + tune authority-narrowing templates ---------- */
 async function loadSkills() {
@@ -830,10 +858,11 @@ async function loadSkills() {
         el.appendChild(div);
       });
     }
-    // Multi-select skill chips: any combination can be active at once.
+    // Multi-select skill chips: any combination can be active at once. When
+    // there are no skills, the rail stays clean (no placeholder).
     if (chipsEl) {
       if (!skills.length) {
-        chipsEl.innerHTML = "<span class='hint sk-empty'>no skills yet</span>";
+        chipsEl.innerHTML = "";
       } else {
         chipsEl.innerHTML = "";
         skills.forEach((s) => {

--- a/thymos/clients/desktop/src/styles.css
+++ b/thymos/clients/desktop/src/styles.css
@@ -408,3 +408,17 @@ body.advanced .adv-only { display: revert; }
 }
 .adv-toggle:hover { border-color: var(--violet); color: var(--text); }
 .adv-toggle input { accent-color: var(--violet); margin: 0; }
+
+/* Per-tab framework context intro */
+.tab-intro {
+  color: var(--muted); font-size: 13px; line-height: 1.6;
+  margin: 0 0 14px; max-width: 70ch;
+  padding: 10px 14px; border-left: 2px solid var(--violet);
+  background: rgba(124, 92, 255, .05); border-radius: 0 8px 8px 0;
+}
+
+/* Backups — live state snapshot */
+.state-card { padding: 14px 16px; }
+.state-grid { display: grid; grid-template-columns: 130px 1fr; gap: 6px 14px; font-size: 13px; align-items: center; }
+.state-grid .dim { color: var(--muted); }
+.state-asof { margin-top: 10px; font-size: 11.5px; color: var(--muted); }


### PR DESCRIPTION
Pre-release UI polish (→ v0.7.1).

- **Chat rail decluttered**: removed the verbose subtext ('This model can…' title, the Model/Skills labels, 'no skills yet'). **Grants stay prominent**; per-chat model override is **Advanced-only**; skill chips show only when you have skills.
- **Framework context** on **Audit / Runs / Mind** — each gets a concise plain-language intro of what the agent did and what the screen shows (Intent → Proposal → Commit → Replay), nicely organized.
- **Backups → 'Backups & state'**: a **live snapshot** card (runtime live/mock, provider + real-model badge, ledger backend, runs recorded, *as of <time>*) + Refresh — users see the current state, not just a file path.

JS valid. Targets v0.7.1 (v0.7.0 is already cut + building).

🤖 Generated with [Claude Code](https://claude.com/claude-code)