### PR TITLE
Runtime visibility: enriched Audit, Advanced tab, Mind as a runtime map (v0.7.3)

### DIFF
--- a/thymos/Cargo.lock
+++ b/thymos/Cargo.lock
@@ -2699,7 +2699,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-cli"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "axum 0.8.9",
  "clap",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-client"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "axum-test",
  "reqwest",
@@ -2733,7 +2733,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-cognition"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -2747,7 +2747,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-compiler"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -2758,7 +2758,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-core"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "blake3",
  "ed25519-dalek",
@@ -2771,7 +2771,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-ledger"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "blake3",
  "deadpool-postgres",
@@ -2787,7 +2787,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-marketplace"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "blake3",
  "hex",
@@ -2800,7 +2800,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-policy"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -2809,7 +2809,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-runtime"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "serde",
@@ -2826,7 +2826,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-server"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2859,7 +2859,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-tools"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "blake3",
  "reqwest",
@@ -2872,7 +2872,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-worker"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "serde_json",
  "thymos-tools",

--- a/thymos/Cargo.toml
+++ b/thymos/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 license = "Apache-2.0"
 rust-version = "1.80"

--- a/thymos/clients/desktop/package-lock.json
+++ b/thymos/clients/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thymos-desktop",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thymos-desktop",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "devDependencies": {
         "@tauri-apps/cli": "^2"
       }

--- a/thymos/clients/desktop/package.json
+++ b/thymos/clients/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thymos-desktop",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "private": true,
   "description": "OpenThymos Desktop — governed-cognition runtime, install once.",
   "scripts": {

--- a/thymos/clients/desktop/src-tauri/Cargo.lock
+++ b/thymos/clients/desktop/src-tauri/Cargo.lock
@@ -3288,7 +3288,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-desktop"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "serde",
  "serde_json",

--- a/thymos/clients/desktop/src-tauri/Cargo.toml
+++ b/thymos/clients/desktop/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "thymos-desktop"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 license = "Apache-2.0"
 description = "OpenThymos Desktop — a governed-cognition client that supervises a local runtime."

--- a/thymos/clients/desktop/src-tauri/tauri.conf.json
+++ b/thymos/clients/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenThymos",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "identifier": "com.openthymos.desktop",
   "build": {
     "frontendDist": "../src"

--- a/thymos/clients/desktop/src/index.html
+++ b/thymos/clients/desktop/src/index.html
@@ -27,9 +27,6 @@
         <span id="ledger" class="pill">ledger: —</span>
       </div>
       <div class="controls">
-        <label class="adv-toggle" title="Show developer internals — raw ledger data, schemas, writs/commits. Off by default.">
-          <input type="checkbox" id="advToggle" /> Advanced
-        </label>
         <button id="startBtn">Start runtime</button>
         <button id="stopBtn" class="ghost">Stop</button>
       </div>
@@ -44,6 +41,7 @@
       <button class="tab" data-tab="tools">▣ Tools</button>
       <button class="tab" data-tab="audit">≡ Audit</button>
       <button class="tab adv-only" data-tab="backups">↧ Backups</button>
+      <button class="tab" data-tab="advanced">⚙ Advanced</button>
     </nav>
 
     <main>
@@ -57,9 +55,8 @@
             <!-- Authority is configured ONCE here and saved to this model, not
                  chosen per message. -->
             <div class="chat-defaults">
-              <!-- Per-chat model override (advanced) + active skill chips — both
-                   appear only when in use, keeping the rail clean. -->
-              <input id="chatModel" class="adv-only" list="modelList" autocomplete="off" placeholder="model override (blank = default)" />
+              <!-- Active skill chips — appear only when in use, keeping the
+                   rail clean. The per-chat model override lives in Advanced. -->
               <div id="skillChips" class="skill-chips" title="Active skills — combine any; they only narrow authority."></div>
               <div class="grants" id="grants" title="What this chat is allowed to do — the writ scope. The runtime rejects anything not granted. No selection = everything granted.">
                 <span class="grant-label">grant</span>
@@ -397,6 +394,59 @@
             runtime at the copy. One-click backup/restore + a chain-head
             integrity report is tracked in <code>docs/rfcs/desktop-app.md §3</code>.
           </p>
+        </div>
+      </section>
+
+      <!-- ADVANCED: the runtime inspection + power-user surface. Everything
+           here reads real state — no placeholder controls. -->
+      <section class="panel" id="tab-advanced">
+        <div class="panel-head"><h2>Advanced — runtime inspection</h2>
+          <button type="button" class="ghost" id="refreshAdvanced">Refresh</button></div>
+        <p class="tab-intro">
+          The deeper controls and live truth of the runtime under this app.
+          Normal chat never needs this tab; it's here when you want to see —
+          or steer — exactly what the runtime is doing.
+        </p>
+
+        <div class="adv-grid">
+          <div class="card">
+            <h3>Runtime</h3>
+            <div id="advRuntime" class="state-card"></div>
+            <label class="adv-toggle" title="Reveal developer internals across the app — raw ledger data, schemas, the Backups tab.">
+              <input type="checkbox" id="advToggle" /> Advanced Mode (show internals everywhere)
+            </label>
+          </div>
+
+          <div class="card">
+            <h3>Model &amp; routing</h3>
+            <div id="advProvider" class="state-card"></div>
+            <label class="adv-label" for="chatModel">Per-chat model override</label>
+            <input id="chatModel" list="modelList" autocomplete="off" placeholder="model override (blank = provider default)" />
+            <p class="note">Applies to new chat messages. Provider, key, and base URL are managed in the <b>Providers</b> tab.</p>
+          </div>
+
+          <div class="card">
+            <h3>Authority</h3>
+            <div id="advAuthority" class="state-card"></div>
+            <p class="note">
+              Grants are the writ scope for new chats (left rail chips). Tools at
+              <b>high</b> risk (e.g. <code>shell</code>) always pause for your
+              approval — tune with <code>THYMOS_APPROVE_RISK</code>.
+            </p>
+          </div>
+
+          <div class="card">
+            <h3>Ledger &amp; debug</h3>
+            <div class="ledger-path-row">
+              <span class="dim">ledger file</span>
+              <code id="advLedgerPath" class="path">—</code>
+            </div>
+            <p class="note">
+              The single hash-chained file holding every governed action.
+              Inspect any run in <b>Audit</b> (now with the full narrative:
+              retries, rejections, grants, errors); verify with replay.
+            </p>
+          </div>
         </div>
       </section>
     </main>

--- a/thymos/clients/desktop/src/main.js
+++ b/thymos/clients/desktop/src/main.js
@@ -45,8 +45,66 @@ document.querySelectorAll(".tab").forEach((btn) => {
     if (btn.dataset.tab === "skills") loadSkills();
     if (btn.dataset.tab === "tools") loadTools();
     if (btn.dataset.tab === "backups") loadBackups();
+    if (btn.dataset.tab === "advanced") loadAdvanced();
   });
 });
+
+/* ---------- Advanced tab: live runtime inspection (all real state) ---------- */
+async function loadAdvanced() {
+  // Runtime card: health truth + where this app is pointed.
+  const rt = $("advRuntime");
+  if (rt) {
+    let health = null;
+    try { health = await getJSON("/health"); } catch (_) {}
+    let appVer = "";
+    try { appVer = await window.__TAURI__?.app?.getVersion?.(); } catch (_) {}
+    rt.innerHTML = health
+      ? `<div class="state-grid">` +
+        `<span class="dim">runtime</span><span><span class="badge ok">live</span> <span class="dim">${escapeHtml(BASE)}</span></span>` +
+        `<span class="dim">mode</span><span>${escapeHtml(health.mode || "?")}</span>` +
+        `<span class="dim">ledger</span><span>${escapeHtml(health.ledger || "?")}</span>` +
+        (appVer ? `<span class="dim">app version</span><span>v${escapeHtml(appVer)}</span>` : "") +
+        `</div>`
+      : `<div class="hint">Runtime not running — press <b>Start runtime</b> (top right).</div>`;
+  }
+  // Model & routing card: the provider this runtime answers with.
+  const pv = $("advProvider");
+  if (pv) {
+    let cfg = null, health = null;
+    try { if (invoke) cfg = await invoke("get_provider_config"); } catch (_) {}
+    try { health = await getJSON("/health"); } catch (_) {}
+    const provider = cfg?.provider || health?.default_provider || "—";
+    const live = !!health?.cognition_live;
+    pv.innerHTML =
+      `<div class="state-grid">` +
+      `<span class="dim">provider</span><span>${escapeHtml(provider)} ` +
+      `<span class="badge ${live ? "ok" : "bad"}">${live ? "live model" : "mock"}</span></span>` +
+      `<span class="dim">default model</span><span>${escapeHtml(cfg?.model || "(provider default)")}</span>` +
+      (cfg?.base_url ? `<span class="dim">base url</span><span>${escapeHtml(cfg.base_url)}</span>` : "") +
+      (cfg ? `<span class="dim">api key</span><span>${cfg.key_set ? "stored locally" : "not set"}</span>` : "") +
+      `</div>`;
+    if (cfg?.provider) fillModelList(cfg.provider);
+  }
+  // Authority card: what new chats are allowed to do, right now.
+  const au = $("advAuthority");
+  if (au) {
+    const scopes = selectedScopes();
+    const skills = selectedSkills();
+    au.innerHTML =
+      `<div class="state-grid">` +
+      `<span class="dim">grants</span><span>${scopes.length ? scopes.map(escapeHtml).join(" · ") : "everything (no chips selected)"}</span>` +
+      `<span class="dim">active skills</span><span>${skills.length ? skills.map(escapeHtml).join(" · ") : "none"}</span>` +
+      `<span class="dim">risk gate</span><span>high-risk tools pause for approval</span>` +
+      `</div>`;
+  }
+  // Ledger card: the real on-disk chain this runtime writes.
+  const lp = $("advLedgerPath");
+  if (lp && invoke) {
+    try { lp.textContent = (await invoke("ledger_path")) || "(runtime not started yet)"; }
+    catch (_) { lp.textContent = "—"; }
+  }
+}
+$("refreshAdvanced")?.addEventListener("click", loadAdvanced);
 
 /* ---------- Advanced Mode ---------- */
 // Off by default: normal users never see raw runtime data, schemas, writs, or
@@ -131,6 +189,24 @@ function pushLine(cls, text) {
   feed.appendChild(div);
   feed.scrollTop = feed.scrollHeight;
   return div;
+}
+
+// Governance refusals are the runtime working, not the tool breaking — turn
+// the raw reason into plain English with the action that unblocks it. Shared
+// by the chat feed and the Audit narrative.
+function governanceHint(e) {
+  const raw = e.detail || "";
+  if (/AuthorityVoid/.test(raw)) {
+    const tool = ((e.title || "").match(/for (\S+)/) || [])[1] || "that tool";
+    return `${tool} isn't granted for this chat. The runtime blocked it (nothing is broken) — toggle its grant chip in the left rail and ask again.`;
+  }
+  if (/PolicyDenied/.test(raw)) {
+    return "policy denied this action — the decision is recorded in the run's audit trail.";
+  }
+  if (/BudgetExhausted|budget/.test(raw) && e.level === "error") {
+    return "this run's budget (tokens / tool calls / time) ran out — start a fresh message to continue.";
+  }
+  return "";
 }
 
 // Map a runtime log entry to a glyph + css class (the shared visual language).
@@ -265,20 +341,8 @@ function renderSnapshot(s) {
     let detail = e.detail ? `  ${e.detail}` : "";
     if (detail.length > 300) detail = detail.slice(0, 300) + "…";
     pushLine(cls, `${g} ${e.title}${detail}`);
-    // Governance refusals are the runtime working, not the tool breaking —
-    // say so in plain English, with the action that unblocks it.
-    const raw = e.detail || "";
-    if (/AuthorityVoid/.test(raw)) {
-      const tool = (e.title.match(/for (\S+)/) || [])[1] || "that tool";
-      pushLine("sys",
-        `   ↳ ${tool} isn't granted for this chat. The runtime blocked it (nothing is broken) — toggle its grant chip in the left rail and ask again.`);
-    } else if (/PolicyDenied/.test(raw)) {
-      pushLine("sys",
-        "   ↳ policy denied this action — the decision is recorded in the run's audit trail.");
-    } else if (/BudgetExhausted|budget/.test(raw) && e.level === "error") {
-      pushLine("sys",
-        "   ↳ this run's budget (tokens / tool calls / time) ran out — start a fresh message to continue.");
-    }
+    const hint = governanceHint(e);
+    if (hint) pushLine("sys", `   ↳ ${hint}`);
   });
   if (s.status === "waiting_approval") showApproval(s.run_id, s.pending_channel);
   if (["completed", "failed", "cancelled"].includes(s.status)) {
@@ -1108,6 +1172,43 @@ async function loadAudit(runId) {
     const entries = await getJSON(`/audit/entries?run_id=${encodeURIComponent(runId)}`);
     const list = Array.isArray(entries) ? entries : entries.entries || [];
     trail.innerHTML = "";
+
+    // --- What happened: the run's narrative, from the execution session log.
+    // Provider retries, grant requests, rejections, executions, errors — with
+    // the same plain-English hints the chat shows.
+    try {
+      const snap = await getJSON(`/runs/${encodeURIComponent(runId)}/execution`);
+      const log = snap?.log || [];
+      if (log.length) {
+        const head = document.createElement("div");
+        head.className = "audit-subhead";
+        head.innerHTML = `<b>What happened</b><span class="meta"> · the run's live narrative (status: ${escapeHtml(snap.status || "?")})</span>`;
+        trail.appendChild(head);
+        log.forEach((e) => {
+          const [g, cls] = glyphFor(e);
+          const when = e.timestamp_ms ? new Date(e.timestamp_ms).toLocaleTimeString() : "";
+          const div = document.createElement("div");
+          div.className = "item audit-narrative";
+          let detail = e.detail || "";
+          if (detail.length > 220) detail = detail.slice(0, 220) + "…";
+          div.innerHTML =
+            `<span class="glyph ${cls}">${g}</span>` +
+            `<b>${escapeHtml(e.title || "")}</b>` +
+            (e.tool ? `<span class="meta">${escapeHtml(e.tool)}</span>` : "") +
+            `<span class="meta">${escapeHtml(when)}</span>` +
+            (detail ? `<div class="audit-detail">${escapeHtml(detail)}</div>` : "");
+          const hint = governanceHint(e);
+          if (hint) div.innerHTML += `<div class="audit-hint">↳ ${escapeHtml(hint)}</div>`;
+          trail.appendChild(div);
+        });
+      }
+    } catch (_) { /* restored runs may have no live session — ledger below */ }
+
+    // --- Ledger chain: the authoritative, hash-chained record.
+    const head2 = document.createElement("div");
+    head2.className = "audit-subhead";
+    head2.innerHTML = `<b>Ledger chain</b><span class="meta"> · authoritative, content-addressed, replay-verified</span>`;
+    trail.appendChild(head2);
     list.forEach((e) => {
       const div = document.createElement("div");
       div.className = "item";
@@ -1128,6 +1229,8 @@ async function loadAudit(runId) {
     }
   } catch (e) { trail.innerHTML = `<div class='hint'>could not load trail: ${e}</div>`; }
 }
+// Mind's inspector links here ("open in Audit").
+window.thymosOpenAudit = openAudit;
 $("auditForm").addEventListener("submit", (ev) => {
   ev.preventDefault();
   const id = $("auditRunId").value.trim();

--- a/thymos/clients/desktop/src/styles.css
+++ b/thymos/clients/desktop/src/styles.css
@@ -443,3 +443,33 @@ body.advanced .adv-only { display: revert; }
 .state-grid { display: grid; grid-template-columns: 130px 1fr; gap: 6px 14px; font-size: 13px; align-items: center; }
 .state-grid .dim { color: var(--muted); }
 .state-asof { margin-top: 10px; font-size: 11.5px; color: var(--muted); }
+
+/* ---------- Audit: narrative + ledger chain in one trail ---------- */
+.audit-subhead {
+  margin: 18px 0 8px; padding-bottom: 6px;
+  border-bottom: 1px solid var(--line);
+  font-size: 13px;
+}
+.audit-subhead:first-child { margin-top: 4px; }
+.audit-narrative { display: block; }
+.audit-detail {
+  margin: 4px 0 0 1.6em; color: var(--muted); font-size: 12px;
+  font-family: ui-monospace, Menlo, monospace; word-break: break-word;
+}
+.audit-hint { margin: 4px 0 0 1.6em; color: var(--green); font-size: 12.5px; }
+
+/* ---------- Advanced tab: runtime inspection cards ---------- */
+.adv-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+.adv-grid .card h3 { margin: 0 0 10px; font-size: 15px; }
+.adv-grid .state-card { margin-bottom: 12px; }
+.adv-label { display: block; margin: 10px 0 6px; font-size: 12.5px; color: var(--muted); }
+#tab-advanced .adv-toggle { margin-top: 12px; display: inline-flex; }
+@media (max-width: 900px) { .adv-grid { grid-template-columns: 1fr; } }
+
+/* Mind inspector → Audit cross-link */
+.mi-audit {
+  margin-top: 10px; width: 100%;
+  background: none; border: 1px solid var(--line); border-radius: 8px;
+  color: var(--violet); padding: 7px 0; cursor: pointer; font: inherit; font-size: 12.5px;
+}
+.mi-audit:hover { border-color: var(--violet); }

--- a/thymos/clients/desktop/src/viz.js
+++ b/thymos/clients/desktop/src/viz.js
@@ -114,39 +114,30 @@ function init() {
   camera.position.set(0, 0, 13);
   glowTex = radialTexture("rgba(124,92,255,0.9)");
 
-  // Starfield.
-  const N = 1100, pos = new Float32Array(N * 3);
-  for (let i = 0; i < N * 3; i++) pos[i] = (Math.random() - 0.5) * 130;
-  const starGeo = new THREE.BufferGeometry();
-  starGeo.setAttribute("position", new THREE.BufferAttribute(pos, 3));
-  scene.add(new THREE.Points(starGeo,
-    new THREE.PointsMaterial({ color: 0x6a5fd0, size: 0.13, transparent: true, opacity: 0.75 })));
-
   // World group (orbited by drag + slow auto-rotation): cage + nodes.
+  // Observability over ornament: no starfield, a single faint cage, a small
+  // core mark — the runtime data is the visual.
   world = new THREE.Group();
   scene.add(world);
 
   cage = new THREE.Group();
   world.add(cage);
   cage.add(new THREE.LineSegments(
-    new THREE.WireframeGeometry(new THREE.IcosahedronGeometry(3.0, 0)),
-    new THREE.LineBasicMaterial({ color: VIOLET, transparent: true, opacity: 0.6 })));
-  cage.add(new THREE.LineSegments(
-    new THREE.WireframeGeometry(new THREE.DodecahedronGeometry(4.2, 0)),
-    new THREE.LineBasicMaterial({ color: CYAN, transparent: true, opacity: 0.28 })));
+    new THREE.WireframeGeometry(new THREE.IcosahedronGeometry(2.2, 0)),
+    new THREE.LineBasicMaterial({ color: VIOLET, transparent: true, opacity: 0.22 })));
 
   nodesGroup = new THREE.Group();
   world.add(nodesGroup);
 
-  // Logo suspended in the cage — a sprite so it always faces the camera.
+  // Small core mark — the run itself; context nodes tether to it.
   const tex = new THREE.TextureLoader().load("logo.png");
   if ("colorSpace" in tex) tex.colorSpace = THREE.SRGBColorSpace;
-  const logo = new THREE.Sprite(new THREE.SpriteMaterial({ map: tex, transparent: true }));
-  logo.scale.set(2.6, 2.6, 1);
+  const logo = new THREE.Sprite(new THREE.SpriteMaterial({ map: tex, transparent: true, opacity: 0.9 }));
+  logo.scale.set(1.6, 1.6, 1);
   scene.add(logo);
   const glow = new THREE.Sprite(new THREE.SpriteMaterial(
-    { map: glowTex, color: VIOLET, transparent: true, blending: THREE.AdditiveBlending, opacity: 0.85 }));
-  glow.scale.set(8, 8, 1);
+    { map: glowTex, color: VIOLET, transparent: true, blending: THREE.AdditiveBlending, opacity: 0.5 }));
+  glow.scale.set(4.5, 4.5, 1);
   scene.add(glow);
 
   // Interaction: drag to orbit, wheel to zoom, click a node to inspect it.
@@ -258,8 +249,12 @@ function inspectNode(nd) {
     (nd.title ? `<div class="mi-title">${escHtml(nd.title)}</div>` : "") +
     `<div class="mi-sum">${escHtml(nd.sum || t.sum)}</div>` +
     `<dl class="mi-fields">${rows.join("")}</dl>` +
-    (detail ? `<pre class="mi-detail">${escHtml(detail).slice(0, 1200)}</pre>` : "");
+    (detail ? `<pre class="mi-detail">${escHtml(detail).slice(0, 1200)}</pre>` : "") +
+    (nd.run ? `<button class="mi-audit" type="button">Open in Audit →</button>` : "");
   box.querySelector(".mi-close").onclick = () => { box.hidden = true; };
+  // Cross-link to the Audit narrative for this run (main.js exposes the hook).
+  const a = box.querySelector(".mi-audit");
+  if (a) a.onclick = () => { window.thymosOpenAudit?.(nd.run); };
 }
 
 let tipEl = null;
@@ -310,16 +305,34 @@ function line(a, b, color, opacity) {
 function buildGraph(timeline, ctx, newFromIdx) {
   clearNodes();
 
-  // ---- lifecycle helix ----
+  // ---- lifecycle lanes: one row per step, events flowing left → right ----
+  // This is the runtime map: Intent → Proposal → (Grant/Rejected) →
+  // Execution → Commit reads as a horizontal path; steps stack downward.
   const visible = timeline.filter((nd) => filters[nd.type] !== false);
-  const n = visible.length || 1;
-  const R = 5.4, step = Math.min(0.6, 9 / n);
+  // Assign each event to its step's lane (system/preamble entries stick to
+  // the lane in progress).
+  let lane = 0;
+  const lanes = [];
+  visible.forEach((nd) => {
+    if (nd.step != null) lane = nd.step;
+    nd._lane = lane;
+    (lanes[lane] = lanes[lane] || []).push(nd);
+  });
+  const laneIds = lanes.map((l, i) => l ? i : -1).filter((i) => i >= 0);
+  const laneCount = laneIds.length || 1;
+  const rowGap = Math.min(1.9, 11 / laneCount);
   const pts = [];
-  visible.forEach((nd, i) => {
-    const a = i * 0.7;
-    const p = new THREE.Vector3(Math.cos(a) * R, (i - (n - 1) / 2) * step, Math.sin(a) * R);
+  const meshAt = new Map(); // timeline order → mesh position for chain/edges
+  visible.forEach((nd) => {
+    const row = laneIds.indexOf(nd._lane);
+    const mates = lanes[nd._lane];
+    const col = mates.indexOf(nd);
+    const x = (col - (mates.length - 1) / 2) * 1.55;
+    const y = ((laneCount - 1) / 2 - row) * rowGap;
+    const p = new THREE.Vector3(x, y, 0);
     pts.push(p);
-    const mesh = makeNodeMesh(nd, p, nd.type === "commit" || nd.type === "error" ? 0.2 : 0.16);
+    const mesh = makeNodeMesh(nd, p, nd.type === "commit" || nd.type === "error" || nd.type === "rejected" ? 0.2 : 0.15);
+    meshAt.set(nd, p);
     if (nd.idx != null && newFromIdx != null && nd.idx >= newFromIdx) {
       mesh.scale.set(0.01, 0.01, 0.01);
       spawnQueue.push({ mesh, t0: clock });


### PR DESCRIPTION
All four items from the UX feedback, in order: (1) Audit opens with the run's live narrative — retries, grants, rejections, executions, errors, with plain-English hints — above the authoritative ledger chain; (2) a new ⚙ Advanced tab consolidates the Advanced Mode toggle, model override, live runtime/provider/authority/ledger inspection (real state only, no placeholders); (3) Mind drops the decorative starfield and renders lifecycle lanes (one row per step, Intent → Proposal → Rejected/Grant → Execution → Commit left-to-right) with an 'Open in Audit' cross-link per node; (4) Config/Ledger discoverability lands inside Advanced. Versions bumped to 0.7.3 for the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)