### PR TITLE
docs(readme): single official download source line

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Terminal, scriptable, server. No Rust, no clone, no compile.
 </table>
 </div>
 
+<sub>All downloads come from the <a href="https://github.com/gryszzz/open-thymos/releases/latest"><b>latest stable release</b></a> — the single official production download source (release notes + checksums there). Nightly dev builds are separate and clearly marked.</sub>
+
 </div>
 
 <details>


### PR DESCRIPTION
One line under the download columns: all downloads come from the latest stable release (single official production source, release notes there); nightly is separate and marked. Part of the release-cleanup pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)