### PR TITLE
fix(desktop): drop deprecated tsconfig baseUrl + add -webkit-user-select

### DIFF
--- a/thymos/clients/desktop/src/styles.css
+++ b/thymos/clients/desktop/src/styles.css
@@ -403,7 +403,7 @@ button.full { width: 100%; }
 body.advanced .adv-only { display: revert; }
 .adv-toggle {
   display: inline-flex; align-items: center; gap: 5px;
-  font-size: 12px; color: var(--muted); cursor: pointer; user-select: none;
+  font-size: 12px; color: var(--muted); cursor: pointer; -webkit-user-select: none; user-select: none;
   padding: 4px 8px; border-radius: 999px; border: 1px solid var(--line);
 }
 .adv-toggle:hover { border-color: var(--violet); color: var(--text); }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,6 @@
         "name": "next"
       }
     ],
-    "baseUrl": ".",
     "paths": {
       "@/*": [
         "./src/*"


### PR DESCRIPTION
Clears two editor diagnostics surfaced in VS Code.

## Changes
- **Root `tsconfig.json`** — remove `baseUrl` (TS5101: deprecated, stops functioning in TypeScript 7.0; on TS 5.9.3 it's a hard error). The `@/*` → `./src/*` path mapping resolves identically without it — since TS 5.4, `paths` resolve relative to the tsconfig's directory. Matches what modern `create-next-app` generates.
- **`thymos/clients/desktop/src/styles.css`** — add `-webkit-user-select: none` alongside `user-select: none` (Microsoft Edge Tools `compat-api/css`). The desktop app renders via WebKit on macOS, so this is a real rendering fix, not just lint-silencing. (`backdrop-filter` and `mask-image` already had their `-webkit-` prefixes.)

## Verification
- `tsc -p tsconfig.json --noEmit` → 0 errors (was TS5101).
- Confirmed `user-select`, `backdrop-filter`, `mask-image` are now all WebKit-paired in `styles.css`.
- No runtime/behavior change; `tauri build` does not read `tsconfig.json`/editor configs.

