### PR TITLE
Recover Groq tool_use_failed as plain text (v0.7.6)

### DIFF
--- a/thymos/Cargo.lock
+++ b/thymos/Cargo.lock
@@ -2699,7 +2699,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-cli"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "axum 0.8.9",
  "clap",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-client"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "axum-test",
  "reqwest",
@@ -2733,7 +2733,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-cognition"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -2747,7 +2747,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-compiler"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -2758,7 +2758,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-core"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "blake3",
  "ed25519-dalek",
@@ -2771,7 +2771,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-ledger"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "blake3",
  "deadpool-postgres",
@@ -2787,7 +2787,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-marketplace"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "blake3",
  "hex",
@@ -2800,7 +2800,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-policy"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -2809,7 +2809,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-runtime"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "anyhow",
  "serde",
@@ -2826,7 +2826,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-server"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2859,7 +2859,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-tools"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "blake3",
  "reqwest",
@@ -2872,7 +2872,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-worker"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "serde_json",
  "thymos-tools",

--- a/thymos/Cargo.toml
+++ b/thymos/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.5"
+version = "0.7.6"
 edition = "2021"
 license = "Apache-2.0"
 rust-version = "1.80"

--- a/thymos/clients/desktop/package-lock.json
+++ b/thymos/clients/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thymos-desktop",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thymos-desktop",
-      "version": "0.7.5",
+      "version": "0.7.6",
       "devDependencies": {
         "@tauri-apps/cli": "^2"
       }

--- a/thymos/clients/desktop/package.json
+++ b/thymos/clients/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thymos-desktop",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "private": true,
   "description": "OpenThymos Desktop — governed-cognition runtime, install once.",
   "scripts": {

--- a/thymos/clients/desktop/src-tauri/Cargo.lock
+++ b/thymos/clients/desktop/src-tauri/Cargo.lock
@@ -3288,7 +3288,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-desktop"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "serde",
  "serde_json",

--- a/thymos/clients/desktop/src-tauri/Cargo.toml
+++ b/thymos/clients/desktop/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "thymos-desktop"
-version = "0.7.5"
+version = "0.7.6"
 edition = "2021"
 license = "Apache-2.0"
 description = "OpenThymos Desktop — a governed-cognition client that supervises a local runtime."

--- a/thymos/clients/desktop/src-tauri/tauri.conf.json
+++ b/thymos/clients/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenThymos",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "identifier": "com.openthymos.desktop",
   "build": {
     "frontendDist": "../src"

--- a/thymos/crates/thymos-cognition/src/openai.rs
+++ b/thymos/crates/thymos-cognition/src/openai.rs
@@ -230,6 +230,28 @@ impl Cognition for OpenAiCognition {
             .json()
             .map_err(|e| Error::Other(format!("openai response parse: {e}")))?;
         if !status.is_success() {
+            // Groq's `tool_use_failed`: the model emitted a malformed tool
+            // call and the API rejected the whole generation with a 400 —
+            // but the text the model was trying to produce is preserved in
+            // `error.failed_generation`. Recover it as a plain assistant
+            // turn instead of failing the run: no tool executes (a call that
+            // can't parse never reaches the runtime), the model just "spoke".
+            if status.as_u16() == 400 {
+                if let Some(failed) = resp_json
+                    .pointer("/error/failed_generation")
+                    .and_then(|v| v.as_str())
+                    .filter(|s| !s.trim().is_empty())
+                {
+                    let text = failed.to_string();
+                    self.messages
+                        .push(json!({ "role": "assistant", "content": text }));
+                    return Ok(CognitionStep {
+                        intents: vec![],
+                        final_answer: Some(text),
+                        usage: crate::CognitionUsage::default(),
+                    });
+                }
+            }
             // Prefer the standard header; fall back to providers that put the
             // precise wait only in the JSON body ("Please try again in 9.62s").
             let hint_ms = retry_after_header

--- a/thymos/crates/thymos-runtime/src/agent_async.rs
+++ b/thymos/crates/thymos-runtime/src/agent_async.rs
@@ -42,7 +42,9 @@ fn parse_retry_after_hint(msg: &str) -> Option<u64> {
 /// some providers, embed request context). Unknown errors get a generic line.
 pub fn humanize_provider_error(msg: &str) -> String {
     let m = msg.to_lowercase();
-    if m.contains("429") || m.contains("rate limit") {
+    if m.contains("tool_use_failed") {
+        "The model fumbled a tool call (a provider-side formatting failure). Just ask again — smaller steps help, or switch models in Providers.".to_string()
+    } else if m.contains("429") || m.contains("rate limit") {
         "The provider is rate-limiting requests right now (token budget).".to_string()
     } else if m.contains("401") || m.contains("invalid api key") || m.contains("unauthorized") {
         "The provider rejected the API key. Check it in Settings.".to_string()


### PR DESCRIPTION
Groq 400/tool_use_failed preserves the model's intended text in error.failed_generation; the adapter now recovers it as a plain assistant turn instead of failing the run (no tool executes — an unparseable call never reaches the runtime). Humanized fallback included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)