### PR TITLE
Ledger Explorer + global search (RFC stage 1, v0.7.10)

### DIFF
--- a/thymos/Cargo.lock
+++ b/thymos/Cargo.lock
@@ -2699,7 +2699,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-cli"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "axum 0.8.9",
  "clap",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-client"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "axum-test",
  "reqwest",
@@ -2733,7 +2733,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-cognition"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -2747,7 +2747,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-compiler"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "serde",
  "serde_json",
@@ -2758,7 +2758,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-core"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "blake3",
  "ed25519-dalek",
@@ -2771,7 +2771,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-ledger"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "blake3",
  "deadpool-postgres",
@@ -2787,7 +2787,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-marketplace"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "blake3",
  "hex",
@@ -2800,7 +2800,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-policy"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "serde",
  "serde_json",
@@ -2809,7 +2809,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-runtime"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "anyhow",
  "serde",
@@ -2826,7 +2826,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-server"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2859,7 +2859,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-tools"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "blake3",
  "reqwest",
@@ -2872,7 +2872,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-worker"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "serde_json",
  "thymos-tools",

--- a/thymos/Cargo.toml
+++ b/thymos/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.9"
+version = "0.7.10"
 edition = "2021"
 license = "Apache-2.0"
 rust-version = "1.80"

--- a/thymos/clients/desktop/package-lock.json
+++ b/thymos/clients/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thymos-desktop",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thymos-desktop",
-      "version": "0.7.9",
+      "version": "0.7.10",
       "devDependencies": {
         "@tauri-apps/cli": "^2"
       }

--- a/thymos/clients/desktop/package.json
+++ b/thymos/clients/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thymos-desktop",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "private": true,
   "description": "OpenThymos Desktop — governed-cognition runtime, install once.",
   "scripts": {

--- a/thymos/clients/desktop/src-tauri/Cargo.lock
+++ b/thymos/clients/desktop/src-tauri/Cargo.lock
@@ -3288,7 +3288,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-desktop"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "serde",
  "serde_json",

--- a/thymos/clients/desktop/src-tauri/Cargo.toml
+++ b/thymos/clients/desktop/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "thymos-desktop"
-version = "0.7.9"
+version = "0.7.10"
 edition = "2021"
 license = "Apache-2.0"
 description = "OpenThymos Desktop — a governed-cognition client that supervises a local runtime."

--- a/thymos/clients/desktop/src-tauri/tauri.conf.json
+++ b/thymos/clients/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenThymos",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "identifier": "com.openthymos.desktop",
   "build": {
     "frontendDist": "../src"

--- a/thymos/clients/desktop/src/index.html
+++ b/thymos/clients/desktop/src/index.html
@@ -373,9 +373,18 @@
           prove it's intact (it never re-runs a tool or calls the model).
         </p>
         <form id="auditForm" class="inline-form">
-          <input id="auditRunId" placeholder="run id (blank = latest)" />
-          <button type="submit">Load trail</button>
+          <input id="auditSearch" placeholder="search everything — tasks, answers, events…" />
+          <input id="auditRunId" placeholder="run id (blank = all activity)" />
+          <button type="submit">Load</button>
         </form>
+        <div id="auditKinds" class="kind-chips">
+          <button type="button" class="chip on" data-kind="commit">✓ commits</button>
+          <button type="button" class="chip on" data-kind="rejection">⊘ rejections</button>
+          <button type="button" class="chip on" data-kind="pending_approval">⏸ approvals</button>
+          <button type="button" class="chip on" data-kind="delegation">⇄ delegations</button>
+          <button type="button" class="chip on" data-kind="skill">✦ skills</button>
+          <button type="button" class="chip on" data-kind="root">◆ roots</button>
+        </div>
         <div id="replayBadge"></div>
         <div id="auditTrail" class="list"></div>
       </section>

--- a/thymos/clients/desktop/src/main.js
+++ b/thymos/clients/desktop/src/main.js
@@ -46,6 +46,7 @@ document.querySelectorAll(".tab").forEach((btn) => {
     if (btn.dataset.tab === "tools") loadTools();
     if (btn.dataset.tab === "backups") loadBackups();
     if (btn.dataset.tab === "advanced") loadAdvanced();
+    if (btn.dataset.tab === "audit" && !$("auditRunId").value.trim()) loadExplorer();
   });
 });
 
@@ -1303,9 +1304,105 @@ async function loadAudit(runId) {
 window.thymosOpenAudit = openAudit;
 $("auditForm").addEventListener("submit", (ev) => {
   ev.preventDefault();
+  const q = $("auditSearch")?.value.trim();
   const id = $("auditRunId").value.trim();
-  if (id) loadAudit(id);
+  if (q) loadSearch(q);
+  else if (id) loadAudit(id);
+  else loadExplorer();
 });
+// Kind chips re-filter the all-activity view in place.
+document.querySelectorAll("#auditKinds .chip").forEach((c) =>
+  c.addEventListener("click", () => {
+    c.classList.toggle("on");
+    if (!$("auditRunId").value.trim() && !$("auditSearch")?.value.trim()) loadExplorer();
+  }));
+
+/* ---------- Ledger Explorer: all activity, grouped by day ---------- */
+// The cross-run timeline (RFC: mind-cognitive-graph, stage 1). Every entry is
+// a real ledger record; clicking one drills into that run's full trail.
+async function loadExplorer() {
+  const trail = $("auditTrail");
+  const badge = $("replayBadge");
+  badge.innerHTML = "";
+  trail.innerHTML = "<div class='hint'>loading all activity…</div>";
+  try {
+    const [entriesRes, runsRes] = await Promise.all([
+      getJSON("/audit/entries?limit=300"),
+      getJSON("/runs?limit=200"),
+    ]);
+    const entries = entriesRes.entries || [];
+    const runs = runsRes.runs || [];
+    const byTraj = {};
+    runs.forEach((r) => { if (r.trajectory_id) byTraj[r.trajectory_id] = r; });
+    const kinds = new Set([...document.querySelectorAll("#auditKinds .chip.on")]
+      .map((c) => c.dataset.kind));
+    const shown = entries.filter((e) =>
+      [...kinds].some((k) => (e.kind || "").toLowerCase().includes(k)));
+    trail.innerHTML = "";
+    if (!shown.length) {
+      trail.innerHTML = "<div class='hint'>no ledger activity yet — chat with the agent and every governed action lands here</div>";
+      return;
+    }
+    // Newest first, grouped by day.
+    shown.sort((a, b) => (b.created_at || 0) - (a.created_at || 0));
+    let lastDay = "";
+    shown.forEach((e) => {
+      const ts = (e.created_at || 0) > 1e12 ? e.created_at : e.created_at * 1000;
+      const day = ts ? new Date(ts).toLocaleDateString() : "unknown date";
+      if (day !== lastDay) {
+        lastDay = day;
+        const h = document.createElement("div");
+        h.className = "audit-subhead";
+        h.innerHTML = `<b>${escapeHtml(day)}</b>`;
+        trail.appendChild(h);
+      }
+      const run = byTraj[e.trajectory_id];
+      const div = document.createElement("div");
+      div.className = "item";
+      div.innerHTML =
+        `<span class="meta">#${e.seq}</span><b>${escapeHtml(e.kind || "")}</b>` +
+        (run ? `<span class="meta">${escapeHtml(String(run.task || "").slice(0, 60))}</span>` : "") +
+        `<span class="meta">${ts ? new Date(ts).toLocaleTimeString() : ""}</span>`;
+      if (run) {
+        div.style.cursor = "pointer";
+        div.title = "open this run's full trail";
+        div.onclick = () => { $("auditRunId").value = run.run_id; loadAudit(run.run_id); };
+      }
+      trail.appendChild(div);
+    });
+    badge.innerHTML = `<span class="meta">${shown.length} entries · click any to open its run · clear filters with the chips above</span>`;
+  } catch (e) { trail.innerHTML = `<div class='hint'>could not load activity: ${e}</div>`; }
+}
+
+/* ---------- global search (lexical, over everything recorded) ---------- */
+async function loadSearch(q) {
+  const trail = $("auditTrail");
+  const badge = $("replayBadge");
+  badge.innerHTML = "";
+  trail.innerHTML = "<div class='hint'>searching…</div>";
+  try {
+    const res = await getJSON(`/search?q=${encodeURIComponent(q)}`);
+    const hits = res.hits || [];
+    trail.innerHTML = "";
+    if (!hits.length) {
+      trail.innerHTML = `<div class='hint'>no matches for “${escapeHtml(q)}”</div>`;
+      return;
+    }
+    hits.forEach((h) => {
+      const div = document.createElement("div");
+      div.className = "item audit-narrative";
+      div.innerHTML =
+        `<span class="badge">${escapeHtml(h.field || "")}</span>` +
+        `<b>${escapeHtml(String(h.task || h.title || "").slice(0, 60))}</b>` +
+        (h.snippet ? `<div class="audit-detail">${escapeHtml(h.snippet)}</div>` : "");
+      div.style.cursor = "pointer";
+      div.title = "open this run's full trail";
+      div.onclick = () => { $("auditRunId").value = h.run_id; $("auditSearch").value = ""; loadAudit(h.run_id); };
+      trail.appendChild(div);
+    });
+    badge.innerHTML = `<span class="meta">${hits.length} matches for “${escapeHtml(q)}” · click any to open its run</span>`;
+  } catch (e) { trail.innerHTML = `<div class='hint'>search failed: ${e}</div>`; }
+}
 
 function escapeHtml(s) {
   return String(s).replace(/[&<>"']/g, (c) =>

--- a/thymos/clients/desktop/src/styles.css
+++ b/thymos/clients/desktop/src/styles.css
@@ -492,3 +492,4 @@ body.advanced .adv-only { display: revert; }
   border-radius: 8px; color: var(--muted); font-size: 12px;
   font-family: ui-monospace, Menlo, monospace; word-break: break-word;
 }
+.kind-chips { display: flex; flex-wrap: wrap; gap: 6px; margin: 8px 0 12px; }

--- a/thymos/crates/thymos-server/src/lib.rs
+++ b/thymos/crates/thymos-server/src/lib.rs
@@ -717,6 +717,7 @@ pub fn app(state: Arc<AppState>) -> Router {
         .route("/usage", get(get_usage))
         .route("/audit/entries", get(audit::get_audit_entries))
         .route("/audit/entries/count", get(audit::count_audit_entries))
+        .route("/search", get(search))
         .route("/skills", get(list_skills).post(create_skill))
         .route("/skills/{id}", get(get_skill));
 
@@ -2377,6 +2378,106 @@ fn event_type(evt: &CognitionEvent) -> &'static str {
         CognitionEvent::TurnComplete { .. } => "turn_complete",
         CognitionEvent::Error { .. } => "error",
     }
+}
+
+#[derive(Deserialize)]
+pub struct SearchQuery {
+    pub q: String,
+    #[serde(default = "default_search_limit")]
+    pub limit: usize,
+}
+fn default_search_limit() -> usize {
+    50
+}
+
+/// A short window of text around the first match, so results read in context.
+fn snippet_around(text: &str, q: &str) -> String {
+    let lower = text.to_lowercase();
+    let Some(pos) = lower.find(q) else {
+        return text.chars().take(120).collect();
+    };
+    let start = text[..pos]
+        .char_indices()
+        .rev()
+        .nth(40)
+        .map(|(i, _)| i)
+        .unwrap_or(0);
+    let out: String = text[start..].chars().take(160).collect();
+    if start > 0 { format!("…{out}") } else { out }
+}
+
+/// GET /search?q= — lexical search across everything the runtime records for
+/// its runs: tasks, final answers, and execution-narrative entries (titles,
+/// details, tools). Case-insensitive substring match; results carry the run
+/// they came from so a client can jump straight to its audit trail. (Semantic
+/// search is deliberately absent until a local embedding store exists.)
+async fn search(
+    State(state): State<Arc<AppState>>,
+    axum::extract::Query(query): axum::extract::Query<SearchQuery>,
+) -> impl IntoResponse {
+    let q = query.q.trim().to_lowercase();
+    if q.len() < 2 {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": "query must be at least 2 characters" })),
+        )
+            .into_response();
+    }
+    let limit = query.limit.clamp(1, 200);
+    let mut hits: Vec<serde_json::Value> = Vec::new();
+
+    {
+        let runs = state.runs.lock().unwrap();
+        for (run_id, rec) in runs.iter() {
+            if hits.len() >= limit {
+                break;
+            }
+            if rec.task.to_lowercase().contains(&q) {
+                hits.push(serde_json::json!({
+                    "run_id": run_id, "field": "task", "status": status_str(&rec.status),
+                    "task": rec.task, "snippet": snippet_around(&rec.task, &q),
+                }));
+            }
+            if let Some(ans) = rec.summary.as_ref().and_then(|s| s.final_answer.as_deref()) {
+                if ans.to_lowercase().contains(&q) {
+                    hits.push(serde_json::json!({
+                        "run_id": run_id, "field": "answer", "status": status_str(&rec.status),
+                        "task": rec.task, "snippet": snippet_around(ans, &q),
+                    }));
+                }
+            }
+        }
+    }
+    {
+        let sessions = state.execution_sessions.lock().unwrap();
+        'outer: for (run_id, session) in sessions.iter() {
+            let mut per_run = 0;
+            for e in &session.log {
+                if hits.len() >= limit {
+                    break 'outer;
+                }
+                if per_run >= 3 {
+                    break;
+                }
+                let hay = format!("{} {} {}", e.title, e.detail, e.tool.as_deref().unwrap_or(""));
+                if hay.to_lowercase().contains(&q) {
+                    hits.push(serde_json::json!({
+                        "run_id": run_id, "field": "event",
+                        "task": session.task, "title": e.title,
+                        "snippet": snippet_around(&e.detail, &q),
+                        "time": e.timestamp_ms,
+                    }));
+                    per_run += 1;
+                }
+            }
+        }
+    }
+
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({ "query": query.q, "count": hits.len(), "hits": hits })),
+    )
+        .into_response()
 }
 
 /// GET /runs/:id/world — current world projection.

--- a/thymos/crates/thymos-server/tests/e2e.rs
+++ b/thymos/crates/thymos-server/tests/e2e.rs
@@ -305,6 +305,32 @@ async fn usage_endpoint_works_without_gateway() {
 }
 
 #[tokio::test]
+async fn search_rejects_short_queries() {
+    let server = test_server(test_state());
+    let resp = server.get("/search?q=x").await;
+    resp.assert_status(axum::http::StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn search_returns_empty_hits_when_nothing_matches() {
+    let server = test_server(test_state());
+    let resp = server.get("/search?q=nothing-matches-this").await;
+    resp.assert_status_ok();
+    let body: Value = resp.json();
+    assert_eq!(body["count"], 0);
+}
+
+#[tokio::test]
+async fn audit_entries_work_without_run_id() {
+    // The cross-run explorer path: no run_id = all trajectories.
+    let server = test_server(test_state());
+    let resp = server.get("/audit/entries?limit=10").await;
+    resp.assert_status_ok();
+    let body: Value = resp.json();
+    assert!(body["entries"].is_array());
+}
+
+#[tokio::test]
 async fn approval_on_nonexistent_run_returns_404() {
     let server = test_server(test_state());
     let resp = server


### PR DESCRIPTION
Stage 1 of the accepted mind-cognitive-graph RFC: the Audit tab defaults to a cross-run Ledger Explorer (all activity, day-grouped, kind-filtered, run-joined, click-through) and a new lexical /search endpoint covers tasks, answers, and narrative events with run-linked hits. Live-smoked; 3 new e2e tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)