### PR TITLE
Out-of-box reliability: runtime version handshake + concrete approvals (v0.7.9)

### DIFF
--- a/thymos/Cargo.lock
+++ b/thymos/Cargo.lock
@@ -2699,7 +2699,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-cli"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "axum 0.8.9",
  "clap",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-client"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "axum-test",
  "reqwest",
@@ -2733,7 +2733,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-cognition"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -2747,7 +2747,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-compiler"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "serde",
  "serde_json",
@@ -2758,7 +2758,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-core"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "blake3",
  "ed25519-dalek",
@@ -2771,7 +2771,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-ledger"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "blake3",
  "deadpool-postgres",
@@ -2787,7 +2787,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-marketplace"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "blake3",
  "hex",
@@ -2800,7 +2800,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-policy"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "serde",
  "serde_json",
@@ -2809,7 +2809,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-runtime"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "anyhow",
  "serde",
@@ -2826,7 +2826,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-server"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2859,7 +2859,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-tools"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "blake3",
  "reqwest",
@@ -2872,7 +2872,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-worker"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "serde_json",
  "thymos-tools",

--- a/thymos/Cargo.toml
+++ b/thymos/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.8"
+version = "0.7.9"
 edition = "2021"
 license = "Apache-2.0"
 rust-version = "1.80"

--- a/thymos/clients/desktop/package-lock.json
+++ b/thymos/clients/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thymos-desktop",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thymos-desktop",
-      "version": "0.7.8",
+      "version": "0.7.9",
       "devDependencies": {
         "@tauri-apps/cli": "^2"
       }

--- a/thymos/clients/desktop/package.json
+++ b/thymos/clients/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thymos-desktop",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "private": true,
   "description": "OpenThymos Desktop — governed-cognition runtime, install once.",
   "scripts": {

--- a/thymos/clients/desktop/src-tauri/Cargo.lock
+++ b/thymos/clients/desktop/src-tauri/Cargo.lock
@@ -3288,7 +3288,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-desktop"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "serde",
  "serde_json",

--- a/thymos/clients/desktop/src-tauri/Cargo.toml
+++ b/thymos/clients/desktop/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "thymos-desktop"
-version = "0.7.8"
+version = "0.7.9"
 edition = "2021"
 license = "Apache-2.0"
 description = "OpenThymos Desktop — a governed-cognition client that supervises a local runtime."

--- a/thymos/clients/desktop/src-tauri/src/lib.rs
+++ b/thymos/clients/desktop/src-tauri/src/lib.rs
@@ -172,21 +172,6 @@ fn start_runtime(app: tauri::AppHandle, state: State<Supervisor>) -> Result<Stri
         }
     }
 
-    // If a Thymos server is already listening on 3001 — one you started in the
-    // terminal, or a prior session — adopt it instead of spawning a conflicting
-    // one. This is what lets the CLI and the desktop share a single runtime +
-    // ledger: whoever owns the port owns the truth, and both surfaces are clients
-    // of it. We only kill servers we ourselves spawned (window-close handler); an
-    // adopted one is left running.
-    if std::net::TcpStream::connect_timeout(
-        &([127, 0, 0, 1], 3001).into(),
-        std::time::Duration::from_millis(300),
-    )
-    .is_ok()
-    {
-        return Ok("adopted-existing".into());
-    }
-
     // Pin a durable, per-user ledger so runs, audit trails, and backups persist
     // across restarts — this is what makes the app a real client of a real,
     // permanent Thymos ledger rather than an ephemeral session. The hash-chained
@@ -198,6 +183,36 @@ fn start_runtime(app: tauri::AppHandle, state: State<Supervisor>) -> Result<Stri
     std::fs::create_dir_all(&data_dir)
         .map_err(|e| format!("create app data dir {}: {e}", data_dir.display()))?;
     let ledger_path = data_dir.join("ledger.db");
+    let pid_file = data_dir.join("runtime.pid");
+
+    // If a Thymos server is already listening on 3001 — one you started in the
+    // terminal, or a prior session — adopt it instead of spawning a conflicting
+    // one, BUT only if it speaks this app's version. After an upgrade, an
+    // orphaned older runtime would otherwise keep answering with old behavior
+    // (this bit real users twice). A version-mismatched server that WE spawned
+    // (its pid is in runtime.pid) is terminated and replaced; one we didn't
+    // spawn is adopted with a warning rather than killed.
+    if std::net::TcpStream::connect_timeout(
+        &([127, 0, 0, 1], 3001).into(),
+        std::time::Duration::from_millis(300),
+    )
+    .is_ok()
+    {
+        let running = runtime_version();
+        if running.as_deref() == Some(env!("CARGO_PKG_VERSION")) {
+            return Ok("adopted-existing".into());
+        }
+        if kill_previous_runtime(&pid_file) {
+            // Freed the port — fall through and spawn the bundled version.
+            std::thread::sleep(std::time::Duration::from_millis(500));
+        } else {
+            return Ok(format!(
+                "adopted-existing (version {} != app {}; not spawned by this app — restart it manually)",
+                running.unwrap_or_else(|| "unknown".into()),
+                env!("CARGO_PKG_VERSION"),
+            ));
+        }
+    }
 
     // User-defined governed tools: the runtime loads JSON manifests from this
     // dir (`ToolManifest`), registering each as a first-class tool bound by its
@@ -213,8 +228,43 @@ fn start_runtime(app: tauri::AppHandle, state: State<Supervisor>) -> Result<Stri
     let child = cmd
         .spawn()
         .map_err(|e| format!("failed to start {}: {e}", bin.display()))?;
+    // Record the child's pid so a future session (e.g. after an app upgrade)
+    // can terminate a stale runtime it finds still holding the port.
+    let _ = std::fs::write(&pid_file, child.id().to_string());
     *guard = Some(child);
     Ok("started".into())
+}
+
+/// Version reported by whatever answers /health on the runtime port, if any.
+fn runtime_version() -> Option<String> {
+    let resp = ureq::get("http://127.0.0.1:3001/health")
+        .timeout(std::time::Duration::from_secs(2))
+        .call()
+        .ok()?;
+    let v: serde_json::Value = resp.into_json().ok()?;
+    v.get("version").and_then(|s| s.as_str()).map(String::from)
+}
+
+/// Terminate the runtime recorded in `runtime.pid` — a process THIS app (a
+/// previous session of it) spawned. Returns true if the pid existed and a
+/// kill was issued. Never touches processes we didn't record.
+fn kill_previous_runtime(pid_file: &std::path::Path) -> bool {
+    let Ok(pid) = std::fs::read_to_string(pid_file).map(|s| s.trim().to_string()) else {
+        return false;
+    };
+    if pid.is_empty() || !pid.chars().all(|c| c.is_ascii_digit()) {
+        return false;
+    }
+    #[cfg(unix)]
+    let ok = Command::new("kill").arg(&pid).status().map(|s| s.success()).unwrap_or(false);
+    #[cfg(windows)]
+    let ok = Command::new("taskkill")
+        .args(["/PID", &pid, "/F"])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    let _ = std::fs::remove_file(pid_file);
+    ok
 }
 
 /// Build the `/models` request for a provider — the host makes this call

--- a/thymos/clients/desktop/src-tauri/tauri.conf.json
+++ b/thymos/clients/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenThymos",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "identifier": "com.openthymos.desktop",
   "build": {
     "frontendDist": "../src"

--- a/thymos/clients/desktop/src/main.js
+++ b/thymos/clients/desktop/src/main.js
@@ -389,7 +389,13 @@ function renderSnapshot(s) {
     const hint = governanceHint(e);
     if (hint) pushLine("sys", `   ↳ ${hint}`);
   });
-  if (s.status === "waiting_approval") showApproval(s.run_id, s.pending_channel);
+  if (s.status === "waiting_approval") {
+    // Show WHAT is being approved: the latest approval request's reason
+    // carries the tool + a compact args preview from the compiler.
+    const req = [...(s.log || [])].reverse()
+      .find((e) => (e.title || "").startsWith("Approval requested"));
+    showApproval(s.run_id, s.pending_channel, req?.detail || "");
+  }
   if (["completed", "failed", "cancelled"].includes(s.status)) {
     if (s.final_answer) {
       pushAnswer(s.status, s.final_answer);
@@ -522,12 +528,18 @@ $("chatStop")?.addEventListener("click", async () => {
   }
 });
 
-function showApproval(runId, channel) {
+function showApproval(runId, channel, why) {
   if (document.querySelector(`.approval-row[data-run="${runId}"]`)) return;
   const row = document.createElement("div");
   row.className = "approval-row";
   row.dataset.run = runId;
   row.innerHTML = `<span class="q">⏸ approval required — channel</span>`;
+  if (why) {
+    const w = document.createElement("div");
+    w.className = "approval-why";
+    w.textContent = String(why).slice(0, 400);
+    row.appendChild(w);
+  }
   const chan = document.createElement("input");
   chan.value = channel || "ops"; // prefilled with the actual pending channel
   chan.style.maxWidth = "120px";

--- a/thymos/clients/desktop/src/styles.css
+++ b/thymos/clients/desktop/src/styles.css
@@ -151,7 +151,7 @@ h2 { margin: 4px 0 14px; letter-spacing: .3px; }
 .deny { color: var(--red); }
 .suspend { color: var(--amber); }
 .sys { color: var(--muted); font-style: italic; }
-.approval-row { display: flex; gap: 8px; align-items: center; margin: 8px 0; padding: 8px 10px; border: 1px solid rgba(255, 194, 75, .35); border-radius: var(--radius-sm); background: rgba(255, 194, 75, .06); }
+.approval-row { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; margin: 8px 0; padding: 8px 10px; border: 1px solid rgba(255, 194, 75, .35); border-radius: var(--radius-sm); background: rgba(255, 194, 75, .06); }
 .approval-row .q { color: var(--amber); }
 
 /* User message bubble */
@@ -485,4 +485,10 @@ body.advanced .adv-only { display: revert; }
 .mode-chip:hover { border-color: var(--violet); color: var(--text); }
 .mode-chip.on {
   background: rgba(124,92,255,.16); border-color: var(--violet); color: var(--text);
+}
+.approval-why {
+  flex-basis: 100%; margin: 6px 0 2px; padding: 8px 10px;
+  background: var(--bg-2, rgba(0,0,0,.25)); border: 1px solid var(--line);
+  border-radius: 8px; color: var(--muted); font-size: 12px;
+  font-family: ui-monospace, Menlo, monospace; word-break: break-word;
 }

--- a/thymos/crates/thymos-compiler/src/lib.rs
+++ b/thymos/crates/thymos-compiler/src/lib.rs
@@ -293,11 +293,20 @@ pub fn compile_with_context(
     let (status, suspension) = match ctx.approve_risk_at_or_above {
         Some(threshold) if suspension.is_none() && tool.meta().risk_class >= threshold => {
             let channel = "high-risk".to_string();
+            // Include a compact args preview so the operator approves a
+            // concrete action ("run `rm -rf …`"), not an abstract tool name.
+            // The full args are in the proposal/ledger regardless.
+            let args_preview: String = serde_json::to_string(&intent.body.args)
+                .unwrap_or_default()
+                .chars()
+                .take(220)
+                .collect();
             let reason = format!(
-                "tool '{}' is {:?}-risk (threshold {:?}); operator approval required",
+                "tool '{}' is {:?}-risk (threshold {:?}); operator approval required. args: {}",
                 effective_tool,
                 tool.meta().risk_class,
-                threshold
+                threshold,
+                args_preview
             );
             (
                 ProposalStatus::Suspended {

--- a/thymos/crates/thymos-server/src/lib.rs
+++ b/thymos/crates/thymos-server/src/lib.rs
@@ -1145,6 +1145,9 @@ fn run_record_for_access(
 async fn health(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     Json(serde_json::json!({
         "status": "ok",
+        // Lets clients (the desktop supervisor in particular) detect a stale
+        // runtime from an older install and replace it instead of adopting it.
+        "version": env!("CARGO_PKG_VERSION"),
         "mode": match state.runtime_mode {
             RuntimeMode::Reference => "reference",
             RuntimeMode::Production => "production",


### PR DESCRIPTION
Two install-experience fixes: (1) the desktop only adopts a port-3001 runtime that matches its version — a stale one it previously spawned is terminated and replaced (pidfile-scoped; never kills foreign processes); (2) approval cards show the concrete action (tool + args preview from the compiler's risk-gate reason) instead of an abstract tool name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)