### PR TITLE
Provider hardening + v0.7.2 production downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ machine.
 
 [![Download the Desktop app](https://img.shields.io/badge/⬇_Download_Desktop_App-7c5cff?style=for-the-badge&labelColor=1c1738)](https://github.com/gryszzz/open-thymos/releases/latest)
 
-<sub>macOS `.dmg` · Windows `.msi` · Linux `.AppImage` — unsigned; one-time "Open anyway".<br/>Or build from source (below).</sub>
+<sub>[macOS Apple silicon](https://github.com/gryszzz/open-thymos/releases/latest/download/OpenThymos-desktop-macos-arm64.dmg) · [macOS Intel](https://github.com/gryszzz/open-thymos/releases/latest/download/OpenThymos-desktop-macos-x64.dmg) · [Windows `.msi`](https://github.com/gryszzz/open-thymos/releases/latest/download/OpenThymos-desktop-windows-x64.msi) · [Linux `.AppImage`](https://github.com/gryszzz/open-thymos/releases/latest/download/OpenThymos-desktop-linux-x64.AppImage)<br/>Unsigned; one-time "Open anyway". Or build from source (below).</sub>
 
 
 
@@ -33,7 +33,9 @@ machine.
 
 Terminal, scriptable, server. No Rust, no clone, no compile.
 
-[![macOS](https://img.shields.io/badge/macOS-1c1738?style=for-the-badge&logo=apple&logoColor=7c5cff)](https://github.com/gryszzz/open-thymos/releases/latest) [![Linux](https://img.shields.io/badge/Linux-1c1738?style=for-the-badge&logo=linux&logoColor=7c5cff)](https://github.com/gryszzz/open-thymos/releases/latest) [![Windows](https://img.shields.io/badge/Windows-1c1738?style=for-the-badge&logo=windows&logoColor=7c5cff)](https://github.com/gryszzz/open-thymos/releases/latest)
+[![macOS](https://img.shields.io/badge/macOS-1c1738?style=for-the-badge&logo=apple&logoColor=7c5cff)](https://github.com/gryszzz/open-thymos/releases/latest/download/OpenThymos-cli-runtime-macos-arm64.tar.gz) [![Linux](https://img.shields.io/badge/Linux-1c1738?style=for-the-badge&logo=linux&logoColor=7c5cff)](https://github.com/gryszzz/open-thymos/releases/latest/download/OpenThymos-cli-runtime-linux-x64.tar.gz) [![Windows](https://img.shields.io/badge/Windows-1c1738?style=for-the-badge&logo=windows&logoColor=7c5cff)](https://github.com/gryszzz/open-thymos/releases/latest/download/OpenThymos-cli-runtime-windows-x64.tar.gz)
+
+<sub>macOS badge = Apple silicon; [Intel build here](https://github.com/gryszzz/open-thymos/releases/latest/download/OpenThymos-cli-runtime-macos-x64.tar.gz). Or one line: `curl -fsSL …/scripts/get.sh | sh` (auto-detects).</sub>
 
 
 </td>

--- a/src/components/marketing/ThymosLanding.tsx
+++ b/src/components/marketing/ThymosLanding.tsx
@@ -214,14 +214,19 @@ export function ThymosLanding() {
                 target="_blank"
                 rel="noreferrer"
               >
-                ⬇ Download OpenThymos
+                ⬇ Download Desktop App
               </a>
               <div className="thymos-download-plats">
-                {["macOS", "Linux", "Windows"].map((plat) => (
+                {[
+                  ["macOS (Apple silicon)", "OpenThymos-desktop-macos-arm64.dmg"],
+                  ["macOS (Intel)", "OpenThymos-desktop-macos-x64.dmg"],
+                  ["Windows", "OpenThymos-desktop-windows-x64.msi"],
+                  ["Linux", "OpenThymos-desktop-linux-x64.AppImage"],
+                ].map(([plat, asset]) => (
                   <a
-                    key={plat}
+                    key={asset}
                     className="thymos-plat"
-                    href={siteConfig.releasesUrl}
+                    href={`${siteConfig.downloadBase}/${asset}`}
                     target="_blank"
                     rel="noreferrer"
                   >
@@ -230,11 +235,14 @@ export function ThymosLanding() {
                 ))}
               </div>
               <p className="thymos-download-note">
-                CLI + runtime for every platform — no Rust, no compile. One line:{" "}
-                <code>curl -fsSL …/scripts/get.sh | sh</code>. The desktop app
-                (chat, Mind view, audit) builds from source today; signed{" "}
-                <code>.dmg</code> / <code>.msi</code> / <code>.AppImage</code> ship
-                with the next release.
+                Desktop app (chat, Mind view, audit): unsigned{" "}
+                <code>.dmg</code> / <code>.msi</code> / <code>.AppImage</code> —
+                one-time &ldquo;Open anyway&rdquo;. Prefer the CLI runtime? One
+                line: <code>curl -fsSL …/scripts/get.sh | sh</code>, or grab a{" "}
+                <a href={siteConfig.releasesUrl} target="_blank" rel="noreferrer">
+                  release tarball
+                </a>
+                . Both come from the same stable release.
               </p>
             </div>
 

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -51,6 +51,7 @@ export const siteConfig = {
   readmeUrl: `${githubUrl}#readme`,
   wikiUrl: `${githubUrl}/wiki`,
   releasesUrl: `${githubUrl}/releases/latest`,
+  downloadBase: `${githubUrl}/releases/latest/download`,
   getScriptUrl: `${githubUrl}/blob/main/scripts/get.sh`,
   org: "Exponet Labs",
 };

--- a/thymos/Cargo.lock
+++ b/thymos/Cargo.lock
@@ -2699,7 +2699,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-cli"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "axum 0.8.9",
  "clap",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-client"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "axum-test",
  "reqwest",
@@ -2733,7 +2733,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-cognition"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -2747,7 +2747,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-compiler"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -2758,7 +2758,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-core"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "blake3",
  "ed25519-dalek",
@@ -2771,7 +2771,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-ledger"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "blake3",
  "deadpool-postgres",
@@ -2787,7 +2787,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-marketplace"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "blake3",
  "hex",
@@ -2800,7 +2800,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-policy"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -2809,7 +2809,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-runtime"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "serde",
@@ -2826,7 +2826,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-server"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2859,7 +2859,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-tools"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "blake3",
  "reqwest",
@@ -2872,7 +2872,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-worker"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "serde_json",
  "thymos-tools",

--- a/thymos/Cargo.toml
+++ b/thymos/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 license = "Apache-2.0"
 rust-version = "1.80"

--- a/thymos/clients/desktop/package-lock.json
+++ b/thymos/clients/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thymos-desktop",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thymos-desktop",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "devDependencies": {
         "@tauri-apps/cli": "^2"
       }

--- a/thymos/clients/desktop/package.json
+++ b/thymos/clients/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thymos-desktop",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "private": true,
   "description": "OpenThymos Desktop — governed-cognition runtime, install once.",
   "scripts": {

--- a/thymos/clients/desktop/src-tauri/Cargo.lock
+++ b/thymos/clients/desktop/src-tauri/Cargo.lock
@@ -3288,7 +3288,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-desktop"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "serde",
  "serde_json",

--- a/thymos/clients/desktop/src-tauri/Cargo.toml
+++ b/thymos/clients/desktop/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "thymos-desktop"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 license = "Apache-2.0"
 description = "OpenThymos Desktop — a governed-cognition client that supervises a local runtime."

--- a/thymos/clients/desktop/src-tauri/tauri.conf.json
+++ b/thymos/clients/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenThymos",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "identifier": "com.openthymos.desktop",
   "build": {
     "frontendDist": "../src"

--- a/thymos/clients/desktop/src/main.js
+++ b/thymos/clients/desktop/src/main.js
@@ -219,7 +219,10 @@ function renderSnapshot(s) {
     if (e.idx < renderedUpTo) return;
     renderedUpTo = e.idx + 1;
     const [g, cls] = glyphFor(e);
-    const detail = e.detail ? `  ${e.detail}` : "";
+    // Chat is a feed, not a log viewer: keep status lines one-line-ish. The
+    // full detail stays in the run's audit trail.
+    let detail = e.detail ? `  ${e.detail}` : "";
+    if (detail.length > 300) detail = detail.slice(0, 300) + "…";
     pushLine(cls, `${g} ${e.title}${detail}`);
   });
   if (s.status === "waiting_approval") showApproval(s.run_id);

--- a/thymos/clients/desktop/src/main.js
+++ b/thymos/clients/desktop/src/main.js
@@ -225,7 +225,7 @@ function renderSnapshot(s) {
     if (detail.length > 300) detail = detail.slice(0, 300) + "…";
     pushLine(cls, `${g} ${e.title}${detail}`);
   });
-  if (s.status === "waiting_approval") showApproval(s.run_id);
+  if (s.status === "waiting_approval") showApproval(s.run_id, s.pending_channel);
   if (["completed", "failed", "cancelled"].includes(s.status)) {
     if (s.final_answer) {
       pushAnswer(s.status, s.final_answer);
@@ -346,14 +346,14 @@ $("chatStop")?.addEventListener("click", async () => {
   catch (e) { pushLine("deny", `✕ cancel failed: ${e}`); }
 });
 
-function showApproval(runId) {
+function showApproval(runId, channel) {
   if (document.querySelector(`.approval-row[data-run="${runId}"]`)) return;
   const row = document.createElement("div");
   row.className = "approval-row";
   row.dataset.run = runId;
   row.innerHTML = `<span class="q">⏸ approval required — channel</span>`;
   const chan = document.createElement("input");
-  chan.value = "ops";
+  chan.value = channel || "ops"; // prefilled with the actual pending channel
   chan.style.maxWidth = "120px";
   const approve = document.createElement("button");
   approve.textContent = "Approve";
@@ -474,7 +474,7 @@ async function loadRuns() {
         `<span class="meta">${r.trajectory_id?.slice(0, 8) || ""}` +
         `${commits !== "" ? " · " + commits + " commits" : ""}</span>`;
       div.style.cursor = "pointer";
-      div.onclick = () => openAudit(r.trajectory_id);
+      div.onclick = () => openAudit(r.run_id);
       el.appendChild(div);
     });
   } catch (e) { el.innerHTML = `<div class='hint'>could not load runs: ${e}</div>`; }

--- a/thymos/crates/thymos-cognition/src/anthropic.rs
+++ b/thymos/crates/thymos-cognition/src/anthropic.rs
@@ -205,6 +205,19 @@ pub fn backoff_delay_ms(attempt: u32) -> u64 {
     500u64 << attempt.min(6)
 }
 
+/// Pick the retry delay: honor the server's `retry-after` hint (delta-seconds)
+/// when present — a rate-limit window can't be cleared by a shorter local
+/// backoff — floored at the exponential and capped so a pathological hint
+/// can't hang the loop.
+pub fn retry_delay_ms(attempt: u32, retry_after: Option<&str>) -> u64 {
+    const MAX_MS: u64 = 60_000;
+    let exp = backoff_delay_ms(attempt);
+    retry_after
+        .and_then(|v| v.trim().parse::<f64>().ok())
+        .map(|secs| ((secs * 1000.0) as u64).clamp(exp, MAX_MS))
+        .unwrap_or(exp)
+}
+
 /// Map short / legacy aliases to canonical model ids.
 ///
 /// Explicit full ids pass through unchanged, so operators can pin any model.
@@ -243,7 +256,7 @@ impl Cognition for AnthropicCognition {
         self.trim_internal_history();
 
         // 2. Assemble the request with optional cache_control breakpoints.
-        let tools_payload = build_tools_payload(ctx.tools, self.cache_prefix);
+        let tools_payload = build_tools_payload(ctx.tools, ctx.writ, self.cache_prefix);
         let system = build_system_prompt_blocks(ctx.writ, self.cache_prefix);
 
         let mut req_body = json!({
@@ -443,17 +456,35 @@ impl AnthropicCognition {
                         attempt += 1;
                         continue;
                     }
-                    return Err(Error::Other(format!("anthropic request failed: {e}")));
+                    // Name the failure class (reqwest's Display omits the
+                    // cause) so downstream layers can produce a useful message.
+                    let kind = if e.is_timeout() {
+                        " (timeout)"
+                    } else if e.is_connect() {
+                        " (connection failed)"
+                    } else {
+                        ""
+                    };
+                    return Err(Error::Other(format!("anthropic request failed{kind}: {e}")));
                 }
             };
 
             let status = resp.status();
+            // Server retry hint, captured before the body is consumed.
+            let retry_after = resp
+                .headers()
+                .get(reqwest::header::RETRY_AFTER)
+                .and_then(|v| v.to_str().ok())
+                .map(str::to_owned);
             // Quick transient HTTP status check before we parse the body.
             if !status.is_success()
                 && is_transient_status(status.as_u16(), None)
                 && attempt < self.max_retries
             {
-                std::thread::sleep(Duration::from_millis(backoff_delay_ms(attempt)));
+                std::thread::sleep(Duration::from_millis(retry_delay_ms(
+                    attempt,
+                    retry_after.as_deref(),
+                )));
                 attempt += 1;
                 continue;
             }
@@ -469,12 +500,22 @@ impl AnthropicCognition {
                     .and_then(|e| e.get("type"))
                     .and_then(|v| v.as_str());
                 if is_transient_status(status.as_u16(), error_type) && attempt < self.max_retries {
-                    std::thread::sleep(Duration::from_millis(backoff_delay_ms(attempt)));
+                    std::thread::sleep(Duration::from_millis(retry_delay_ms(
+                        attempt,
+                        retry_after.as_deref(),
+                    )));
                     attempt += 1;
                     continue;
                 }
+                // Surface the server's wait hint so the runtime-level retry
+                // loop can honor it (same convention as the OpenAI adapter).
+                let suffix = retry_after
+                    .as_deref()
+                    .and_then(|v| v.trim().parse::<f64>().ok())
+                    .map(|secs| format!(" [retry_after_ms={}]", (secs * 1000.0) as u64))
+                    .unwrap_or_default();
                 return Err(Error::Other(format!(
-                    "anthropic API error {status}: {resp_json}"
+                    "anthropic API error {status}: {resp_json}{suffix}"
                 )));
             }
 
@@ -581,6 +622,12 @@ PROPOSED actions. The runtime compiles each proposal, evaluates policy \
 against a bounded Capability Writ, and either commits the effect or rejects \
 the proposal. The runtime is the sole source of truth.
 
+Not every message needs a tool. If the user is greeting you, making small \
+talk, or asking something you can answer from your own knowledge, just reply \
+with plain text and no tool_use blocks. Only propose a tool call when the task \
+genuinely requires an external effect (reading or writing files, running a \
+command, fetching data). Never call a tool merely to acknowledge a message.
+
 Constraints you MUST respect:
   * You may only call tools that match your Writ scope. Current scope: [{scopes_str}].
   * Your budget is bounded: {tokens} tokens, {calls} tool calls, ~{usd} USD (in millicents), {time}ms wall-clock.
@@ -646,8 +693,15 @@ fn summarize_world(ctx: &CognitionContext<'_>) -> String {
     lines.join("\n")
 }
 
-fn build_tools_payload(tools: &ToolRegistry, cache_prefix: bool) -> Vec<Value> {
-    let names: Vec<String> = tools.names().map(|s| s.to_string()).collect();
+/// Build the `tools` request payload, advertising **only** the tools the Writ
+/// authorizes — same rationale as the OpenAI adapter: out-of-scope schemas
+/// waste tokens and invite proposals the runtime can only reject.
+fn build_tools_payload(tools: &ToolRegistry, writ: &Writ, cache_prefix: bool) -> Vec<Value> {
+    let names: Vec<String> = tools
+        .names()
+        .filter(|n| writ.authorizes_tool(n))
+        .map(|s| s.to_string())
+        .collect();
     let mut out = Vec::with_capacity(names.len());
     let last_idx = names.len().saturating_sub(1);
     for (i, name) in names.iter().enumerate() {
@@ -835,5 +889,20 @@ mod tests {
         assert!(is_tool_result_user_message(&tool_result));
         assert!(!is_tool_result_user_message(&plain_user));
         assert!(!is_tool_result_user_message(&assistant));
+    }
+
+    #[test]
+    fn retry_delay_honors_server_hint_within_bounds() {
+        // No hint → pure exponential.
+        assert_eq!(retry_delay_ms(0, None), 500);
+        assert_eq!(retry_delay_ms(2, None), 2000);
+        // Hint above the exponential floor is honored.
+        assert_eq!(retry_delay_ms(0, Some("10")), 10_000);
+        // Hint below the floor is raised to the exponential.
+        assert_eq!(retry_delay_ms(3, Some("0.1")), 4000);
+        // Pathological hint is capped at 60s.
+        assert_eq!(retry_delay_ms(0, Some("3600")), 60_000);
+        // Unparseable (HTTP-date) hint falls back to the exponential.
+        assert_eq!(retry_delay_ms(1, Some("Wed, 21 Oct 2015 07:28:00 GMT")), 1000);
     }
 }

--- a/thymos/crates/thymos-cognition/src/lib.rs
+++ b/thymos/crates/thymos-cognition/src/lib.rs
@@ -364,6 +364,7 @@ pub fn build_cognition(config: &CognitionConfig) -> Box<dyn Cognition> {
             let base_url = config
                 .base_url
                 .clone()
+                .or_else(generic_base_url_env)
                 .unwrap_or_else(|| "http://localhost:11434/v1".into());
             let model = config.model.clone().unwrap_or_else(|| "llama3".into());
             // Local endpoints often don't need an API key; use a dummy.
@@ -391,6 +392,7 @@ pub fn build_cognition(config: &CognitionConfig) -> Box<dyn Cognition> {
                 .base_url
                 .clone()
                 .or_else(|| std::env::var("LMSTUDIO_BASE_URL").ok())
+                .or_else(generic_base_url_env)
                 .unwrap_or_else(|| "http://localhost:1234/v1".into());
             let model = config
                 .model
@@ -418,6 +420,7 @@ pub fn build_cognition(config: &CognitionConfig) -> Box<dyn Cognition> {
                 .base_url
                 .clone()
                 .or_else(|| std::env::var("HF_BASE_URL").ok())
+                .or_else(generic_base_url_env)
                 .unwrap_or_else(|| "https://router.huggingface.co/v1".into());
             let model = config
                 .model
@@ -426,6 +429,9 @@ pub fn build_cognition(config: &CognitionConfig) -> Box<dyn Cognition> {
                 .unwrap_or_else(|| "Qwen/Qwen2.5-Coder-32B-Instruct".into());
             let api_key = std::env::var("HF_TOKEN")
                 .or_else(|_| std::env::var("HUGGINGFACE_API_KEY"))
+                // The desktop injects the stored key generically; honor it so
+                // an HF token entered there isn't silently dropped.
+                .or_else(|_| std::env::var("OPENAI_API_KEY"))
                 .unwrap_or_default();
             if api_key.is_empty() {
                 eprintln!(
@@ -453,6 +459,16 @@ pub fn build_cognition(config: &CognitionConfig) -> Box<dyn Cognition> {
     }
 }
 
+/// Generic base-URL override for any OpenAI-compatible adapter. This is the
+/// variable the desktop injects for every non-Anthropic provider, so a custom
+/// endpoint (Ollama on another port, a remote LM Studio, a gateway) reaches
+/// the preset path instead of being silently dropped.
+fn generic_base_url_env() -> Option<String> {
+    std::env::var("OPENAI_BASE_URL")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+}
+
 /// Build an OpenAI-compatible adapter from a named [`presets`] entry. The API
 /// key is read **server-side** from the preset's environment variables (never
 /// from the wire); local presets need no key. Falls back to mock — with a clear
@@ -472,6 +488,7 @@ fn build_from_preset(name: &str, config: &CognitionConfig) -> Box<dyn Cognition>
     let base_url = config
         .base_url
         .clone()
+        .or_else(generic_base_url_env)
         .unwrap_or_else(|| preset.base_url.to_string());
     let model = config
         .model

--- a/thymos/crates/thymos-cognition/src/openai.rs
+++ b/thymos/crates/thymos-cognition/src/openai.rs
@@ -66,6 +66,24 @@ pub struct OpenAiCognition {
     pub total_output_tokens: u64,
 }
 
+/// Parse a `Retry-After` header into milliseconds. The header is delta-seconds
+/// for rate limits (we ignore the rare HTTP-date form, which returns `None`).
+fn parse_retry_after_header(v: &str) -> Option<u64> {
+    v.trim().parse::<f64>().ok().map(|s| (s * 1000.0) as u64)
+}
+
+/// Some providers (e.g. Groq) put the precise wait only in the JSON error body:
+/// `"Please try again in 9.62s"`. Extract that as milliseconds.
+fn parse_retry_after_body(body: &str) -> Option<u64> {
+    const MARKER: &str = "try again in ";
+    let start = body.find(MARKER)? + MARKER.len();
+    let num: String = body[start..]
+        .chars()
+        .take_while(|c| c.is_ascii_digit() || *c == '.')
+        .collect();
+    num.parse::<f64>().ok().map(|s| (s * 1000.0) as u64)
+}
+
 impl OpenAiCognition {
     pub fn from_env() -> Result<Self> {
         let api_key = std::env::var("OPENAI_API_KEY")
@@ -169,7 +187,7 @@ impl Cognition for OpenAiCognition {
             "messages": self.messages,
         });
         if matches!(self.tool_protocol, ToolProtocol::Native) {
-            let tools_payload = build_tools_payload(ctx.tools);
+            let tools_payload = build_tools_payload(ctx.tools, ctx.writ);
             if !tools_payload.is_empty() {
                 req_body["tools"] = json!(tools_payload);
             }
@@ -184,15 +202,45 @@ impl Cognition for OpenAiCognition {
             .header("Content-Type", "application/json")
             .json(&req_body)
             .send()
-            .map_err(|e| Error::Other(format!("openai request failed: {e}")))?;
+            .map_err(|e| {
+                // reqwest's Display omits the cause ("error sending request for
+                // url (…)"); name the failure class so downstream layers can
+                // produce a useful message.
+                let kind = if e.is_timeout() {
+                    " (timeout)"
+                } else if e.is_connect() {
+                    " (connection failed)"
+                } else {
+                    ""
+                };
+                Error::Other(format!("openai request failed{kind}: {e}"))
+            })?;
 
         let status = resp.status();
+        // Capture the server's retry hint *before* the body is consumed. On a
+        // 429 the budget (e.g. Groq's tokens-per-minute) resets on the
+        // provider's wall clock; a fixed local backoff can't clear it, so we
+        // surface the server's own wait for the runtime to honor.
+        let retry_after_header = resp
+            .headers()
+            .get(reqwest::header::RETRY_AFTER)
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_owned);
         let resp_json: Value = resp
             .json()
             .map_err(|e| Error::Other(format!("openai response parse: {e}")))?;
         if !status.is_success() {
+            // Prefer the standard header; fall back to providers that put the
+            // precise wait only in the JSON body ("Please try again in 9.62s").
+            let hint_ms = retry_after_header
+                .as_deref()
+                .and_then(parse_retry_after_header)
+                .or_else(|| parse_retry_after_body(&resp_json.to_string()));
+            let suffix = hint_ms
+                .map(|ms| format!(" [retry_after_ms={ms}]"))
+                .unwrap_or_default();
             return Err(Error::Other(format!(
-                "openai API error {status}: {resp_json}"
+                "openai API error {status}: {resp_json}{suffix}"
             )));
         }
 
@@ -352,6 +400,13 @@ fn build_system_prompt(writ: &Writ) -> String {
          PROPOSED actions. The runtime evaluates policy against a bounded Capability \
          Writ, and either commits the effect or rejects the proposal.\n\
          \n\
+         Not every message needs a tool. If the user is greeting you, making \
+         small talk, or asking something you can answer from your own knowledge, \
+         just reply with plain text and no function calls. Only propose a tool \
+         call when the task genuinely requires an external effect (reading or \
+         writing files, running a command, fetching data). Never call a tool \
+         merely to acknowledge a message.\n\
+         \n\
          Constraints:\n\
          - You may only call tools matching your Writ scope: [{scopes_str}].\n\
          - Budget: {tokens} tokens, {calls} tool calls, ~{usd} USD (millicents), {time}ms wall-clock.\n\
@@ -384,9 +439,17 @@ fn build_opening_user_message(ctx: &CognitionContext<'_>) -> String {
     )
 }
 
-fn build_tools_payload(tools: &ToolRegistry) -> Vec<Value> {
+/// Build the `tools` request payload, advertising **only** the tools the Writ
+/// authorizes. Sending schemas for out-of-scope tools wastes tokens (a real
+/// problem against per-minute budgets) and invites guaranteed-rejected
+/// proposals — the model proposes a tool it can see, then hits `AuthorityVoid`.
+/// The advertised surface now matches the actual granted authority.
+fn build_tools_payload(tools: &ToolRegistry, writ: &Writ) -> Vec<Value> {
     let mut out = Vec::new();
     for name in tools.names() {
+        if !writ.authorizes_tool(name) {
+            continue;
+        }
         if let Ok(tool) = tools.get(name) {
             out.push(json!({
                 "type": "function",
@@ -494,6 +557,11 @@ fn build_system_prompt_jsonblock(writ: &Writ, tools: &ToolRegistry) -> String {
 
     let mut tool_lines = Vec::new();
     for name in tools.names() {
+        // Only inline tools the Writ authorizes — same rationale as the native
+        // payload: fewer tokens, no proposals the runtime will only reject.
+        if !writ.authorizes_tool(name) {
+            continue;
+        }
         if let Ok(t) = tools.get(name) {
             let schema_str =
                 serde_json::to_string(&t.input_schema()).unwrap_or_else(|_| "{}".into());
@@ -522,6 +590,11 @@ fn build_system_prompt_jsonblock(writ: &Writ, tools: &ToolRegistry) -> String {
          proposed action. Plain prose around the blocks is allowed but only \
          the JSON blocks are executed. When you are done, reply with text and \
          no JSON blocks.\n\
+         \n\
+         Not every message needs a tool. If the user is greeting you, making \
+         small talk, or asking something you can answer directly, just reply \
+         with plain text and emit no JSON blocks. Only emit a tool block when \
+         the task genuinely requires an external effect.\n\
          \n\
          Constraints:\n\
          - Writ scope: [{scopes_str}].\n\
@@ -662,6 +735,21 @@ pub(crate) fn parse_json_blocks(text: &str) -> Vec<JsonBlockCall> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn retry_after_header_parses_delta_seconds() {
+        assert_eq!(parse_retry_after_header("10"), Some(10_000));
+        assert_eq!(parse_retry_after_header(" 2.5 "), Some(2_500));
+        // HTTP-date form is unsupported → None (caller falls back to body).
+        assert_eq!(parse_retry_after_header("Wed, 21 Oct 2015 07:28:00 GMT"), None);
+    }
+
+    #[test]
+    fn retry_after_body_extracts_groq_wait() {
+        let body = r#"{"error":{"message":"Rate limit reached ... Please try again in 9.62s. Need more tokens?","code":"rate_limit_exceeded"}}"#;
+        assert_eq!(parse_retry_after_body(body), Some(9_620));
+        assert_eq!(parse_retry_after_body("no hint here"), None);
+    }
 
     #[test]
     fn parse_json_blocks_extracts_fenced_blocks() {

--- a/thymos/crates/thymos-runtime/src/agent_async.rs
+++ b/thymos/crates/thymos-runtime/src/agent_async.rs
@@ -24,6 +24,41 @@ use super::agent::{
 };
 use crate::{Run, Runtime, Step};
 
+/// Upper bound on a single retry backoff. A provider's wait hint is honored up
+/// to this; beyond it we'd rather surface the error than appear hung.
+const MAX_RETRY_BACKOFF_MS: u64 = 60_000;
+
+/// Extract a provider wait hint (`[retry_after_ms=N]`) embedded in an error
+/// string by the OpenAI-compatible adapter. Returns the wait in milliseconds.
+fn parse_retry_after_hint(msg: &str) -> Option<u64> {
+    const MARKER: &str = "retry_after_ms=";
+    let start = msg.find(MARKER)? + MARKER.len();
+    let digits: String = msg[start..].chars().take_while(|c| c.is_ascii_digit()).collect();
+    digits.parse().ok()
+}
+
+/// Map a raw provider/transport error to a short, plain-English sentence for
+/// the chat UI. Never echoes the raw JSON body (which can be noisy and, for
+/// some providers, embed request context). Unknown errors get a generic line.
+pub fn humanize_provider_error(msg: &str) -> String {
+    let m = msg.to_lowercase();
+    if m.contains("429") || m.contains("rate limit") {
+        "The provider is rate-limiting requests right now (token budget).".to_string()
+    } else if m.contains("401") || m.contains("invalid api key") || m.contains("unauthorized") {
+        "The provider rejected the API key. Check it in Settings.".to_string()
+    } else if m.contains("404") && m.contains("model") {
+        "That model isn't available on this provider.".to_string()
+    } else if m.contains("timeout") || m.contains("timed out") {
+        "The provider took too long to respond.".to_string()
+    } else if m.contains("connection") || m.contains("dns") || m.contains("connect") {
+        "Couldn't reach the provider. Check your network — or, for a local model, that it is running.".to_string()
+    } else if m.contains("500") || m.contains("502") || m.contains("503") {
+        "The provider had a server error.".to_string()
+    } else {
+        "The provider returned an error.".to_string()
+    }
+}
+
 /// Approval decision sent through the approval channel.
 #[derive(Debug, Clone)]
 pub struct ApprovalDecision {
@@ -161,7 +196,16 @@ pub async fn run_agent_streaming<L: LedgerStore>(
                         if !is_retryable || attempt > max_retries {
                             return Err(e);
                         }
-                        let backoff_ms = 1000 * 2u64.pow(attempt - 1); // 1s, 2s, 4s
+                        // Prefer the provider's own wait hint (e.g. Groq's
+                        // tokens-per-minute reset, surfaced as
+                        // `[retry_after_ms=N]`). A per-minute budget can't be
+                        // cleared by a sub-second local backoff, so honor the
+                        // server — capped so a pathological hint can't hang the
+                        // run, floored at the exponential as a sane minimum.
+                        let exp_ms = 1000 * 2u64.pow(attempt - 1); // 1s, 2s, 4s
+                        let backoff_ms = parse_retry_after_hint(&e.to_string())
+                            .map(|hint| hint.clamp(exp_ms, MAX_RETRY_BACKOFF_MS))
+                            .unwrap_or(exp_ms);
                         emit_event(
                             trace_tx.as_ref(),
                             AgentTraceEvent::RetryScheduled {
@@ -173,8 +217,11 @@ pub async fn run_agent_streaming<L: LedgerStore>(
                         );
                         let _ = event_tx.send(CognitionEvent::Error {
                             message: format!(
-                                "transient error (attempt {}/{}), retrying in {}ms: {}",
-                                attempt, max_retries, backoff_ms, e
+                                "{} Retrying (attempt {}/{}) in {}s\u{2026}",
+                                humanize_provider_error(&e.to_string()),
+                                attempt,
+                                max_retries,
+                                backoff_ms.div_ceil(1000),
                             ),
                         });
                         tokio::time::sleep(std::time::Duration::from_millis(backoff_ms)).await;
@@ -419,4 +466,35 @@ fn last_observation<L: LedgerStore>(
         "commit {:?} not found in trajectory",
         commit_id
     )))
+}
+
+#[cfg(test)]
+mod retry_tests {
+    use super::*;
+
+    #[test]
+    fn parses_embedded_retry_hint() {
+        let e = "openai API error 429 Too Many Requests: {\"error\":{...}} [retry_after_ms=9620]";
+        assert_eq!(parse_retry_after_hint(e), Some(9620));
+        assert_eq!(parse_retry_after_hint("no hint"), None);
+    }
+
+    #[test]
+    fn hint_is_clamped_into_sane_window() {
+        // A hint is honored, but never below the exponential floor (1s) nor
+        // above the ceiling.
+        assert_eq!(15_000u64.clamp(1_000, MAX_RETRY_BACKOFF_MS), 15_000);
+        assert_eq!(120_000u64.clamp(1_000, MAX_RETRY_BACKOFF_MS), MAX_RETRY_BACKOFF_MS);
+        assert_eq!(200u64.clamp(1_000, MAX_RETRY_BACKOFF_MS), 1_000);
+    }
+
+    #[test]
+    fn humanizes_known_provider_errors_without_leaking_body() {
+        let raw = "openai API error 429: {\"error\":{\"message\":\"Rate limit reached for org_secret123\"}}";
+        let friendly = humanize_provider_error(raw);
+        assert!(friendly.contains("rate-limiting"));
+        assert!(!friendly.contains("org_secret123")); // raw body never echoed
+        assert!(humanize_provider_error("401 invalid api key").contains("API key"));
+        assert!(humanize_provider_error("connection refused").contains("reach"));
+    }
 }

--- a/thymos/crates/thymos-server/src/audit.rs
+++ b/thymos/crates/thymos-server/src/audit.rs
@@ -40,11 +40,20 @@ fn default_format() -> String {
 /// Resolve a run_id to a TrajectoryId by looking up the runs map.
 fn resolve_trajectory(state: &AppState, run_id: &str) -> Option<TrajectoryId> {
     let runs = state.runs.lock().unwrap();
-    let rec = runs.get(run_id)?;
-    if rec.trajectory_id.is_empty() {
-        return None;
-    }
-    let bytes = hex::decode(&rec.trajectory_id).ok()?;
+    // Run id (the normal case), else accept a trajectory id directly — the
+    // Runs list and chat history carry both, and operators paste either.
+    let hex_id = match runs.get(run_id) {
+        Some(rec) if !rec.trajectory_id.is_empty() => rec.trajectory_id.clone(),
+        _ => {
+            let candidate = run_id.strip_prefix("traj:").unwrap_or(run_id);
+            if runs.values().any(|r| r.trajectory_id == candidate) {
+                candidate.to_string()
+            } else {
+                return None;
+            }
+        }
+    };
+    let bytes = hex::decode(&hex_id).ok()?;
     if bytes.len() != 32 {
         return None;
     }

--- a/thymos/crates/thymos-server/src/execution.rs
+++ b/thymos/crates/thymos-server/src/execution.rs
@@ -577,14 +577,20 @@ impl ExecutionSession {
     }
 
     pub fn mark_failed(&mut self, detail: impl Into<String>) {
+        let detail = detail.into();
         self.status = ExecutionStatus::Failed;
         self.phase = ExecutionPhase::Result;
         self.operator_state = "Runtime stopped on an unrecovered error".into();
+        // The chat renders `final_answer` as the reply bubble; give it the
+        // plain-English line. The raw detail stays in the log entry below.
+        self.final_answer = Some(thymos_runtime::agent_async::humanize_provider_error(
+            &detail,
+        ));
         self.push_log(
             ExecutionPhase::Result,
             ExecutionLogLevel::Error,
             "Run failed",
-            detail.into(),
+            detail,
             Some(self.current_step.saturating_sub(1)),
             self.active_tool.clone(),
             None,
@@ -598,6 +604,7 @@ impl ExecutionSession {
         self.status = ExecutionStatus::Cancelled;
         self.phase = ExecutionPhase::Result;
         self.operator_state = "Run cancelled by operator".into();
+        self.final_answer = Some("Run cancelled.".into());
         self.push_log(
             ExecutionPhase::Result,
             ExecutionLogLevel::Warning,

--- a/thymos/crates/thymos-server/src/execution.rs
+++ b/thymos/crates/thymos-server/src/execution.rs
@@ -95,6 +95,10 @@ pub struct ExecutionSession {
     pub active_tool: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub final_answer: Option<String>,
+    /// Channel of the proposal currently awaiting operator approval, so the
+    /// UI can target the decision instead of asking the operator to guess.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pending_channel: Option<String>,
     pub counters: ExecutionCounters,
     pub updated_at_ms: u64,
     pub log: Vec<ExecutionLogEntry>,
@@ -115,6 +119,7 @@ impl ExecutionSession {
             max_steps,
             active_tool: None,
             final_answer: None,
+            pending_channel: None,
             counters: ExecutionCounters::default(),
             updated_at_ms: now_ms(),
             log: Vec::new(),
@@ -329,6 +334,7 @@ impl ExecutionSession {
                 self.phase = ExecutionPhase::Proposal;
                 self.active_tool = Some(tool.clone());
                 self.counters.approvals_pending += 1;
+                self.pending_channel = Some(channel.clone());
                 self.operator_state = format!("Awaiting approval on {}", channel);
                 self.push_log(
                     ExecutionPhase::Proposal,
@@ -354,6 +360,7 @@ impl ExecutionSession {
                 self.phase = ExecutionPhase::Proposal;
                 self.active_tool = Some(tool.clone());
                 self.counters.approvals_pending = self.counters.approvals_pending.saturating_sub(1);
+                self.pending_channel = None;
                 self.operator_state = if approved {
                     "Approval received; resuming execution".into()
                 } else {

--- a/thymos/crates/thymos-server/src/lib.rs
+++ b/thymos/crates/thymos-server/src/lib.rs
@@ -1403,7 +1403,11 @@ async fn resume_run(
                         commits: 0,
                         rejections: 0,
                         failures: 1,
-                        final_answer: Some(format!("error: {e}")),
+                        // Plain-English for the chat UI; the raw error stays in
+                        // the execution session log below for diagnostics.
+                        final_answer: Some(
+                            thymos_runtime::agent_async::humanize_provider_error(&e.to_string()),
+                        ),
                         terminated_by: "Error".into(),
                     });
                 }
@@ -1424,7 +1428,6 @@ async fn resume_run(
         .into_response()
 }
 
-/// POST /runs ��� start a new agent run with async streaming cognition.
 /// GET /skills — list authored skills (id + metadata).
 async fn list_skills(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     let skills: Vec<serde_json::Value> = state
@@ -1481,6 +1484,7 @@ async fn create_skill(
     }
 }
 
+/// POST /runs — start a new agent run with async streaming cognition.
 async fn create_run(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
@@ -1865,21 +1869,29 @@ async fn create_run(
                 }
             }
             Err(e) => {
+                let cancelled = e.to_string().contains("run cancelled by user");
+                // Plain-English for the chat UI; the raw error stays in the
+                // execution session log below for diagnostics.
+                let answer = if cancelled {
+                    "Run cancelled.".to_string()
+                } else {
+                    thymos_runtime::agent_async::humanize_provider_error(&e.to_string())
+                };
                 let err_dto = RunSummaryDto {
                     steps_executed: 0,
                     intents_submitted: 0,
                     commits: 0,
                     rejections: 0,
                     failures: 1,
-                    final_answer: Some(format!("error: {e}")),
-                    terminated_by: "Error".into(),
+                    final_answer: Some(answer),
+                    terminated_by: if cancelled { "Cancelled".into() } else { "Error".into() },
                 };
                 if let Some(rec) = runs.get_mut(&run_id2) {
                     rec.status = RunStatus::Failed;
                     rec.summary = Some(err_dto.clone());
                 }
                 with_execution_session(&state2, &run_id2, &task2, req.max_steps, |session| {
-                    if e.to_string().contains("run cancelled by user") {
+                    if cancelled {
                         session.mark_cancelled();
                     } else {
                         session.mark_failed(format!("error: {e}"));


### PR DESCRIPTION
## What this does

Makes the stable production download actually contain the working runtime, and fixes the broken/unclear pieces between chat, providers, audit, and downloads.

### Provider correctness (commit 93f0e46)
- `OPENAI_BASE_URL` now reaches **every** OpenAI-compatible path (presets like ollama/groq/vllm, local, lmstudio, huggingface) — the desktop injects it for all non-Anthropic providers but only the native `openai` arm read it, so custom endpoints were silently dropped. Proven live.
- HuggingFace arm accepts the generic `OPENAI_API_KEY` the desktop injects (HF token entered in Settings was silently dropped).
- Anthropic adapter parity: writ-scoped tool advertisement, `retry-after` honored (clamped 1s–60s), `[retry_after_ms=N]` surfaced for the runtime retry loop.
- Failed/cancelled runs now produce a plain-English chat reply (`final_answer`); raw diagnostics stay in the run log. Transport errors name their class (timeout/connection).

### Release/downloads (commit 042c0e4)
- Version bump → **0.7.2** (workspace + desktop + lockfiles) so `releases/latest` serves binaries with these fixes.
- Landing page: stale "installers ship with the next release" claim removed; Desktop (direct per-platform asset links) and CLI (get.sh / tarball) clearly separated.
- README: download badges deep-link exact `releases/latest/download/` assets.

### Audit/approval fixes
- `/audit/entries?run_id=` resolves trajectory ids too (Runs-tab clicks 404'd before; proven fixed live).
- Execution snapshot exposes `pending_channel`; the approval UI prefills it instead of guessing "ops".

## Verified
- `cargo test --workspace` green, clippy zero warnings, website `tsc --noEmit` clean, desktop `src-tauri` cargo check clean, JS syntax-checked.
- Live smoke tests: governed run end-to-end, replay, audit by run id / trajectory id / `traj:`-prefixed, custom base-URL propagation, humanized failure replies.
- All `releases/latest/download/` asset URLs HEAD-checked 200; brew tap and GHCR package verified to exist.

**Not verified here:** live cloud-provider calls (gated `live_provider` test per repo discipline); desktop installers for this version are built by the tag-triggered Release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)