### PR TITLE
Authority modes: Auto / Edit / Plan / Custom (v0.7.5)

### DIFF
--- a/thymos/Cargo.lock
+++ b/thymos/Cargo.lock
@@ -2699,7 +2699,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-cli"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "axum 0.8.9",
  "clap",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-client"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "axum-test",
  "reqwest",
@@ -2733,7 +2733,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-cognition"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -2747,7 +2747,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-compiler"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -2758,7 +2758,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-core"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "blake3",
  "ed25519-dalek",
@@ -2771,7 +2771,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-ledger"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "blake3",
  "deadpool-postgres",
@@ -2787,7 +2787,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-marketplace"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "blake3",
  "hex",
@@ -2800,7 +2800,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-policy"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -2809,7 +2809,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-runtime"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "serde",
@@ -2826,7 +2826,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-server"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2859,7 +2859,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-tools"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "blake3",
  "reqwest",
@@ -2872,7 +2872,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-worker"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "serde_json",
  "thymos-tools",

--- a/thymos/Cargo.toml
+++ b/thymos/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.4"
+version = "0.7.5"
 edition = "2021"
 license = "Apache-2.0"
 rust-version = "1.80"

--- a/thymos/clients/desktop/package-lock.json
+++ b/thymos/clients/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thymos-desktop",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thymos-desktop",
-      "version": "0.7.4",
+      "version": "0.7.5",
       "devDependencies": {
         "@tauri-apps/cli": "^2"
       }

--- a/thymos/clients/desktop/package.json
+++ b/thymos/clients/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thymos-desktop",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "private": true,
   "description": "OpenThymos Desktop — governed-cognition runtime, install once.",
   "scripts": {

--- a/thymos/clients/desktop/src-tauri/Cargo.lock
+++ b/thymos/clients/desktop/src-tauri/Cargo.lock
@@ -3288,7 +3288,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-desktop"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "serde",
  "serde_json",

--- a/thymos/clients/desktop/src-tauri/Cargo.toml
+++ b/thymos/clients/desktop/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "thymos-desktop"
-version = "0.7.4"
+version = "0.7.5"
 edition = "2021"
 license = "Apache-2.0"
 description = "OpenThymos Desktop — a governed-cognition client that supervises a local runtime."

--- a/thymos/clients/desktop/src-tauri/tauri.conf.json
+++ b/thymos/clients/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenThymos",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "identifier": "com.openthymos.desktop",
   "build": {
     "frontendDist": "../src"

--- a/thymos/clients/desktop/src/index.html
+++ b/thymos/clients/desktop/src/index.html
@@ -58,6 +58,19 @@
               <!-- Active skill chips — appear only when in use, keeping the
                    rail clean. The per-chat model override lives in Advanced. -->
               <div id="skillChips" class="skill-chips" title="Active skills — combine any; they only narrow authority."></div>
+              <!-- Authority mode: how much the agent may do. Maps to real writ
+                   scopes derived from each tool's effect class. Dangerous
+                   (high-risk) tools always pause for approval regardless. -->
+              <div class="mode-row" id="modeRow">
+                <button type="button" class="mode-chip" data-mode="auto"
+                  title="Everything granted. Dangerous tools (shell, http) still pause and ask you first.">Auto</button>
+                <button type="button" class="mode-chip" data-mode="edit"
+                  title="Read + local edits: inspect files, apply patches, run tests, keep memory. No shell/network.">Edit</button>
+                <button type="button" class="mode-chip" data-mode="plan"
+                  title="Read-only: inspect, search, map the repo. Proposes changes but cannot make them.">Plan</button>
+                <button type="button" class="mode-chip" data-mode="custom"
+                  title="Pick exact tools with the grant chips below.">Custom</button>
+              </div>
               <div class="grants" id="grants" title="What this chat is allowed to do — the writ scope. The runtime rejects anything not granted. No selection = everything granted.">
                 <span class="grant-label">grant</span>
                 <!-- Chips are built from the live tool registry once the

--- a/thymos/clients/desktop/src/main.js
+++ b/thymos/clients/desktop/src/main.js
@@ -88,11 +88,12 @@ async function loadAdvanced() {
   // Authority card: what new chats are allowed to do, right now.
   const au = $("advAuthority");
   if (au) {
-    const scopes = selectedScopes();
+    const scopes = effectiveScopes();
     const skills = selectedSkills();
     au.innerHTML =
       `<div class="state-grid">` +
-      `<span class="dim">grants</span><span>${scopes.length ? scopes.map(escapeHtml).join(" · ") : "everything (no chips selected)"}</span>` +
+      `<span class="dim">mode</span><span>${escapeHtml(currentMode())}</span>` +
+      `<span class="dim">grants</span><span>${scopes.length ? scopes.map(escapeHtml).join(" · ") : "everything"}</span>` +
       `<span class="dim">active skills</span><span>${skills.length ? skills.map(escapeHtml).join(" · ") : "none"}</span>` +
       `<span class="dim">risk gate</span><span>high-risk tools pause for approval</span>` +
       `</div>`;
@@ -198,7 +199,7 @@ function governanceHint(e) {
   const raw = e.detail || "";
   if (/AuthorityVoid/.test(raw)) {
     const tool = ((e.title || "").match(/for (\S+)/) || [])[1] || "that tool";
-    return `${tool} isn't granted for this chat. The runtime blocked it (nothing is broken) — toggle its grant chip in the left rail and ask again.`;
+    return `${tool} isn't allowed in ${currentMode()} mode. The runtime blocked it (nothing is broken) — switch the mode in the left rail (Auto allows everything; dangerous tools still ask first) and try again.`;
   }
   if (/PolicyDenied/.test(raw)) {
     return "policy denied this action — the decision is recorded in the run's audit trail.";
@@ -244,6 +245,50 @@ function savedScopes() {
   try { const a = JSON.parse(localStorage.getItem(GRANTS_KEY) || "null"); return Array.isArray(a) ? a : null; }
   catch (_) { return null; }
 }
+
+/* ---------- authority modes (Auto / Edit / Plan / Custom) ---------- */
+// The standard AI-tool posture, mapped onto real writ scopes: each mode is a
+// set of tools derived from the live registry's effect classes. Auto grants
+// everything (the risk gate still pauses dangerous tools for approval).
+const MODE_KEY = "thymos.authmode.v1";
+let toolsCache = []; // [{name, effect_class}] from the live registry
+// Offline fallbacks so modes work before the registry loads.
+const FALLBACK_READ = ["fs_read", "grep", "list_files", "repo_map", "kv_get", "memory_recall"];
+const FALLBACK_WRITE = ["fs_patch", "test_run", "kv_set", "memory_store"];
+function currentMode() {
+  try { return localStorage.getItem(MODE_KEY) || "auto"; } catch (_) { return "auto"; }
+}
+function setMode(m) {
+  try { localStorage.setItem(MODE_KEY, m); } catch (_) {}
+  renderModeUI();
+}
+function toolsByEffect(effects) {
+  if (!toolsCache.length) {
+    return effects.includes("write") ? FALLBACK_READ.concat(FALLBACK_WRITE) : FALLBACK_READ;
+  }
+  return toolsCache
+    .filter((t) => effects.includes(String(t.effect_class || "").toLowerCase()))
+    .map((t) => t.name);
+}
+// The writ scopes a new chat message will request, given the active mode.
+// Empty array = the server grants `*` (everything).
+function effectiveScopes() {
+  switch (currentMode()) {
+    case "auto": return [];
+    case "plan": return toolsByEffect(["read"]);
+    case "edit": return toolsByEffect(["read", "write"]);
+    default: return selectedScopes(); // custom = the chips
+  }
+}
+function renderModeUI() {
+  const m = currentMode();
+  document.querySelectorAll("#modeRow .mode-chip").forEach((b) =>
+    b.classList.toggle("on", b.dataset.mode === m));
+  const grants = $("grants");
+  if (grants) grants.hidden = m !== "custom";
+}
+document.querySelectorAll("#modeRow .mode-chip").forEach((b) =>
+  b.addEventListener("click", () => setMode(b.dataset.mode)));
 // Rebuild the grant chips from the LIVE tool registry, so every registered
 // tool is grantable — the static HTML chips are only an offline fallback.
 // (Previously the chips were a hardcoded subset: tools like repo_map existed
@@ -268,10 +313,10 @@ function renderGrantChips(names) {
     wrap.appendChild(b);
   });
 }
-// Does the current grant selection authorize a tool? Empty selection means
+// Does the current authority mode authorize a tool? Empty scope list means
 // the server grants `*` (everything) — mirror the writ's prefix-glob match.
 function scopeAuthorizes(name) {
-  const scopes = selectedScopes();
+  const scopes = effectiveScopes();
   if (!scopes.length) return true;
   return scopes.some((s) =>
     s.endsWith("*") ? name.startsWith(s.slice(0, -1)) : name === s);
@@ -525,9 +570,9 @@ async function startRun(task) {
   if (!task || activeRunId) return;
   const welcome = feed.querySelector(".welcome");
   if (welcome) welcome.remove();
-  // Authority comes from the active skills + grants in the left rail.
+  // Authority comes from the active skills + the authority mode (left rail).
   const skills = selectedSkills();
-  const scopes = selectedScopes();
+  const scopes = effectiveScopes();
   lastTask = task;
   pushBubble(task);
   addMessage("user", task);
@@ -873,7 +918,8 @@ async function loadTools() {
     const tools = res.tools || (Array.isArray(res) ? res : []);
     el.innerHTML = "";
     if (!tools.length) { el.innerHTML = "<div class='hint'>no tools registered</div>"; return; }
-    // Keep the grant chips in sync with the real registry.
+    // Keep the grant chips + mode→scope mapping in sync with the registry.
+    toolsCache = tools.map((t) => ({ name: t.name, effect_class: t.effect_class }));
     renderGrantChips(tools.map((t) => t.name).filter(Boolean));
     tools
       .sort((a, b) => (EFFECT_RANK[a.effect_class] ?? 0) - (EFFECT_RANK[b.effect_class] ?? 0))
@@ -1262,10 +1308,15 @@ function escapeHtml(s) {
   restoreDefaults();
   if (chats.length) openChat(chats[0].id); else newChatSession(false);
   loadSkills().catch(() => {}); // fills the skill chips + restores the active set
-  // Grant chips come from the live registry (every registered tool grantable).
+  // Grant chips + mode→scope mapping come from the live registry.
   getJSON("/tools")
-    .then((r) => renderGrantChips((r.tools || []).map((t) => t.name).filter(Boolean)))
+    .then((r) => {
+      const tools = r.tools || [];
+      toolsCache = tools.map((t) => ({ name: t.name, effect_class: t.effect_class }));
+      renderGrantChips(tools.map((t) => t.name).filter(Boolean));
+    })
     .catch(() => {}); // offline: the static fallback chips stay
+  renderModeUI();
   // Seed the model menu from the configured provider so chat/skill Model fields
   // suggest real models from the start (Discover replaces with the live list).
   if (invoke) {

--- a/thymos/clients/desktop/src/styles.css
+++ b/thymos/clients/desktop/src/styles.css
@@ -474,3 +474,15 @@ body.advanced .adv-only { display: revert; }
 }
 .mi-audit:hover { border-color: var(--violet); }
 .lg.lavender { color: #d9bcff; }
+
+/* Authority mode selector — the standard AI-tool posture (Auto/Edit/Plan/Custom) */
+.mode-row { display: flex; gap: 6px; margin-bottom: 8px; }
+.mode-chip {
+  flex: 1; padding: 6px 0; font: inherit; font-size: 12.5px; font-weight: 600;
+  background: none; border: 1px solid var(--line); border-radius: 8px;
+  color: var(--muted); cursor: pointer;
+}
+.mode-chip:hover { border-color: var(--violet); color: var(--text); }
+.mode-chip.on {
+  background: rgba(124,92,255,.16); border-color: var(--violet); color: var(--text);
+}


### PR DESCRIPTION
Replaces per-tool chips as the primary authority control with standard AI-tool modes mapped to real writ scopes derived from live effect classes. Auto (default) grants everything with the risk gate still pausing dangerous tools; Edit = read+local writes; Plan = read-only; Custom keeps the chips. Fixes the 'agent feels shallow' default where saved chips silently limited runs to fs_read+grep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)