### PR TITLE
Mind always-on: follow current chat, Answer nodes (v0.7.4)

### DIFF
--- a/thymos/Cargo.lock
+++ b/thymos/Cargo.lock
@@ -2699,7 +2699,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-cli"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "axum 0.8.9",
  "clap",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-client"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "axum-test",
  "reqwest",
@@ -2733,7 +2733,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-cognition"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -2747,7 +2747,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-compiler"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -2758,7 +2758,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-core"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "blake3",
  "ed25519-dalek",
@@ -2771,7 +2771,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-ledger"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "blake3",
  "deadpool-postgres",
@@ -2787,7 +2787,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-marketplace"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "blake3",
  "hex",
@@ -2800,7 +2800,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-policy"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -2809,7 +2809,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-runtime"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "serde",
@@ -2826,7 +2826,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-server"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2859,7 +2859,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-tools"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "blake3",
  "reqwest",
@@ -2872,7 +2872,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-worker"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "serde_json",
  "thymos-tools",

--- a/thymos/Cargo.toml
+++ b/thymos/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.3"
+version = "0.7.4"
 edition = "2021"
 license = "Apache-2.0"
 rust-version = "1.80"

--- a/thymos/clients/desktop/package-lock.json
+++ b/thymos/clients/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thymos-desktop",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thymos-desktop",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "devDependencies": {
         "@tauri-apps/cli": "^2"
       }

--- a/thymos/clients/desktop/package.json
+++ b/thymos/clients/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thymos-desktop",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "private": true,
   "description": "OpenThymos Desktop — governed-cognition runtime, install once.",
   "scripts": {

--- a/thymos/clients/desktop/src-tauri/Cargo.lock
+++ b/thymos/clients/desktop/src-tauri/Cargo.lock
@@ -3288,7 +3288,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-desktop"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "serde",
  "serde_json",

--- a/thymos/clients/desktop/src-tauri/Cargo.toml
+++ b/thymos/clients/desktop/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "thymos-desktop"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2021"
 license = "Apache-2.0"
 description = "OpenThymos Desktop — a governed-cognition client that supervises a local runtime."

--- a/thymos/clients/desktop/src-tauri/tauri.conf.json
+++ b/thymos/clients/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenThymos",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "identifier": "com.openthymos.desktop",
   "build": {
     "frontendDist": "../src"

--- a/thymos/clients/desktop/src/index.html
+++ b/thymos/clients/desktop/src/index.html
@@ -103,9 +103,8 @@
         <div class="panel-head">
           <h2>Mind — reasoning in 3D</h2>
           <div class="mind-controls">
-            <input id="mindRunId" placeholder="run id (blank = current chat)" />
+            <input id="mindRunId" placeholder="following current chat — enter a run id to pin" />
             <input id="mindSearch" placeholder="search nodes…" />
-            <button id="mindLoad" class="ghost">Visualize</button>
           </div>
         </div>
         <p class="tab-intro">
@@ -129,6 +128,7 @@
           <button type="button" class="lg orange" data-type="rejected">⊘ rejected</button>
           <button type="button" class="lg blue" data-type="execution">▣ execution</button>
           <button type="button" class="lg green" data-type="commit">✓ commit</button>
+          <button type="button" class="lg lavender" data-type="answer">✎ answer</button>
           <button type="button" class="lg red" data-type="error">✕ error</button>
           <button type="button" class="lg dim off" data-type="system">· system</button>
         </div>

--- a/thymos/clients/desktop/src/styles.css
+++ b/thymos/clients/desktop/src/styles.css
@@ -473,3 +473,4 @@ body.advanced .adv-only { display: revert; }
   color: var(--violet); padding: 7px 0; cursor: pointer; font: inherit; font-size: 12.5px;
 }
 .mi-audit:hover { border-color: var(--violet); }
+.lg.lavender { color: #d9bcff; }

--- a/thymos/clients/desktop/src/viz.js
+++ b/thymos/clients/desktop/src/viz.js
@@ -22,6 +22,7 @@ const TYPES = {
   proposal:  { color: VIOLET, label: "Proposal",   sum: "Compiler + policy checks resolved authority, budget, and risk." },
   grant:     { color: AMBER,  label: "Grant",      sum: "Suspended — waiting for (or resolved by) an operator approval." },
   rejected:  { color: ORANGE, label: "Rejected",   sum: "The runtime refused this proposal — authority or policy said no. Governed, not broken: grant the tool (or change policy) and retry." },
+  answer:    { color: 0xd9bcff, label: "Answer",   sum: "The model's final reply for this run, recorded once the governed loop finished." },
   execution: { color: BLUE,   label: "Execution",  sum: "The runtime executed a governed tool contract." },
   commit:    { color: GREEN,  label: "Commit",     sum: "An authorized action mutated world state — appended to the ledger." },
   error:     { color: RED,    label: "Error",      sum: "Something failed here. The raw detail is preserved below." },
@@ -73,7 +74,10 @@ let spawnQueue = [];           // meshes animating in
 let activeMesh = null;         // newest lifecycle node while the run is live
 let runStatus = "";            // running | waiting_approval | completed | failed
 let searchQ = "";
-const filters = { intent: true, proposal: true, grant: true, rejected: true, execution: true, commit: true, error: true, system: false };
+const filters = { intent: true, proposal: true, grant: true, rejected: true, execution: true, commit: true, answer: true, error: true, system: false };
+// When the operator types a run id, Mind pins to it; otherwise it follows
+// whatever the chat is currently doing.
+let pinnedRun = false;
 
 function radialTexture(inner) {
   const c = document.createElement("canvas");
@@ -453,10 +457,27 @@ async function loadRun(idRaw) {
         seq: en.seq, id: en.commit_id || en.id, run: id, color: 0,
       }));
     }
+    runStatus = snap?.status || "";
+
+    // The model's reply is part of the story — give it a node, so a plain
+    // chat (no tools) is more than "step 1": Intent → … → Answer.
+    if (snap?.final_answer && ["completed", "failed", "cancelled"].includes(runStatus)) {
+      const lastIdx = timeline.length ? (timeline[timeline.length - 1].idx ?? 0) : 0;
+      const lastStep = [...timeline].reverse().find((n) => n.step != null)?.step ?? null;
+      timeline.push({
+        idx: lastIdx + 1,
+        type: runStatus === "completed" ? "answer" : "error",
+        title: runStatus === "completed" ? "Answer" : "Run " + runStatus,
+        detail: snap.final_answer,
+        time: snap.updated_at_ms,
+        step: lastStep,
+        run: id,
+        color: 0,
+      });
+    }
+
     timeline = timeline.slice(-MAX_TIMELINE);
     timeline.forEach((nd) => { nd.color = (TYPES[nd.type] || TYPES.system).color; });
-
-    runStatus = snap?.status || "";
 
     // Context: provider/mode, the tools this run actually used, replay verdict.
     let health = null, replay = null;
@@ -573,11 +594,18 @@ function frame() {
 }
 function start() {
   if (!running) { running = true; frame(); }
-  // Live growth: while visible, re-poll the current run so streamed entries
-  // appear in the graph. Cleared on stop to avoid background work.
+  // Always-on: while visible, follow the chat's current run (switching when a
+  // new message starts a new run), unless the operator pinned a run id.
   if (!refreshTimer) {
     refreshTimer = setInterval(() => {
-      if (currentRunId) loadRun(currentRunId);
+      const live = window.thymosActiveRun;
+      if (!pinnedRun && live && live !== currentRunId) {
+        loadRun(live);
+      } else if (currentRunId) {
+        loadRun(currentRunId);
+      } else {
+        loadRun("");
+      }
     }, 1500);
   }
 }
@@ -598,8 +626,14 @@ window.addEventListener("DOMContentLoaded", () => {
   });
   document.querySelectorAll('.tab:not([data-tab="mind"])').forEach((t) =>
     t.addEventListener("click", stop));
-  document.getElementById("mindLoad")?.addEventListener("click", () =>
-    loadRun(document.getElementById("mindRunId")?.value));
+  // No "Visualize" button — Mind is always on. Typing a run id pins to it;
+  // clearing the field resumes following the current chat.
+  const runInput = document.getElementById("mindRunId");
+  runInput?.addEventListener("change", () => {
+    const v = runInput.value.trim();
+    pinnedRun = !!v;
+    loadRun(v);
+  });
 
   // Legend doubles as a filter bar — click a type to hide/show it.
   document.querySelectorAll(".mind-legend .lg[data-type]").forEach((b) => {


### PR DESCRIPTION
Removes the Visualize button — Mind follows the current chat's run live (run-id input pins instead), and every completed run now ends in an ✎ Answer node carrying the model's full reply (failures end in an explanatory error node), so plain chats are no longer a lone 'step 1'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)