### PR TITLE
CLI/desktop parity, risk-gated approvals, stuck-'governing…' fix, live Mind state

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -25,8 +25,14 @@ services or API keys:
   parent-ceiling delegation checks), budget projected from the ledger, time
   windows, revocation with one-level cascade. Each has a dedicated test file
   (`revocation`, `cognition_budget`, `quorum`, `compensation`(+gate,
-  +cross-trajectory), `idempotency`, `redaction`, `replay_safety`,
+  +cross-trajectory), `risk_gate`, `idempotency`, `redaction`, `replay_safety`,
   `compiler_rejection`, `json_policy_e2e`).
+- **Risk gate (compiler stage 9c).** Tools at or above a configured `RiskClass`
+  pause for operator approval even on a bare policy permit — the HTTP server
+  defaults to `high` (so `shell` always asks; file edits/reads flow under their
+  writ grants). Tune or disable with `THYMOS_APPROVE_RISK`
+  (`off|low|medium|high|critical`). Desktop prefills the pending channel in its
+  approval UI; `thymos run --follow` prompts y/N inline on a TTY.
 - **The agent loop**, end to end, against the deterministic `MockCognition`
   (`submit → compile → govern → execute → ledger`).
 - **HTTP server surface**: `/runs`, `/routed-submit`, `/routing-outcomes`, auth

--- a/thymos/clients/desktop/src/index.html
+++ b/thymos/clients/desktop/src/index.html
@@ -113,6 +113,7 @@
           they happened. It's the <b>Intent → Proposal → Commit</b> spine made
           visible; click any node to see exactly what it was.
         </p>
+        <div id="mindState" class="mind-state" hidden></div>
         <div class="mind-stage">
           <div id="mindCanvas" class="mind-canvas"></div>
           <div id="mindTip" class="mind-tip" hidden></div>

--- a/thymos/clients/desktop/src/main.js
+++ b/thymos/clients/desktop/src/main.js
@@ -214,6 +214,11 @@ function setBusy(on) {
 }
 
 function renderSnapshot(s) {
+  // The busy indicator mirrors the runtime's actual state ("Planning step 2",
+  // "Executing fs_patch", "Awaiting approval on high-risk") instead of a
+  // static "governing…" that reads as frozen.
+  const wl = document.querySelector("#workingLine span:last-child");
+  if (wl && s.operator_state) wl.textContent = s.operator_state.toLowerCase() + "…";
   // Snapshot carries the full log; render only newly-arrived entries.
   (s.log || []).forEach((e) => {
     if (e.idx < renderedUpTo) return;
@@ -342,8 +347,20 @@ $("newChat")?.addEventListener("click", () => newChatSession());
 // Stop: cancel the in-flight run via the real cancel endpoint.
 $("chatStop")?.addEventListener("click", async () => {
   if (!activeRunId) return;
-  try { await postJSON(`/runs/${activeRunId}/cancel`, {}); pushLine("sys", "— cancel requested"); }
-  catch (e) { pushLine("deny", `✕ cancel failed: ${e}`); }
+  const runId = activeRunId;
+  try { await postJSON(`/runs/${runId}/cancel`, {}); pushLine("sys", "— cancel requested"); }
+  catch (e) {
+    const msg = String(e);
+    if (msg.includes("409") || msg.includes("404")) {
+      // The run already reached a terminal state — nothing to cancel. Sync
+      // the chat with reality instead of surfacing it as a failure.
+      pushLine("sys", "— run already finished");
+      try { renderSnapshot(await getJSON(`/runs/${runId}/execution`)); } catch (_) {}
+      if (activeRunId === runId) { activeRunId = null; setBusy(false); }
+    } else {
+      pushLine("deny", `✕ cancel failed: ${e}`);
+    }
+  }
 });
 
 function showApproval(runId, channel) {
@@ -362,7 +379,7 @@ function showApproval(runId, channel) {
   deny.className = "ghost";
   const act = async (decision) => {
     try {
-      await postJSON(`/runs/${runId}/approvals/${chan.value}`, { decision });
+      await postJSON(`/runs/${runId}/approvals/${chan.value}`, { approve: decision === "approve" });
       pushLine("sys", `— ${decision} (${chan.value})`);
       row.remove();
     } catch (e) { alert("Approval failed: " + e); }
@@ -409,19 +426,42 @@ async function startRun(task) {
     if (model) body.model = model; // per-chat model override (else server default)
     const { run_id } = await postJSON("/runs", body);
     activeRunId = run_id;
+    window.thymosActiveRun = run_id; // Mind opens on the chat's current run
     pushLine("sys", `— run ${String(run_id).slice(0, 8)}`);
     if (currentStream) currentStream.close();
     renderedUpTo = 0;
-    currentStream = new EventSource(api(`/runs/${run_id}/execution/stream`));
-    currentStream.onmessage = (m) => {
-      try { renderSnapshot(JSON.parse(m.data)); } catch (_) {}
-    };
-    currentStream.onerror = () => { currentStream && currentStream.close(); };
+    openRunStream(run_id);
   } catch (e) {
     pushLine("deny", `✕ could not start run: ${e}. Is the runtime live?`);
     activeRunId = null;
     setBusy(false);
   }
+}
+
+// Attach the execution SSE stream for a run. If the stream drops mid-run
+// (sleep, runtime restart, proxy hiccup) the chat must never stick in "busy":
+// recover the snapshot over plain HTTP, render it, and re-attach while the
+// run is still going.
+function openRunStream(run_id) {
+  currentStream = new EventSource(api(`/runs/${run_id}/execution/stream`));
+  currentStream.onmessage = (m) => {
+    try { renderSnapshot(JSON.parse(m.data)); } catch (_) {}
+  };
+  currentStream.onerror = async () => {
+    if (currentStream) currentStream.close();
+    if (activeRunId !== run_id) return; // run already concluded
+    try {
+      const snap = await getJSON(`/runs/${run_id}/execution`);
+      renderSnapshot(snap); // clears busy state if the run is terminal
+      if (activeRunId === run_id) setTimeout(() => {
+        if (activeRunId === run_id) openRunStream(run_id);
+      }, 1000);
+    } catch (_) {
+      pushLine("deny", "✕ lost connection to the runtime");
+      activeRunId = null;
+      setBusy(false);
+    }
+  };
 }
 
 $("composer").addEventListener("submit", (ev) => {

--- a/thymos/clients/desktop/src/styles.css
+++ b/thymos/clients/desktop/src/styles.css
@@ -224,6 +224,7 @@ code {
 .badge { border-radius: 999px; padding: 3px 10px; font-size: 12px; font-weight: 700; }
 .badge.ok { background: rgba(70,211,154,.15); color: var(--green); border: 1px solid var(--green); }
 .badge.bad { background: rgba(255,107,138,.15); color: var(--red); border: 1px solid var(--red); }
+.badge.warn { background: rgba(255,196,87,.15); color: var(--amber, #ffc457); border: 1px solid var(--amber, #ffc457); }
 .glyph { width: 1.4em; display: inline-block; text-align: center; }
 
 /* Tool effect-class badges (the governed ceiling) */
@@ -287,6 +288,15 @@ code {
 .mind-canvas:active { cursor: grabbing; }
 .mind-canvas canvas { display: block; width: 100%; height: 100%; }
 .mind-legend { display: flex; flex-wrap: wrap; gap: 16px; margin-top: 10px; font-size: 12.5px; }
+/* Live run-state strip above the Mind canvas — real runtime data, not décor. */
+.mind-state {
+  display: flex; flex-wrap: wrap; gap: 8px 18px; align-items: center;
+  margin: 0 0 10px; padding: 8px 12px; font-size: 12.5px;
+  border: 1px solid var(--line); border-radius: 10px; color: var(--muted);
+}
+.mind-state .ms-label { color: var(--muted); margin-right: 4px; }
+.mind-state .ms-val { color: var(--text); font-weight: 600; }
+.mind-state code { font-size: 11.5px; }
 .lg { font-weight: 600; color: var(--muted); }
 .lg.cyan { color: var(--cyan); }
 .lg.violet { color: var(--violet); }

--- a/thymos/clients/desktop/src/viz.js
+++ b/thymos/clients/desktop/src/viz.js
@@ -248,6 +248,11 @@ async function loadRun(idRaw) {
   let id = (idRaw || "").trim();
   try {
     if (!id) {
+      // Prefer the chat's current run (set by main.js) over "latest overall",
+      // so Mind opens on what the user is actually doing.
+      id = window.thymosActiveRun || "";
+    }
+    if (!id) {
       const runs = await (await fetch(`${BASE}/runs`)).json();
       const list = Array.isArray(runs) ? runs : runs.runs || [];
       id = list[0]?.run_id || list[0]?.trajectory_id || "";
@@ -265,7 +270,48 @@ async function loadRun(idRaw) {
     }
     const el = document.getElementById("mindRunId");
     if (el && !el.value) el.placeholder = `${id.slice(0, 8)} · ${entries.length} entries`;
+    await renderRunState(id);
   } catch (_) { /* runtime not up yet — the cage still renders */ }
+}
+
+// The live strip above the canvas: the run's real status, the runtime's
+// current operator state, provider/model, governed counters, and the replay
+// verdict — every field read from the runtime, none decorative.
+async function renderRunState(id) {
+  const box = document.getElementById("mindState");
+  if (!box) return;
+  let snap = null, health = null, replay = null;
+  try { snap = await (await fetch(`${BASE}/runs/${id}/execution`)).json(); } catch (_) {}
+  try { health = await (await fetch(`${BASE}/health`)).json(); } catch (_) {}
+  try {
+    const r = await fetch(`${BASE}/runs/${id}/replay`);
+    if (r.ok) replay = await r.json();
+  } catch (_) {}
+  if (!snap) { box.hidden = true; return; }
+  const st = snap.status || "?";
+  const stCls = st === "completed" ? "ok" : (st === "failed" ? "bad" : "warn");
+  const c = snap.counters || {};
+  const pieces = [
+    `<span><span class="ms-label">run</span><code>${escHtml(String(id).slice(0, 8))}</code></span>`,
+    `<span><span class="ms-label">status</span><span class="badge ${stCls}">${escHtml(st)}</span></span>`,
+    snap.operator_state
+      ? `<span><span class="ms-label">now</span><span class="ms-val">${escHtml(snap.operator_state)}</span></span>`
+      : "",
+    health
+      ? `<span><span class="ms-label">provider</span><span class="ms-val">${escHtml(health.default_provider || "?")}</span>` +
+        ` <span class="badge ${health.cognition_live ? "ok" : "bad"}">${health.cognition_live ? "live" : "mock"}</span></span>`
+      : "",
+    `<span><span class="ms-label">commits</span><span class="ms-val">${c.commits ?? 0}</span></span>`,
+    `<span><span class="ms-label">rejections</span><span class="ms-val">${c.rejections ?? 0}</span></span>`,
+    (c.approvals_pending ?? 0) > 0
+      ? `<span class="badge warn">⏸ ${c.approvals_pending} awaiting approval</span>`
+      : "",
+    replay
+      ? `<span><span class="ms-label">replay</span><span class="badge ok">verified · ${replay.commits_replayed ?? 0} commits</span></span>`
+      : "",
+  ];
+  box.innerHTML = pieces.filter(Boolean).join("");
+  box.hidden = false;
 }
 
 function frame() {

--- a/thymos/crates/thymos-cli/src/main.rs
+++ b/thymos/crates/thymos-cli/src/main.rs
@@ -123,9 +123,17 @@ enum Commands {
         json: bool,
     },
     /// List supported cognition providers / models (presets + how to start).
-    Providers,
+    Providers {
+        /// Print the preset registry as JSON.
+        #[arg(long)]
+        json: bool,
+    },
     /// List the real-world actions (tools) the agent can take, by effect class.
-    Tools,
+    Tools {
+        /// Print the live runtime's registered tools as JSON (queries the server).
+        #[arg(long)]
+        json: bool,
+    },
     /// Show API gateway usage stats.
     Usage,
     /// Health check.
@@ -189,6 +197,9 @@ enum RunsAction {
         /// Offset for pagination.
         #[arg(long, default_value = "0")]
         offset: u32,
+        /// Print the raw JSON page instead of the table.
+        #[arg(long)]
+        json: bool,
     },
     /// Show full record + ledger entries for one run.
     Show {
@@ -328,8 +339,8 @@ async fn main() {
         Commands::Audit { run_id, json } => {
             cmd_audit(&client, &cli.url, cli.api_key.as_deref(), &run_id, json).await
         }
-        Commands::Providers => cmd_providers(),
-        Commands::Tools => cmd_tools(),
+        Commands::Providers { json } => cmd_providers(json),
+        Commands::Tools { json } => cmd_tools(&client, &cli.url, json).await,
         Commands::Usage => cmd_usage(&client, &cli.url, cli.api_key.as_deref()).await,
         Commands::Health => cmd_health(&client, &cli.url).await,
         Commands::Doctor => cmd_doctor(&client, &cli.url, cli.api_key.as_deref()).await,
@@ -364,6 +375,7 @@ async fn main() {
                 status,
                 limit,
                 offset,
+                json,
             } => {
                 cmd_runs_ls(
                     &client,
@@ -372,6 +384,7 @@ async fn main() {
                     status.as_deref(),
                     limit,
                     offset,
+                    json,
                 )
                 .await
             }
@@ -705,7 +718,19 @@ fn cmd_setup(init: bool) -> Result<(), String> {
 
 /// `thymos tools` — the catalog of real-world actions the agent can take,
 /// grouped by effect class. Pure print; mirrors the built-in tool registry.
-fn cmd_tools() -> Result<(), String> {
+async fn cmd_tools(client: &reqwest::Client, url: &str, json: bool) -> Result<(), String> {
+    if json {
+        // The live registry (built-ins + manifest + MCP tools), not the static
+        // overview table — query the running server.
+        let resp = client
+            .get(format!("{url}/tools"))
+            .send()
+            .await
+            .map_err(|e| format!("could not reach the runtime at {url}: {e}"))?;
+        let body = json_body_or_error(resp).await?;
+        println!("{}", serde_json::to_string_pretty(&body).unwrap());
+        return Ok(());
+    }
     brand_banner();
     println!("  {}", paint(C_VIOLET_B, "Real-world actions the agent can take"));
     println!(
@@ -881,6 +906,70 @@ fn mask_secret(value: Option<&str>) -> String {
         Some(v) if v.len() > 8 => format!("{}...{}", &v[..4], &v[v.len() - 4..]),
         Some(_) => "(set)".into(),
         None => "(not set)".into(),
+    }
+}
+
+/// Probe the active provider's `/models` endpoint with locally-resolved
+/// credentials — the same check the desktop's "Test connection" runs. Returns
+/// (reachable, human detail). Never prints or returns key material.
+async fn probe_provider(provider: &str) -> (bool, String) {
+    use thymos_cognition::presets;
+    let p = provider.trim().to_ascii_lowercase();
+    if p == "mock" || p.is_empty() {
+        return (true, "mock — offline, nothing to probe".into());
+    }
+
+    let (base_url, headers): (String, Vec<(String, String)>) = if p == "anthropic" {
+        let base = std::env::var("ANTHROPIC_BASE_URL")
+            .unwrap_or_else(|_| "https://api.anthropic.com/v1".into());
+        let mut hs = vec![("anthropic-version".to_string(), "2023-06-01".to_string())];
+        if let Ok(k) = std::env::var("ANTHROPIC_API_KEY") {
+            hs.push(("x-api-key".to_string(), k));
+        }
+        (base, hs)
+    } else {
+        // openai + every OpenAI-compatible preset share one shape.
+        let preset = presets::resolve(&p);
+        let base = std::env::var("OPENAI_BASE_URL")
+            .ok()
+            .filter(|s| !s.trim().is_empty())
+            .or_else(|| preset.map(|pr| pr.base_url.to_string()))
+            .unwrap_or_else(|| "https://api.openai.com/v1".into());
+        let key = preset
+            .into_iter()
+            .flat_map(|pr| pr.api_key_envs.iter())
+            .find_map(|e| std::env::var(e).ok())
+            .or_else(|| std::env::var("OPENAI_API_KEY").ok());
+        let hs = key
+            .map(|k| vec![("Authorization".to_string(), format!("Bearer {k}"))])
+            .unwrap_or_default();
+        (base.trim_end_matches('/').to_string(), hs)
+    };
+
+    let client = match reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => return (false, format!("probe client failed: {e}")),
+    };
+    let mut req = client.get(format!("{base_url}/models"));
+    for (k, v) in headers {
+        req = req.header(&k, &v);
+    }
+    match req.send().await {
+        Ok(resp) if resp.status().is_success() => {
+            let body: Value = resp.json().await.unwrap_or(Value::Null);
+            let n = body["data"].as_array().map(|a| a.len()).unwrap_or(0);
+            (true, format!("reachable — {n} models"))
+        }
+        Ok(resp) => (
+            false,
+            format!("HTTP {} — check the key / base URL", resp.status().as_u16()),
+        ),
+        Err(e) if e.is_timeout() => (false, "timed out after 10s".into()),
+        Err(e) if e.is_connect() => (false, "not reachable (connection failed)".into()),
+        Err(_) => (false, "not reachable".into()),
     }
 }
 
@@ -1263,6 +1352,9 @@ pub(crate) async fn cmd_stream(url: &str, run_id: &str) -> Result<(), String> {
     let mut last_log_idx = 0u64;
     let mut last_status = String::new();
     let mut last_operator_state = String::new();
+    // Channels we've already prompted (or hinted) for, so repeated snapshots
+    // of the same suspension don't re-prompt.
+    let mut handled_approvals: std::collections::HashSet<String> = Default::default();
 
     while let Some(chunk) = stream.next().await {
         let chunk = chunk.map_err(|e| e.to_string())?;
@@ -1303,6 +1395,18 @@ pub(crate) async fn cmd_stream(url: &str, run_id: &str) -> Result<(), String> {
                             }
                         }
 
+                        // A suspended proposal: resolve it right here in the
+                        // terminal (TTY), or print the exact command to run.
+                        if status == "waiting_approval" {
+                            let channel = snapshot["pending_channel"]
+                                .as_str()
+                                .unwrap_or("ops")
+                                .to_string();
+                            if handled_approvals.insert(channel.clone()) {
+                                prompt_approval(url, run_id, &channel).await;
+                            }
+                        }
+
                         if matches!(status, "completed" | "failed" | "cancelled") {
                             if let Some(answer) = snapshot["final_answer"].as_str() {
                                 println!("\n{}", paint(C_VIOLET_B, "── final answer ──"));
@@ -1316,6 +1420,57 @@ pub(crate) async fn cmd_stream(url: &str, run_id: &str) -> Result<(), String> {
     }
     println!();
     Ok(())
+}
+
+/// Resolve a pending approval from the stream: interactive y/n on a TTY,
+/// otherwise print the exact `thymos approve` command and leave it pending.
+async fn prompt_approval(url: &str, run_id: &str, channel: &str) {
+    use std::io::IsTerminal;
+    if !std::io::stdin().is_terminal() {
+        println!(
+            "{}",
+            paint(
+                C_DIM,
+                format!(
+                    "resolve with:  thymos approve {run_id} {channel}   (add --deny to reject)"
+                ),
+            )
+        );
+        return;
+    }
+    print!(
+        "{} ",
+        paint("1;33", format!("⏸ approve '{channel}'? [y/N]"))
+    );
+    use std::io::Write as _;
+    let _ = std::io::stdout().flush();
+    let line = tokio::task::spawn_blocking(|| {
+        let mut s = String::new();
+        let _ = std::io::stdin().read_line(&mut s);
+        s
+    })
+    .await
+    .unwrap_or_default();
+    let approve = matches!(line.trim().to_ascii_lowercase().as_str(), "y" | "yes");
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{url}/runs/{run_id}/approvals/{channel}"))
+        .json(&serde_json::json!({ "approve": approve }))
+        .send()
+        .await;
+    match resp {
+        Ok(r) if r.status().is_success() => {
+            println!(
+                "{}",
+                paint(C_DIM, if approve { "— approved" } else { "— denied" })
+            );
+        }
+        Ok(r) => println!(
+            "{}",
+            paint(C_DIM, format!("approval not accepted (HTTP {})", r.status()))
+        ),
+        Err(e) => println!("{}", paint(C_DIM, format!("approval failed: {e}"))),
+    }
 }
 
 fn print_execution_entry(entry: &Value) {
@@ -1760,8 +1915,31 @@ pub(crate) async fn cmd_health(client: &reqwest::Client, url: &str) -> Result<()
 // Literal args are deliberate: this is a width-aligned table, so inlining them
 // into the format string would break the column layout.
 #[allow(clippy::print_literal)]
-pub(crate) fn cmd_providers() -> Result<(), String> {
+pub(crate) fn cmd_providers(json: bool) -> Result<(), String> {
     use thymos_cognition::presets;
+
+    if json {
+        let entries: Vec<Value> = presets::all()
+            .iter()
+            .map(|p| {
+                serde_json::json!({
+                    "id": p.id,
+                    "label": p.label,
+                    "base_url": p.base_url,
+                    "default_model": p.default_model,
+                    "api_key_envs": p.api_key_envs,
+                    "native_tools": p.native_tools,
+                    "local": p.local,
+                })
+            })
+            .collect();
+        let out = serde_json::json!({
+            "native": ["anthropic", "openai", "mock"],
+            "presets": entries,
+        });
+        println!("{}", serde_json::to_string_pretty(&out).unwrap());
+        return Ok(());
+    }
 
     brand_banner();
     println!("{}", paint("1", "Cognition providers — drive (almost) any model"));
@@ -1823,6 +2001,7 @@ pub(crate) async fn cmd_doctor(
     }
 
     println!();
+    let mut active_provider: Option<String> = None;
     match client.get(format!("{url}/health")).send().await {
         Ok(resp) => {
             let status = resp.status();
@@ -1839,6 +2018,7 @@ pub(crate) async fn cmd_doctor(
             // The single most common first-run footgun: not knowing whether the
             // server is answering with a real model or the deterministic mock.
             let provider = body["default_provider"].as_str().unwrap_or("unknown");
+            active_provider = Some(provider.to_string());
             let live = body["cognition_live"].as_bool().unwrap_or(false);
             status_line(
                 "cognition",
@@ -1903,6 +2083,15 @@ pub(crate) async fn cmd_doctor(
         std::env::var_os("OPENAI_BASE_URL").is_some(),
         std::env::var("OPENAI_BASE_URL").unwrap_or_else(|_| "(not set)".into()),
     );
+
+    // Live connection test against the active provider's /models endpoint —
+    // the same probe the desktop's "Test connection" button runs. Keys stay
+    // local; only reachability and a model count are printed.
+    if let Some(provider) = active_provider.as_deref() {
+        println!();
+        let (ok, detail) = probe_provider(provider).await;
+        status_line("provider connection", ok, format!("{provider}: {detail}"));
+    }
 
     println!();
     println!("{}", paint("38;2;199;125;255;1", "Next moves"));
@@ -1983,6 +2172,7 @@ pub(crate) async fn cmd_runs_ls(
     status: Option<&str>,
     limit: u32,
     offset: u32,
+    json: bool,
 ) -> Result<(), String> {
     let mut endpoint = format!("{url}/runs?limit={limit}&offset={offset}");
     if let Some(s) = status {
@@ -1994,6 +2184,11 @@ pub(crate) async fn cmd_runs_ls(
     }
     let resp = req.send().await.map_err(|e| e.to_string())?;
     let body = json_body_or_error(resp).await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&body).unwrap());
+        return Ok(());
+    }
 
     let runs = body["runs"].as_array().cloned().unwrap_or_default();
     let total = body["total"].as_u64().unwrap_or(0);

--- a/thymos/crates/thymos-cli/src/shell.rs
+++ b/thymos/crates/thymos-cli/src/shell.rs
@@ -345,7 +345,7 @@ async fn dispatch(
             match sub {
                 "ls" => {
                     let (status_flag, limit, offset) = parse_runs_ls(&args[1..])?;
-                    cmd_runs_ls(client, url, api_key, status_flag.as_deref(), limit, offset)
+                    cmd_runs_ls(client, url, api_key, status_flag.as_deref(), limit, offset, false)
                         .await?;
                 }
                 "show" => {

--- a/thymos/crates/thymos-compiler/src/lib.rs
+++ b/thymos/crates/thymos-compiler/src/lib.rs
@@ -38,7 +38,7 @@ use thymos_core::{
     writ::Writ,
 };
 use thymos_policy::PolicyEngine;
-use thymos_tools::{EffectClass, ToolInvocation, ToolRegistry};
+use thymos_tools::{EffectClass, RiskClass, ToolInvocation, ToolRegistry};
 
 pub enum Compiled {
     Staged(Proposal),
@@ -77,6 +77,12 @@ pub struct CompileContext {
     /// (preserves prior behavior); enable via
     /// `Runtime::with_require_compensation_for_irreversible`.
     pub require_compensation_for_irreversible: bool,
+    /// When set, any tool whose declared `RiskClass` is at or above this
+    /// threshold is escalated to `Suspended` (require approval) even if policy
+    /// permitted — the operator signs off on dangerous actions (e.g. `shell`)
+    /// instead of the writ alone authorizing them. `None` (the default)
+    /// preserves prior behavior.
+    pub approve_risk_at_or_above: Option<RiskClass>,
 }
 
 impl CompileContext {
@@ -88,6 +94,7 @@ impl CompileContext {
             budget_used: BudgetCost::default(),
             revoked: HashSet::new(),
             require_compensation_for_irreversible: false,
+            approve_risk_at_or_above: None,
         }
     }
 }
@@ -278,6 +285,29 @@ pub fn compile_with_context(
         )
     } else {
         (status, suspension)
+    };
+
+    // 9c. Risk gate. A tool at or above the configured risk threshold needs an
+    // explicit operator approval even on a bare permit — the writ grants the
+    // capability, the operator signs off on each dangerous use of it.
+    let (status, suspension) = match ctx.approve_risk_at_or_above {
+        Some(threshold) if suspension.is_none() && tool.meta().risk_class >= threshold => {
+            let channel = "high-risk".to_string();
+            let reason = format!(
+                "tool '{}' is {:?}-risk (threshold {:?}); operator approval required",
+                effective_tool,
+                tool.meta().risk_class,
+                threshold
+            );
+            (
+                ProposalStatus::Suspended {
+                    channel: channel.clone(),
+                    reason: reason.clone(),
+                },
+                Some((channel, reason)),
+            )
+        }
+        _ => (status, suspension),
     };
 
     // 10. Emit Proposal.

--- a/thymos/crates/thymos-runtime/src/lib.rs
+++ b/thymos/crates/thymos-runtime/src/lib.rs
@@ -177,6 +177,11 @@ pub struct Runtime<L: LedgerStore = Ledger> {
     /// require approval (compiler stage 9b) instead of executing on a bare
     /// policy permit. Default `false`.
     pub require_compensation_for_irreversible: bool,
+    /// When set, tools at or above this risk class are escalated to require
+    /// operator approval (compiler stage 9c) even on a bare policy permit.
+    /// Default `None` (library embedders opt in; the HTTP server defaults to
+    /// `High` so e.g. `shell` always pauses for sign-off).
+    pub approve_risk_at_or_above: Option<thymos_tools::RiskClass>,
 }
 
 /// Thread-safe set of revoked writ ids, consulted by the compiler on every
@@ -274,6 +279,7 @@ impl<L: LedgerStore> Runtime<L> {
             redactor: thymos_core::Redactor::default_secrets(),
             revocations: Revocations::new(),
             require_compensation_for_irreversible: false,
+            approve_risk_at_or_above: None,
             clock: std::sync::Arc::new(SystemClock),
             approval_quorum: 1,
             quorum: QuorumTracker::new(),
@@ -291,6 +297,16 @@ impl<L: LedgerStore> Runtime<L> {
     /// (compiler stage 9b). Off by default.
     pub fn with_require_compensation_for_irreversible(mut self, on: bool) -> Self {
         self.require_compensation_for_irreversible = on;
+        self
+    }
+
+    /// Builder: require operator approval for tools at or above this risk
+    /// class (compiler stage 9c). Off by default.
+    pub fn with_approve_risk_at_or_above(
+        mut self,
+        threshold: Option<thymos_tools::RiskClass>,
+    ) -> Self {
+        self.approve_risk_at_or_above = threshold;
         self
     }
 
@@ -662,6 +678,7 @@ impl<'a, L: LedgerStore> Run<'a, L> {
             require_compensation_for_irreversible: self
                 .runtime
                 .require_compensation_for_irreversible,
+            approve_risk_at_or_above: self.runtime.approve_risk_at_or_above,
         };
 
         // Compile (with budget + time-window checks).

--- a/thymos/crates/thymos-runtime/tests/risk_gate.rs
+++ b/thymos/crates/thymos-runtime/tests/risk_gate.rs
@@ -1,0 +1,154 @@
+//! Risk gate (compiler stage 9c): when a threshold is set, a tool whose
+//! declared `RiskClass` is at or above it is escalated to require operator
+//! approval, even on a bare policy permit. Lower-risk tools and the
+//! no-threshold default are unaffected.
+
+use serde_json::{json, Value};
+
+use thymos_core::{commit::Observation, delta::StructuredDelta, error::Result};
+use thymos_ledger::Ledger;
+use thymos_policy::{PolicyEngine, WritAuthorityPolicy};
+use thymos_runtime::{
+    generate_signing_key, public_key_of, Budget, CoreIntent, DelegationBounds, EffectCeiling,
+    IntentBody, IntentKind, Runtime, Step, TimeWindow, ToolPattern, Writ, WritBody,
+};
+use thymos_tools::{
+    EffectClass, RiskClass, ToolContract, ToolContractMeta, ToolInvocation, ToolOutcome,
+    ToolRegistry,
+};
+
+struct RiskyTool {
+    risk: RiskClass,
+}
+impl ToolContract for RiskyTool {
+    fn meta(&self) -> &ToolContractMeta {
+        Box::leak(Box::new(ToolContractMeta {
+            name: "risky_write".into(),
+            version: "1.0.0".into(),
+            effect_class: EffectClass::Write,
+            risk_class: self.risk,
+        }))
+    }
+    fn description(&self) -> &str {
+        "a write whose risk class drives the 9c gate"
+    }
+    fn input_schema(&self) -> Value {
+        json!({"type": "object"})
+    }
+    fn execute(&self, _inv: &ToolInvocation<'_>) -> Result<ToolOutcome> {
+        Ok(ToolOutcome {
+            delta: StructuredDelta(vec![]),
+            observation: Observation {
+                tool: "risky_write".into(),
+                output: json!(null),
+                latency_ms: 0,
+            },
+        })
+    }
+}
+
+fn writ() -> Writ {
+    let issuer = generate_signing_key();
+    let subject = generate_signing_key();
+    Writ::sign(
+        WritBody {
+            issuer: "root".into(),
+            issuer_pubkey: public_key_of(&issuer),
+            subject: "agent".into(),
+            subject_pubkey: public_key_of(&subject),
+            nonce: [0u8; 16],
+            parent: None,
+            tenant_id: String::new(),
+            tool_scopes: vec![ToolPattern::exact("risky_write")],
+            budget: Budget {
+                tokens: 10_000,
+                tool_calls: 100,
+                wall_clock_ms: 600_000,
+                usd_millicents: 1_000_000,
+            },
+            effect_ceiling: EffectCeiling {
+                read: true,
+                write: true,
+                external: false,
+                irreversible: false,
+            },
+            time_window: TimeWindow {
+                not_before: 0,
+                expires_at: u64::MAX,
+            },
+            delegation: DelegationBounds {
+                max_depth: 1,
+                may_subdivide: false,
+            },
+        },
+        &issuer,
+    )
+    .unwrap()
+}
+
+fn act() -> CoreIntent {
+    CoreIntent::new(IntentBody {
+        parent_commit: None,
+        author: "test".into(),
+        kind: IntentKind::Act,
+        target: "risky_write".into(),
+        args: json!({}),
+        rationale: "gate".into(),
+        nonce: [7; 16],
+    })
+    .unwrap()
+}
+
+fn runtime(risk: RiskClass, threshold: Option<RiskClass>) -> Runtime {
+    let mut tools = ToolRegistry::new();
+    tools.register(RiskyTool { risk });
+    Runtime::new(
+        Ledger::open_in_memory().unwrap(),
+        tools,
+        PolicyEngine::new().with(WritAuthorityPolicy),
+    )
+    .with_approve_risk_at_or_above(threshold)
+}
+
+#[test]
+fn at_threshold_suspends() {
+    let rt = runtime(RiskClass::High, Some(RiskClass::High));
+    let run = rt.create_run("r1", b"r1").unwrap();
+    match run.submit(act(), &writ()).unwrap() {
+        Step::Suspended { channel, reason } => {
+            assert_eq!(channel, "high-risk");
+            assert!(reason.contains("risky_write"));
+        }
+        other => panic!("expected suspension, got {other:?}"),
+    }
+}
+
+#[test]
+fn above_threshold_suspends() {
+    let rt = runtime(RiskClass::Critical, Some(RiskClass::High));
+    let run = rt.create_run("r2", b"r2").unwrap();
+    assert!(matches!(
+        run.submit(act(), &writ()).unwrap(),
+        Step::Suspended { .. }
+    ));
+}
+
+#[test]
+fn below_threshold_commits() {
+    let rt = runtime(RiskClass::Medium, Some(RiskClass::High));
+    let run = rt.create_run("r3", b"r3").unwrap();
+    assert!(matches!(
+        run.submit(act(), &writ()).unwrap(),
+        Step::Committed(_)
+    ));
+}
+
+#[test]
+fn no_threshold_is_default_behavior() {
+    let rt = runtime(RiskClass::Critical, None);
+    let run = rt.create_run("r4", b"r4").unwrap();
+    assert!(matches!(
+        run.submit(act(), &writ()).unwrap(),
+        Step::Committed(_)
+    ));
+}

--- a/thymos/crates/thymos-server/src/lib.rs
+++ b/thymos/crates/thymos-server/src/lib.rs
@@ -471,8 +471,22 @@ pub const MAX_CONCURRENT_RUNS_GLOBAL: u32 = 100;
 
 #[derive(Deserialize)]
 pub struct ApprovalRequest {
-    pub approve: bool,
+    /// Canonical form: `{"approve": true|false}`.
+    pub approve: Option<bool>,
+    /// Compatibility form sent by older desktop builds: `"approve"|"deny"`.
+    pub decision: Option<String>,
     pub proposal_id: Option<String>,
+}
+
+impl ApprovalRequest {
+    /// Resolve the operator's verdict from either accepted shape.
+    pub fn verdict(&self) -> Option<bool> {
+        self.approve.or_else(|| {
+            self.decision
+                .as_deref()
+                .map(|d| d.eq_ignore_ascii_case("approve"))
+        })
+    }
 }
 
 /// Build a runtime with a file-backed ledger.
@@ -536,7 +550,31 @@ fn build_runtime(
     load_mcp_servers(&mut tools);
 
     let policy = PolicyEngine::new().with(WritAuthorityPolicy);
-    Arc::new(Runtime::new(ledger, tools, policy))
+    Arc::new(
+        Runtime::new(ledger, tools, policy)
+            .with_approve_risk_at_or_above(approve_risk_from_env()),
+    )
+}
+
+/// Risk threshold above which proposals pause for operator approval
+/// (compiler stage 9c). `THYMOS_APPROVE_RISK` = `off` | `low` | `medium` |
+/// `high` | `critical`; default `high`, so dangerous tools (e.g. `shell`)
+/// always require an explicit sign-off while file edits and reads flow
+/// under their writ grants.
+fn approve_risk_from_env() -> Option<thymos_tools::RiskClass> {
+    use thymos_tools::RiskClass;
+    match std::env::var("THYMOS_APPROVE_RISK")
+        .unwrap_or_default()
+        .trim()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "off" | "none" => None,
+        "low" => Some(RiskClass::Low),
+        "medium" => Some(RiskClass::Medium),
+        "critical" => Some(RiskClass::Critical),
+        _ => Some(RiskClass::High),
+    }
 }
 
 fn load_programmable_capabilities(tools: &mut ToolRegistry, tool_manifest_dirs: &[String]) {
@@ -1264,7 +1302,29 @@ async fn resume_run(
         let cognition = match tokio::task::spawn_blocking(move || build_cognition(&config)).await {
             Ok(c) => c,
             Err(e) => {
+                // Same as create_run: never leave the run in `Running` with no
+                // terminal snapshot — the UI would show "governing…" forever.
                 eprintln!("cognition construction panicked: {e}");
+                let mut runs = state2.runs.lock().unwrap();
+                if let Some(rec) = runs.get_mut(&run_id) {
+                    rec.status = RunStatus::Failed;
+                    rec.summary = Some(RunSummaryDto {
+                        steps_executed: 0,
+                        intents_submitted: 0,
+                        commits: 0,
+                        rejections: 0,
+                        failures: 1,
+                        final_answer: Some(
+                            "The model provider failed to initialize. Check the provider settings."
+                                .into(),
+                        ),
+                        terminated_by: "Error".into(),
+                    });
+                }
+                drop(runs);
+                with_execution_session(&state2, &run_id, &task, req.max_steps, |session| {
+                    session.mark_failed(format!("cognition construction panicked: {e}"));
+                });
                 return;
             }
         };
@@ -1778,7 +1838,37 @@ async fn create_run(
         let cognition = match tokio::task::spawn_blocking(move || build_cognition(&config)).await {
             Ok(c) => c,
             Err(e) => {
+                // A bare return here would leave the run in `Running` forever
+                // (the UI shows "governing…" indefinitely) and leak the
+                // concurrency slot. Mark it failed so every surface sees a
+                // terminal state.
                 eprintln!("cognition construction panicked: {e}");
+                let err_dto = RunSummaryDto {
+                    steps_executed: 0,
+                    intents_submitted: 0,
+                    commits: 0,
+                    rejections: 0,
+                    failures: 1,
+                    final_answer: Some(
+                        "The model provider failed to initialize. Check the provider settings."
+                            .into(),
+                    ),
+                    terminated_by: "Error".into(),
+                };
+                {
+                    let mut runs = state2.runs.lock().unwrap();
+                    if let Some(rec) = runs.get_mut(&run_id2) {
+                        rec.status = RunStatus::Failed;
+                        rec.summary = Some(err_dto.clone());
+                    }
+                }
+                with_execution_session(&state2, &run_id2, &task2, req.max_steps, |session| {
+                    session.mark_failed(format!("cognition construction panicked: {e}"));
+                });
+                if let Some(store) = &state2.run_store {
+                    let _ = store.update(&run_id2, "", "failed", Some(&err_dto));
+                }
+                state2.active_runs.fetch_sub(1, Ordering::Relaxed);
                 return;
             }
         };
@@ -2498,6 +2588,15 @@ async fn post_approval(
     Path((id, channel)): Path<(String, String)>,
     Json(req): Json<ApprovalRequest>,
 ) -> impl IntoResponse {
+    let Some(approve) = req.verdict() else {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": "missing verdict: send {\"approve\": true|false} (or {\"decision\": \"approve\"|\"deny\"})",
+            })),
+        )
+            .into_response();
+    };
     let key = (id.clone(), channel.clone());
     let sender = {
         let mut pending = state.pending_approvals.lock().unwrap();
@@ -2506,16 +2605,14 @@ async fn post_approval(
 
     match sender {
         Some(tx) => {
-            let decision = ApprovalDecision {
-                approve: req.approve,
-            };
+            let decision = ApprovalDecision { approve };
             match tx.send(decision) {
                 Ok(()) => (
                     StatusCode::OK,
                     Json(serde_json::json!({
                         "run_id": id,
                         "channel": channel,
-                        "approved": req.approve,
+                        "approved": approve,
                     })),
                 )
                     .into_response(),
@@ -2888,6 +2985,26 @@ fn entry_to_dto(e: &thymos_ledger::Entry) -> EntryDto {
         id: e.id.short().to_string(),
         detail,
         commit_id,
+    }
+}
+
+#[cfg(test)]
+mod approval_request_tests {
+    use super::ApprovalRequest;
+
+    #[test]
+    fn verdict_accepts_both_wire_shapes() {
+        let canonical: ApprovalRequest =
+            serde_json::from_str(r#"{"approve": true}"#).unwrap();
+        assert_eq!(canonical.verdict(), Some(true));
+        let legacy_approve: ApprovalRequest =
+            serde_json::from_str(r#"{"decision": "approve"}"#).unwrap();
+        assert_eq!(legacy_approve.verdict(), Some(true));
+        let legacy_deny: ApprovalRequest =
+            serde_json::from_str(r#"{"decision": "deny"}"#).unwrap();
+        assert_eq!(legacy_deny.verdict(), Some(false));
+        let empty: ApprovalRequest = serde_json::from_str(r#"{}"#).unwrap();
+        assert_eq!(empty.verdict(), None);
     }
 }
 

--- a/thymos/crates/thymos-server/tests/e2e.rs
+++ b/thymos/crates/thymos-server/tests/e2e.rs
@@ -315,6 +315,28 @@ async fn approval_on_nonexistent_run_returns_404() {
 }
 
 #[tokio::test]
+async fn approval_accepts_legacy_decision_shape() {
+    // Older desktop builds sent {"decision": "approve"} — must deserialize
+    // (404 here because the run doesn't exist, NOT 422 on the body shape).
+    let server = test_server(test_state());
+    let resp = server
+        .post("/runs/nonexistent/approvals/test-channel")
+        .json(&json!({ "decision": "approve" }))
+        .await;
+    resp.assert_status(axum::http::StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn approval_without_verdict_is_a_clear_400() {
+    let server = test_server(test_state());
+    let resp = server
+        .post("/runs/nonexistent/approvals/test-channel")
+        .json(&json!({}))
+        .await;
+    resp.assert_status(axum::http::StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
 async fn world_on_nonexistent_run_returns_404() {
     let server = test_server(test_state());
     let resp = server.get("/runs/nonexistent/world").await;

--- a/thymos/crates/thymos-tools/src/lib.rs
+++ b/thymos/crates/thymos-tools/src/lib.rs
@@ -39,7 +39,7 @@ pub enum EffectClass {
     Irreversible,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum RiskClass {
     Low,


### PR DESCRIPTION
## Stuck on "governing…" — root causes found and fixed

1. **Swallowed panic, missing state transition**: when cognition construction panicked, `create_run`/`resume_run` bailed with a bare `return` — the run stayed `Running` forever, no terminal snapshot ever streamed, and the UI spun on "governing…" indefinitely. `create_run` also leaked its concurrency slot (eventually blocking all new runs). Both sites now mark the run failed (plain-English chat answer, raw panic in the session log), persist, and release the slot.
2. **Approval deadlock**: the desktop sent `{"decision":"approve"}` but the server required `{"approve":bool}` — **422 on every Approve/Deny click**, so any suspended run was unrecoverable from the UI. Server accepts both shapes now (unit + e2e tested); desktop sends the canonical form; the approval channel is prefilled from the snapshot.
3. **SSE drop / cancel race**: a dropped stream left the chat stuck busy; cancel after completion alerted "409". The stream now recovers from `/execution` and re-attaches; cancel treats 409/404 as "already finished" and resyncs.
4. **Perception**: the busy line now mirrors the runtime's live `operator_state` ("planning step 2…", "executing fs_patch…", "awaiting approval on high-risk…") instead of a static label.

## Risk gate (compiler stage 9c)
Tools at or above a configured `RiskClass` pause for operator approval even on a bare policy permit. `THYMOS_APPROVE_RISK` (`off|low|medium|high|critical`), server default `high` → `shell` always asks; file edits/reads flow under writ grants. 4 new tests; STATUS.md updated.

## CLI ↔ Desktop parity (one runtime, no duplicated storage)
- `thymos run --follow`/`stream` resolves suspensions inline: y/N prompt on a TTY, exact `thymos approve` hint otherwise.
- `--json` on `runs ls`, `providers`, `tools` (live registry).
- `thymos doctor` probes the active provider's `/models` (same as desktop "Test connection"); never prints key material.
- Verified live: a CLI-created run is visible on the same `/runs`/audit/replay surfaces the desktop reads.

## Mind: real, inspectable runtime state
Live strip above the canvas — run id, status, current operator state, provider + live/mock, commit/rejection counters, pending approvals, replay verdict — all from `/execution`, `/health`, `/runs/{id}/replay`. Mind opens on the chat's current run; nodes remain real ledger entries with click-to-inspect.

## Verified
`cargo test --workspace` green (incl. new `risk_gate`, approval-shape e2e), clippy zero warnings, JS syntax-checked, live server smokes for shared state and the Mind data shapes. **Not verified here:** a live model proposing `shell` end-to-end (needs a provider key; the suspension itself is unit-tested at the compile boundary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)