### PR TITLE
Multi-turn chat memory (v0.7.8)

### DIFF
--- a/thymos/Cargo.lock
+++ b/thymos/Cargo.lock
@@ -2699,7 +2699,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-cli"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "axum 0.8.9",
  "clap",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-client"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "axum-test",
  "reqwest",
@@ -2733,7 +2733,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-cognition"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -2747,7 +2747,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-compiler"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "serde",
  "serde_json",
@@ -2758,7 +2758,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-core"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "blake3",
  "ed25519-dalek",
@@ -2771,7 +2771,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-ledger"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "blake3",
  "deadpool-postgres",
@@ -2787,7 +2787,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-marketplace"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "blake3",
  "hex",
@@ -2800,7 +2800,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-policy"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "serde",
  "serde_json",
@@ -2809,7 +2809,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-runtime"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "anyhow",
  "serde",
@@ -2826,7 +2826,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-server"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2859,7 +2859,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-tools"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "blake3",
  "reqwest",
@@ -2872,7 +2872,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-worker"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "serde_json",
  "thymos-tools",

--- a/thymos/Cargo.toml
+++ b/thymos/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.7"
+version = "0.7.8"
 edition = "2021"
 license = "Apache-2.0"
 rust-version = "1.80"

--- a/thymos/clients/desktop/package-lock.json
+++ b/thymos/clients/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thymos-desktop",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thymos-desktop",
-      "version": "0.7.7",
+      "version": "0.7.8",
       "devDependencies": {
         "@tauri-apps/cli": "^2"
       }

--- a/thymos/clients/desktop/package.json
+++ b/thymos/clients/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thymos-desktop",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "private": true,
   "description": "OpenThymos Desktop — governed-cognition runtime, install once.",
   "scripts": {

--- a/thymos/clients/desktop/src-tauri/Cargo.lock
+++ b/thymos/clients/desktop/src-tauri/Cargo.lock
@@ -3288,7 +3288,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-desktop"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "serde",
  "serde_json",

--- a/thymos/clients/desktop/src-tauri/Cargo.toml
+++ b/thymos/clients/desktop/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "thymos-desktop"
-version = "0.7.7"
+version = "0.7.8"
 edition = "2021"
 license = "Apache-2.0"
 description = "OpenThymos Desktop — a governed-cognition client that supervises a local runtime."

--- a/thymos/clients/desktop/src-tauri/tauri.conf.json
+++ b/thymos/clients/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenThymos",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "identifier": "com.openthymos.desktop",
   "build": {
     "frontendDist": "../src"

--- a/thymos/clients/desktop/src/main.js
+++ b/thymos/clients/desktop/src/main.js
@@ -583,6 +583,18 @@ async function startRun(task) {
     if (scopes.length) body.tool_scopes = scopes;
     const model = $("chatModel")?.value.trim();
     if (model) body.model = model; // per-chat model override (else server default)
+    // Multi-turn memory: send this chat's recent transcript (minus the
+    // message we just appended) so the model can follow the conversation.
+    // The server caps and composes it; each run stays its own trajectory.
+    const hist = (curChat()?.messages || [])
+      .slice(0, -1)
+      .filter((m) => m.role === "user" || m.role === "agent")
+      .slice(-12)
+      .map((m) => ({
+        role: m.role === "agent" ? "assistant" : "user",
+        text: String(m.text || "").slice(0, 1500),
+      }));
+    if (hist.length) body.history = hist;
     const { run_id } = await postJSON("/runs", body);
     activeRunId = run_id;
     window.thymosActiveRun = run_id; // Mind opens on the chat's current run

--- a/thymos/crates/thymos-server/src/lib.rs
+++ b/thymos/crates/thymos-server/src/lib.rs
@@ -457,6 +457,63 @@ pub struct CreateRunRequest {
     /// server's configured ones.
     #[serde(default)]
     pub model: Option<String>,
+    /// Prior conversation turns for multi-turn chat. Composed (size-capped,
+    /// newest kept) into the agent's task context so the model can follow the
+    /// conversation; the run record itself keeps only `task`. Each run remains
+    /// its own governed trajectory — context never carries authority.
+    #[serde(default)]
+    pub history: Vec<HistoryTurn>,
+}
+
+#[derive(Clone, Deserialize)]
+pub struct HistoryTurn {
+    /// "user" or "assistant" (anything unrecognized is treated as "user").
+    pub role: String,
+    pub text: String,
+}
+
+/// Caps for composed conversation context: keep the newest turns, drop the
+/// oldest once over budget, clip any single turn. Bounds prompt size no matter
+/// what a client sends.
+pub const MAX_HISTORY_TURNS: usize = 24;
+pub const MAX_HISTORY_TURN_CHARS: usize = 1_500;
+pub const MAX_HISTORY_CHARS: usize = 8_000;
+
+/// Compose the agent-facing task: prior conversation (newest-biased, capped)
+/// followed by the current message. Returns the bare task when there is no
+/// history.
+fn compose_agent_task(task: &str, history: &[HistoryTurn]) -> String {
+    if history.is_empty() {
+        return task.to_string();
+    }
+    let mut turns: Vec<String> = Vec::new();
+    let mut used = 0usize;
+    for t in history.iter().rev().take(MAX_HISTORY_TURNS) {
+        let role = if t.role.eq_ignore_ascii_case("assistant") {
+            "assistant"
+        } else {
+            "user"
+        };
+        let mut text: String = t.text.trim().chars().take(MAX_HISTORY_TURN_CHARS).collect();
+        if t.text.trim().chars().count() > MAX_HISTORY_TURN_CHARS {
+            text.push('…');
+        }
+        let line = format!("{role}: {text}");
+        if used + line.len() > MAX_HISTORY_CHARS {
+            break;
+        }
+        used += line.len();
+        turns.push(line);
+    }
+    if turns.is_empty() {
+        return task.to_string();
+    }
+    turns.reverse();
+    format!(
+        "## Conversation so far (context only — answer the current message)\n{}\n\n## Current message\n{}",
+        turns.join("\n"),
+        task
+    )
 }
 
 fn default_max_steps() -> u32 {
@@ -1648,14 +1705,26 @@ async fn create_run(
 
     let run_id = uuid::Uuid::new_v4().to_string();
     // Prepend every bound skill's instructions, then the task.
+    let instrs: Vec<String> = bound_skills
+        .iter()
+        .map(|s| s.render_instructions(&req.skill_params))
+        .collect();
     let task = if bound_skills.is_empty() {
         req.task.clone()
     } else {
-        let instrs: Vec<String> = bound_skills
-            .iter()
-            .map(|s| s.render_instructions(&req.skill_params))
-            .collect();
         format!("{}\n\n---\nTask: {}", instrs.join("\n\n"), req.task)
+    };
+    // The agent-facing task additionally carries the conversation context
+    // (multi-turn chat). The run record and execution session keep the clean
+    // `task`; the composed version reaches cognition and the trajectory, so
+    // the context the model saw is itself auditable.
+    let convo = compose_agent_task(&req.task, &req.history);
+    let agent_task = if req.history.is_empty() {
+        task.clone()
+    } else if bound_skills.is_empty() {
+        convo
+    } else {
+        format!("{}\n\n---\n{}", instrs.join("\n\n"), convo)
     };
 
     let user_id = if let Some(axum::Extension(claims)) = &jwt_claims {
@@ -1809,6 +1878,7 @@ async fn create_run(
     let state2 = state.clone();
     let run_id2 = run_id.clone();
     let task2 = task.clone();
+    let agent_task2 = agent_task.clone();
     let bound_skills2 = bound_skills.clone();
     // Effective model: per-run override (chat) > a bound skill's preferred model
     // > the server default. Only the model id is swapped — the provider/key are
@@ -1903,7 +1973,7 @@ async fn create_run(
         let agent_fut = thymos_runtime::run_agent_streaming(
             &runtime,
             &mut streaming,
-            &task2,
+            &agent_task2,
             &writ,
             AgentRunOptions {
                 max_steps: req.max_steps,
@@ -2985,6 +3055,50 @@ fn entry_to_dto(e: &thymos_ledger::Entry) -> EntryDto {
         id: e.id.short().to_string(),
         detail,
         commit_id,
+    }
+}
+
+#[cfg(test)]
+mod history_tests {
+    use super::{compose_agent_task, HistoryTurn, MAX_HISTORY_CHARS};
+
+    fn turn(role: &str, text: &str) -> HistoryTurn {
+        HistoryTurn { role: role.into(), text: text.into() }
+    }
+
+    #[test]
+    fn no_history_returns_bare_task() {
+        assert_eq!(compose_agent_task("do x", &[]), "do x");
+    }
+
+    #[test]
+    fn history_composes_in_order_with_current_message_last() {
+        let h = vec![turn("user", "hello"), turn("assistant", "hi there")];
+        let out = compose_agent_task("now do x", &h);
+        let hello = out.find("user: hello").unwrap();
+        let hi = out.find("assistant: hi there").unwrap();
+        let cur = out.find("## Current message\nnow do x").unwrap();
+        assert!(hello < hi && hi < cur);
+    }
+
+    #[test]
+    fn history_is_capped_keeping_newest() {
+        // 40 long turns blow the budget; the newest must survive.
+        let h: Vec<HistoryTurn> = (0..40)
+            .map(|i| turn("user", &format!("turn-{i} {}", "x".repeat(900))))
+            .collect();
+        let out = compose_agent_task("t", &h);
+        assert!(out.len() < MAX_HISTORY_CHARS + 200);
+        assert!(out.contains("turn-39"));
+        assert!(!out.contains("turn-0 "));
+    }
+
+    #[test]
+    fn single_turn_is_clipped_on_char_boundary() {
+        let h = vec![turn("user", &"é".repeat(5_000))];
+        let out = compose_agent_task("t", &h);
+        assert!(out.contains('…'));
+        assert!(out.len() < 10_000);
     }
 }
 


### PR DESCRIPTION
Chat messages stop being amnesiac runs: the desktop sends the chat's recent transcript and the server composes it (capped, newest-kept) into the agent-facing task, while the run record stays clean and each message remains its own governed trajectory — context never carries authority, and the context the model saw is itself in the ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)