### PR TITLE
Harden Mind polling + verify terminal (v0.7.13)

### DIFF
--- a/thymos/Cargo.lock
+++ b/thymos/Cargo.lock
@@ -2699,7 +2699,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-cli"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "axum 0.8.9",
  "clap",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-client"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "axum-test",
  "reqwest",
@@ -2733,7 +2733,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-cognition"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -2747,7 +2747,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-compiler"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "serde",
  "serde_json",
@@ -2758,7 +2758,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-core"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "blake3",
  "ed25519-dalek",
@@ -2771,7 +2771,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-ledger"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "blake3",
  "deadpool-postgres",
@@ -2787,7 +2787,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-marketplace"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "blake3",
  "hex",
@@ -2800,7 +2800,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-policy"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "serde",
  "serde_json",
@@ -2809,7 +2809,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-runtime"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "anyhow",
  "serde",
@@ -2826,7 +2826,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-server"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2859,7 +2859,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-tools"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "blake3",
  "reqwest",
@@ -2872,7 +2872,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-worker"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "serde_json",
  "thymos-tools",

--- a/thymos/Cargo.toml
+++ b/thymos/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.12"
+version = "0.7.13"
 edition = "2021"
 license = "Apache-2.0"
 rust-version = "1.80"

--- a/thymos/clients/desktop/package-lock.json
+++ b/thymos/clients/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thymos-desktop",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thymos-desktop",
-      "version": "0.7.12",
+      "version": "0.7.13",
       "devDependencies": {
         "@tauri-apps/cli": "^2"
       }

--- a/thymos/clients/desktop/package.json
+++ b/thymos/clients/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thymos-desktop",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "private": true,
   "description": "OpenThymos Desktop — governed-cognition runtime, install once.",
   "scripts": {

--- a/thymos/clients/desktop/src-tauri/Cargo.lock
+++ b/thymos/clients/desktop/src-tauri/Cargo.lock
@@ -3288,7 +3288,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-desktop"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "serde",
  "serde_json",

--- a/thymos/clients/desktop/src-tauri/Cargo.toml
+++ b/thymos/clients/desktop/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "thymos-desktop"
-version = "0.7.12"
+version = "0.7.13"
 edition = "2021"
 license = "Apache-2.0"
 description = "OpenThymos Desktop — a governed-cognition client that supervises a local runtime."

--- a/thymos/clients/desktop/src-tauri/tauri.conf.json
+++ b/thymos/clients/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenThymos",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "identifier": "com.openthymos.desktop",
   "build": {
     "frontendDist": "../src"

--- a/thymos/clients/desktop/src/viz.js
+++ b/thymos/clients/desktop/src/viz.js
@@ -66,6 +66,7 @@ let inited = false, running = false, raf = 0, loadedOnce = false;
 // Stable 2D navigation: the graph is planar (z=0), so we pan + zoom instead of
 // orbiting. Nothing auto-moves — nodes stay put so they're easy to click.
 let panX = 0, panY = 0, targetPanX = 0, targetPanY = 0;
+let lastSessionMsgCount = -1, hasRenderedOnce = false;
 let drag = null;
 let nodeMeshes = [], raycaster, pointer, dragMoved = false;
 
@@ -426,6 +427,18 @@ function applySearchDim() {
 // long conversation stays light.
 const SESSION_DETAIL_RUNS = 8;
 
+// Caches so the 1.5s refresh isn't a fetch storm. A finished run's execution
+// log never changes — fetch it once and reuse forever. /health is near-static
+// — refetch at most every 30s.
+const snapCache = new Map(); // run_id → snapshot (only cached when terminal)
+let healthCache = null, healthAt = 0;
+async function fetchHealthCached() {
+  if (healthCache && Date.now() - healthAt < 30_000) return healthCache;
+  try { healthCache = await (await fetch(`${BASE}/health`)).json(); healthAt = Date.now(); } catch (_) {}
+  return healthCache;
+}
+const TERMINAL = new Set(["completed", "failed", "cancelled"]);
+
 // Map one run's execution log → lifecycle nodes for conversation turn `turn`.
 function runNodes(snap, runId, turn) {
   const out = [];
@@ -490,7 +503,14 @@ async function renderSession(session) {
   const snaps = {};
   await Promise.all([...detailIdx].map(async (i) => {
     const rid = turns[i].reply.run_id;
-    try { snaps[i] = await (await fetch(`${BASE}/runs/${rid}/execution`)).json(); } catch (_) {}
+    // Reuse a finished run's snapshot — its log is immutable. Only in-flight
+    // runs (and uncached ones) actually hit the network each tick.
+    if (snapCache.has(rid)) { snaps[i] = snapCache.get(rid); return; }
+    try {
+      const s = await (await fetch(`${BASE}/runs/${rid}/execution`)).json();
+      snaps[i] = s;
+      if (TERMINAL.has(s?.status)) snapCache.set(rid, s);
+    } catch (_) {}
   }));
 
   let timeline = [];
@@ -523,8 +543,7 @@ async function renderSession(session) {
   timeline.forEach((nd) => { nd.color = (TYPES[nd.type] || TYPES.system).color; });
   runStatus = liveStatus;
 
-  let health = null;
-  try { health = await (await fetch(`${BASE}/health`)).json(); } catch (_) {}
+  const health = await fetchHealthCached();
   const tools = [...new Set(timeline.map((nd) => nd.tool).filter(Boolean))].slice(0, 8);
   const ctx = { provider: health?.default_provider || "", live: !!health?.cognition_live, tools, replayOk: false };
 
@@ -709,9 +728,17 @@ function start() {
   // new message starts a new run), unless the operator pinned a run id.
   if (!refreshTimer) {
     // Pinned → keep refreshing that run; otherwise re-render the whole
-    // conversation (picks up new messages + streaming actions live).
+    // conversation. Idle gate: when nothing is in flight and the conversation
+    // hasn't grown, skip the refresh entirely (the frame loop keeps the gentle
+    // shimmer) — no fetch storm while you're just reading.
     refreshTimer = setInterval(() => {
-      loadRun(pinnedRun ? (document.getElementById("mindRunId")?.value || "") : "");
+      if (pinnedRun) { loadRun(document.getElementById("mindRunId")?.value || ""); return; }
+      const live = !!window.thymosActiveRun;
+      const n = window.thymosSession?.()?.messages?.length ?? 0;
+      if (!live && n === lastSessionMsgCount && hasRenderedOnce) return;
+      lastSessionMsgCount = n;
+      hasRenderedOnce = true;
+      loadRun("");
     }, 1500);
   }
 }


### PR DESCRIPTION
Fixes a fetch-storm bottleneck recent Mind work introduced (~6 req/sec while open, even idle): caches finished runs' snapshots, caches /health 30s, and adds an idle gate so a quiet Mind makes ~0 requests. Verified the CLI end-to-end alongside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)