### PR TITLE
Mind: live streaming + activity panel + 2D navigation + audit-404 fix (v0.7.12)

### DIFF
--- a/thymos/Cargo.lock
+++ b/thymos/Cargo.lock
@@ -2699,7 +2699,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-cli"
-version = "0.7.11"
+version = "0.7.12"
 dependencies = [
  "axum 0.8.9",
  "clap",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-client"
-version = "0.7.11"
+version = "0.7.12"
 dependencies = [
  "axum-test",
  "reqwest",
@@ -2733,7 +2733,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-cognition"
-version = "0.7.11"
+version = "0.7.12"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -2747,7 +2747,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-compiler"
-version = "0.7.11"
+version = "0.7.12"
 dependencies = [
  "serde",
  "serde_json",
@@ -2758,7 +2758,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-core"
-version = "0.7.11"
+version = "0.7.12"
 dependencies = [
  "blake3",
  "ed25519-dalek",
@@ -2771,7 +2771,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-ledger"
-version = "0.7.11"
+version = "0.7.12"
 dependencies = [
  "blake3",
  "deadpool-postgres",
@@ -2787,7 +2787,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-marketplace"
-version = "0.7.11"
+version = "0.7.12"
 dependencies = [
  "blake3",
  "hex",
@@ -2800,7 +2800,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-policy"
-version = "0.7.11"
+version = "0.7.12"
 dependencies = [
  "serde",
  "serde_json",
@@ -2809,7 +2809,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-runtime"
-version = "0.7.11"
+version = "0.7.12"
 dependencies = [
  "anyhow",
  "serde",
@@ -2826,7 +2826,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-server"
-version = "0.7.11"
+version = "0.7.12"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2859,7 +2859,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-tools"
-version = "0.7.11"
+version = "0.7.12"
 dependencies = [
  "blake3",
  "reqwest",
@@ -2872,7 +2872,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-worker"
-version = "0.7.11"
+version = "0.7.12"
 dependencies = [
  "serde_json",
  "thymos-tools",

--- a/thymos/Cargo.toml
+++ b/thymos/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.11"
+version = "0.7.12"
 edition = "2021"
 license = "Apache-2.0"
 rust-version = "1.80"

--- a/thymos/clients/desktop/package-lock.json
+++ b/thymos/clients/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thymos-desktop",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thymos-desktop",
-      "version": "0.7.11",
+      "version": "0.7.12",
       "devDependencies": {
         "@tauri-apps/cli": "^2"
       }

--- a/thymos/clients/desktop/package.json
+++ b/thymos/clients/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thymos-desktop",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "private": true,
   "description": "OpenThymos Desktop — governed-cognition runtime, install once.",
   "scripts": {

--- a/thymos/clients/desktop/src-tauri/Cargo.lock
+++ b/thymos/clients/desktop/src-tauri/Cargo.lock
@@ -3288,7 +3288,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-desktop"
-version = "0.7.11"
+version = "0.7.12"
 dependencies = [
  "serde",
  "serde_json",

--- a/thymos/clients/desktop/src-tauri/Cargo.toml
+++ b/thymos/clients/desktop/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "thymos-desktop"
-version = "0.7.11"
+version = "0.7.12"
 edition = "2021"
 license = "Apache-2.0"
 description = "OpenThymos Desktop — a governed-cognition client that supervises a local runtime."

--- a/thymos/clients/desktop/src-tauri/tauri.conf.json
+++ b/thymos/clients/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenThymos",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "identifier": "com.openthymos.desktop",
   "build": {
     "frontendDist": "../src"

--- a/thymos/clients/desktop/src/index.html
+++ b/thymos/clients/desktop/src/index.html
@@ -132,8 +132,14 @@
           <div id="mindCanvas" class="mind-canvas"></div>
           <div id="mindTip" class="mind-tip" hidden></div>
           <div id="mindInspector" class="mind-inspector" hidden></div>
+          <!-- Always-on activity stream: the current turn's events read top to
+               bottom, live, so you follow the agent without clicking nodes. -->
+          <aside id="mindActivity" class="mind-activity">
+            <div class="ma-head">Live activity</div>
+            <div id="mindActivityList" class="ma-list"></div>
+          </aside>
         </div>
-        <p class="hint mind-hint">Click any node to inspect it — what it was, when, with which tool, in which run. Drag to orbit · scroll to zoom · click a legend type to filter.</p>
+        <p class="hint mind-hint">The graph streams live as the agent works; the side panel reads the current turn top-to-bottom. Click a node (or a panel row) for details · drag to pan · scroll to zoom · double-click empty space to reset · click a legend type to filter.</p>
         <div class="mind-legend">
           <button type="button" class="lg msg" data-type="message">● you</button>
           <button type="button" class="lg cyan" data-type="intent">◆ intent</button>

--- a/thymos/clients/desktop/src/main.js
+++ b/thymos/clients/desktop/src/main.js
@@ -406,6 +406,9 @@ function renderSnapshot(s) {
       });
     }
     activeRunId = null;
+    // Clear the live marker so Mind stops showing this run as in-flight; the
+    // finished turn is now a persisted reply it picks up normally.
+    if (window.thymosActiveRun === s.run_id) window.thymosActiveRun = null;
     setBusy(false);
   }
 }
@@ -1257,8 +1260,16 @@ async function loadAudit(runId) {
   trail.innerHTML = "<div class='hint'>loading…</div>";
   badge.innerHTML = "";
   try {
-    const entries = await getJSON(`/audit/entries?run_id=${encodeURIComponent(runId)}`);
-    const list = Array.isArray(entries) ? entries : entries.entries || [];
+    // Ledger entries are fetched softly: a run that failed before recording a
+    // trajectory (e.g. provider init error) legitimately has none and the
+    // endpoint 404s — that must NOT blank the whole view. The narrative below
+    // still tells the story.
+    let list = [];
+    let ledgerMissing = false;
+    try {
+      const entries = await getJSON(`/audit/entries?run_id=${encodeURIComponent(runId)}`);
+      list = Array.isArray(entries) ? entries : entries.entries || [];
+    } catch (_) { ledgerMissing = true; }
     trail.innerHTML = "";
 
     // --- What happened: the run's narrative, from the execution session log.
@@ -1297,6 +1308,14 @@ async function loadAudit(runId) {
     head2.className = "audit-subhead";
     head2.innerHTML = `<b>Ledger chain</b><span class="meta"> · authoritative, content-addressed, replay-verified</span>`;
     trail.appendChild(head2);
+    if (!list.length) {
+      const note = document.createElement("div");
+      note.className = "hint";
+      note.textContent = ledgerMissing
+        ? "No ledger entries for this run — it ended before committing anything (e.g. a provider error or an early rejection). The narrative above is the full story."
+        : "No ledger entries yet.";
+      trail.appendChild(note);
+    }
     list.forEach((e) => {
       const div = document.createElement("div");
       div.className = "item";
@@ -1305,15 +1324,17 @@ async function loadAudit(runId) {
         `<span class="meta">${escapeHtml((e.commit_id || e.id || "").slice(0, 12))}</span>`;
       trail.appendChild(div);
     });
-    // Replay always verifies integrity; a 200 means the chain folded cleanly.
-    try {
-      const rep = await getJSON(`/runs/${runId}/replay`);
-      badge.innerHTML =
-        `<span class="badge ok">replay ✓ verified</span> ` +
-        `<span class="meta">${rep.commits_replayed} commits · ` +
-        `${rep.rejected_proposals} rejected · head ${(rep.head_commit || "").slice(0, 12)}</span>`;
-    } catch (_) {
-      badge.innerHTML = `<span class="badge bad">replay could not verify</span>`;
+    // Replay verifies integrity; only meaningful if there's a chain to fold.
+    if (!ledgerMissing) {
+      try {
+        const rep = await getJSON(`/runs/${runId}/replay`);
+        badge.innerHTML =
+          `<span class="badge ok">replay ✓ verified</span> ` +
+          `<span class="meta">${rep.commits_replayed} commits · ` +
+          `${rep.rejected_proposals} rejected · head ${(rep.head_commit || "").slice(0, 12)}</span>`;
+      } catch (_) {
+        badge.innerHTML = `<span class="badge bad">replay could not verify</span>`;
+      }
     }
   } catch (e) { trail.innerHTML = `<div class='hint'>could not load trail: ${e}</div>`; }
 }

--- a/thymos/clients/desktop/src/styles.css
+++ b/thymos/clients/desktop/src/styles.css
@@ -494,3 +494,29 @@ body.advanced .adv-only { display: revert; }
 }
 .kind-chips { display: flex; flex-wrap: wrap; gap: 6px; margin: 8px 0 12px; }
 .lg.msg { color: #9aa6ff; }
+
+/* Mind live-activity panel — always-on stream of the current turn's events */
+.mind-activity {
+  position: absolute; top: 12px; left: 12px; width: 268px; max-height: 82%;
+  display: flex; flex-direction: column; z-index: 6;
+  background: rgba(17, 13, 34, .92); border: 1px solid var(--line);
+  border-radius: 10px; box-shadow: 0 10px 34px rgba(0, 0, 0, .45);
+}
+.ma-head {
+  padding: 9px 13px; font-size: 12px; font-weight: 700; letter-spacing: .03em;
+  color: var(--muted); border-bottom: 1px solid var(--line); text-transform: uppercase;
+}
+.ma-list { overflow-y: auto; padding: 6px; }
+.ma-row {
+  display: flex; gap: 9px; padding: 7px 8px; border-radius: 8px; cursor: pointer;
+}
+.ma-row:hover { background: rgba(255, 255, 255, .04); }
+.ma-dot { flex: 0 0 8px; width: 8px; height: 8px; border-radius: 50%; margin-top: 5px; }
+.ma-body { min-width: 0; }
+.ma-title { font-size: 12.5px; color: var(--text); font-weight: 600; }
+.ma-tool { color: var(--cyan); font-family: ui-monospace, Menlo, monospace; font-weight: 500; }
+.ma-detail { font-size: 11.5px; color: var(--muted); margin-top: 2px; word-break: break-word; }
+.ma-working .ma-title { color: var(--muted); }
+.ma-pulse { background: var(--violet); animation: ma-blink 1.1s ease-in-out infinite; }
+@keyframes ma-blink { 0%,100% { opacity: .3; } 50% { opacity: 1; } }
+@media (max-width: 760px) { .mind-activity { display: none; } }

--- a/thymos/clients/desktop/src/viz.js
+++ b/thymos/clients/desktop/src/viz.js
@@ -63,7 +63,9 @@ function classifyAudit(en) {
 
 let renderer, scene, camera, world, nodesGroup, glowTex;
 let inited = false, running = false, raf = 0, loadedOnce = false;
-let targetRotY = 0, targetRotX = 0.25, curRotY = 0, curRotX = 0.25;
+// Stable 2D navigation: the graph is planar (z=0), so we pan + zoom instead of
+// orbiting. Nothing auto-moves — nodes stay put so they're easy to click.
+let panX = 0, panY = 0, targetPanX = 0, targetPanY = 0;
 let drag = null;
 let nodeMeshes = [], raycaster, pointer, dragMoved = false;
 
@@ -118,16 +120,16 @@ function init() {
   camera.position.set(0, 0, 13);
   glowTex = radialTexture("rgba(124,92,255,0.9)");
 
-  // World group (orbited by drag + slow auto-rotation). Pure network: no
-  // logo, no cage, no decoration — the only things on screen are the run's
-  // real events and what connects them.
+  // Flat, front-facing graph. Pure network: no logo, no cage, no decoration —
+  // only the run's real events and what connects them, held still.
   world = new THREE.Group();
   scene.add(world);
 
   nodesGroup = new THREE.Group();
   world.add(nodesGroup);
 
-  // Interaction: drag to orbit, wheel to zoom, click a node to inspect it.
+  // Interaction: drag to PAN, wheel to zoom, click a node to inspect it.
+  // No rotation, no auto-motion — clicking is precise.
   raycaster = new THREE.Raycaster();
   pointer = new THREE.Vector2();
   const el = renderer.domElement;
@@ -136,20 +138,26 @@ function init() {
   window.addEventListener("pointermove", (e) => {
     if (!drag) return;
     if (Math.abs(e.clientX - drag.x) + Math.abs(e.clientY - drag.y) > 3) dragMoved = true;
-    targetRotY += (e.clientX - drag.x) * 0.006;
-    targetRotX += (e.clientY - drag.y) * 0.006;
-    targetRotX = Math.max(-1.2, Math.min(1.2, targetRotX));
+    // Pan in the view plane; scale by zoom so it tracks the cursor 1:1.
+    const k = camera.position.z / 520;
+    targetPanX += (e.clientX - drag.x) * k;
+    targetPanY -= (e.clientY - drag.y) * k;
     drag = { x: e.clientX, y: e.clientY };
   });
   el.addEventListener("wheel", (e) => {
     e.preventDefault();
-    camera.position.z = Math.max(7, Math.min(26, camera.position.z + e.deltaY * 0.01));
+    camera.position.z = Math.max(6, Math.min(30, camera.position.z + e.deltaY * 0.012));
   }, { passive: false });
-  // Click (not drag) on a node → open the inspector + swing it to the front.
+  // Click (not drag) on a node → open the inspector + center it.
   el.addEventListener("click", (e) => {
     if (dragMoved) return;
     const hit = nodeAt(e);
     if (hit) { inspectNode(hit.userData); focusOn(hit); }
+  });
+  // Double-click empty space → reset the view to fit.
+  el.addEventListener("dblclick", (e) => {
+    if (nodeAt(e)) return;
+    targetPanX = 0; targetPanY = 0; camera.position.z = 13;
   });
   // Hover → quick tooltip + pointer cursor.
   el.addEventListener("pointermove", (e) => {
@@ -199,18 +207,10 @@ function nodeAt(e) {
   return hits.length ? hits[0].object : null;
 }
 
-// Smoothly rotate the world so the clicked node faces the camera.
+// Smoothly pan the clicked node to the center of the view.
 function focusOn(mesh) {
-  const p = mesh.position;
-  // Camera looks down -Z; a node at world angle a faces front when the world
-  // is rotated so the node lands near +Z.
-  const a = Math.atan2(p.x, p.z);
-  const want = -a;
-  // Take the shortest path from the current rotation.
-  let delta = (want - targetRotY) % (Math.PI * 2);
-  if (delta > Math.PI) delta -= Math.PI * 2;
-  if (delta < -Math.PI) delta += Math.PI * 2;
-  targetRotY += delta;
+  targetPanX = -mesh.position.x;
+  targetPanY = -mesh.position.y;
 }
 
 function inspectNode(nd) {
@@ -468,9 +468,18 @@ async function renderSession(session) {
   for (let i = 0; i < msgs.length; i++) {
     if (msgs[i].role !== "user") continue;
     const reply = msgs.slice(i + 1).find((m) => m.role === "agent");
-    turns.push({ user: msgs[i], reply: reply || null });
+    turns.push({ user: msgs[i], reply: reply ? { ...reply } : null });
   }
   if (!turns.length) return;
+
+  // Live follow: if a run is in flight (its reply isn't in the chat yet), the
+  // newest unreplied turn IS that run — attach it so the graph streams the
+  // agent's actions as they happen, not just finished turns.
+  const liveRun = window.thymosActiveRun;
+  if (liveRun) {
+    const open = [...turns].reverse().find((t) => !t.reply);
+    if (open) open.reply = { run_id: liveRun, status: "running", text: "" };
+  }
 
   // Fetch lifecycle only for the most recent turns that have a run.
   const detailIdx = new Set();
@@ -496,8 +505,11 @@ async function renderSession(session) {
       timeline = timeline.concat(runNodes(snap, t.reply.run_id, i));
       if (i === turns.length - 1) liveStatus = snap.status || "";
     }
-    if (t.reply) {
-      const st = t.reply.status || snap?.status || "completed";
+    const st = t.reply?.status || snap?.status || "";
+    const terminal = ["completed", "failed", "cancelled"].includes(st);
+    // Only finished turns get an Answer/Error node — a live turn ends on its
+    // newest action, breathing, until it resolves.
+    if (t.reply && terminal) {
       timeline.push({
         idx: i * 1000 + 900,
         type: st === "failed" ? "error" : "answer",
@@ -516,15 +528,49 @@ async function renderSession(session) {
   const tools = [...new Set(timeline.map((nd) => nd.tool).filter(Boolean))].slice(0, 8);
   const ctx = { provider: health?.default_provider || "", live: !!health?.cognition_live, tools, replayOk: false };
 
-  const sig = `${session.id}:${timeline.length}:${JSON.stringify(filters)}`;
+  // Live-aware signature: includes status so the final Answer node appears the
+  // moment the run resolves, and node count so streamed actions re-render.
+  const sig = `${session.id}:${timeline.length}:${liveStatus}:${JSON.stringify(filters)}`;
   if (sig !== lastFilterKey) {
     const grew = sig.split(":")[0] === lastFilterKey.split(":")[0];
     lastFilterKey = sig;
-    buildGraph(timeline, ctx, grew ? -1 : null); // new turns animate in
+    buildGraph(timeline, ctx, grew ? -1 : null); // new turns/actions animate in
   }
   const el = document.getElementById("mindRunId");
   if (el && !el.value) el.placeholder = `${turns.length} messages · ${timeline.length} nodes`;
   renderSessionState(session, turns, health);
+  // The always-on activity panel: the latest turn, read top-to-bottom.
+  renderActivity(timeline, liveStatus);
+}
+
+// Stream the current turn's events into the side panel — full titles + detail,
+// newest turn, auto-scrolled — so the agent's work reads without clicking.
+function renderActivity(timeline, status) {
+  const list = document.getElementById("mindActivityList");
+  if (!list) return;
+  const lastStep = timeline.reduce((m, n) => Math.max(m, n.step ?? 0), 0);
+  const turn = timeline.filter((n) => (n.step ?? 0) === lastStep);
+  list.innerHTML = "";
+  turn.forEach((nd) => {
+    const t = TYPES[nd.type] || TYPES.system;
+    const row = document.createElement("div");
+    row.className = "ma-row";
+    const d = (nd.detail || "").slice(0, 160);
+    row.innerHTML =
+      `<span class="ma-dot" style="background:${hex(t.color)}"></span>` +
+      `<div class="ma-body"><div class="ma-title">${escHtml(t.label)}` +
+      (nd.tool ? ` · <span class="ma-tool">${escHtml(nd.tool)}</span>` : "") +
+      `</div>` + (d ? `<div class="ma-detail">${escHtml(d)}</div>` : "") + `</div>`;
+    row.onclick = () => inspectNode(nd);
+    list.appendChild(row);
+  });
+  if (status === "running" || status === "waiting_approval") {
+    const w = document.createElement("div");
+    w.className = "ma-row ma-working";
+    w.innerHTML = `<span class="ma-dot ma-pulse"></span><div class="ma-body"><div class="ma-title">working…</div></div>`;
+    list.appendChild(w);
+  }
+  list.scrollTop = list.scrollHeight;
 }
 
 let prevMaxIdx = -1;
@@ -631,11 +677,10 @@ function renderRunState(id, snap, health, replay) {
 function frame() {
   raf = requestAnimationFrame(frame);
   clock += 0.016;
-  targetRotY += 0.0016;
-  curRotY += (targetRotY - curRotY) * 0.08;
-  curRotX += (targetRotX - curRotX) * 0.08;
-  world.rotation.y = curRotY;
-  world.rotation.x = curRotX;
+  // Eased pan toward target — the only world motion, and only when you drag.
+  panX += (targetPanX - panX) * 0.18;
+  panY += (targetPanY - panY) * 0.18;
+  world.position.set(panX, panY, 0);
 
   // Gentle, uniform halo breathing — a calm "alive" shimmer, not flashing.
   // (Errors get a slightly stronger pulse so they read as needing attention.)


### PR DESCRIPTION
Addresses the Mind feedback: (1) it streams live (in-flight run attached, status-aware rebuild) instead of being a prefilled snapshot; (2) an always-on activity panel reads the current turn top-to-bottom so you don't click every node; (3) 3D orbit + auto-rotation replaced with stable 2D pan/zoom (nothing auto-moves, clicking is precise, double-click resets); (4) Audit degrades gracefully when a run has no ledger entries instead of showing a 404 error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)