### PR TITLE
Vision-true agent identity + readable Audit (v0.7.14)

### DIFF
--- a/thymos/Cargo.lock
+++ b/thymos/Cargo.lock
@@ -2699,7 +2699,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-cli"
-version = "0.7.13"
+version = "0.7.14"
 dependencies = [
  "axum 0.8.9",
  "clap",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-client"
-version = "0.7.13"
+version = "0.7.14"
 dependencies = [
  "axum-test",
  "reqwest",
@@ -2733,7 +2733,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-cognition"
-version = "0.7.13"
+version = "0.7.14"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -2747,7 +2747,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-compiler"
-version = "0.7.13"
+version = "0.7.14"
 dependencies = [
  "serde",
  "serde_json",
@@ -2758,7 +2758,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-core"
-version = "0.7.13"
+version = "0.7.14"
 dependencies = [
  "blake3",
  "ed25519-dalek",
@@ -2771,7 +2771,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-ledger"
-version = "0.7.13"
+version = "0.7.14"
 dependencies = [
  "blake3",
  "deadpool-postgres",
@@ -2787,7 +2787,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-marketplace"
-version = "0.7.13"
+version = "0.7.14"
 dependencies = [
  "blake3",
  "hex",
@@ -2800,7 +2800,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-policy"
-version = "0.7.13"
+version = "0.7.14"
 dependencies = [
  "serde",
  "serde_json",
@@ -2809,7 +2809,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-runtime"
-version = "0.7.13"
+version = "0.7.14"
 dependencies = [
  "anyhow",
  "serde",
@@ -2826,7 +2826,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-server"
-version = "0.7.13"
+version = "0.7.14"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2859,7 +2859,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-tools"
-version = "0.7.13"
+version = "0.7.14"
 dependencies = [
  "blake3",
  "reqwest",
@@ -2872,7 +2872,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-worker"
-version = "0.7.13"
+version = "0.7.14"
 dependencies = [
  "serde_json",
  "thymos-tools",

--- a/thymos/Cargo.toml
+++ b/thymos/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.13"
+version = "0.7.14"
 edition = "2021"
 license = "Apache-2.0"
 rust-version = "1.80"

--- a/thymos/clients/desktop/package-lock.json
+++ b/thymos/clients/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thymos-desktop",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thymos-desktop",
-      "version": "0.7.13",
+      "version": "0.7.14",
       "devDependencies": {
         "@tauri-apps/cli": "^2"
       }

--- a/thymos/clients/desktop/package.json
+++ b/thymos/clients/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thymos-desktop",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "private": true,
   "description": "OpenThymos Desktop — governed-cognition runtime, install once.",
   "scripts": {

--- a/thymos/clients/desktop/src-tauri/Cargo.lock
+++ b/thymos/clients/desktop/src-tauri/Cargo.lock
@@ -3288,7 +3288,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-desktop"
-version = "0.7.13"
+version = "0.7.14"
 dependencies = [
  "serde",
  "serde_json",

--- a/thymos/clients/desktop/src-tauri/Cargo.toml
+++ b/thymos/clients/desktop/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "thymos-desktop"
-version = "0.7.13"
+version = "0.7.14"
 edition = "2021"
 license = "Apache-2.0"
 description = "OpenThymos Desktop — a governed-cognition client that supervises a local runtime."

--- a/thymos/clients/desktop/src-tauri/tauri.conf.json
+++ b/thymos/clients/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenThymos",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "identifier": "com.openthymos.desktop",
   "build": {
     "frontendDist": "../src"

--- a/thymos/clients/desktop/src/index.html
+++ b/thymos/clients/desktop/src/index.html
@@ -373,24 +373,24 @@
       <section class="panel" id="tab-audit">
         <div class="panel-head"><h2>Audit</h2></div>
         <p class="tab-intro">
-          The complete, tamper-evident record of what the agent did — every
-          <b>intent</b> the model proposed, the runtime's <b>verdict</b> (permit /
-          deny / needs-approval), and every <b>commit</b> that changed state, under
-          which signed authority. <b>Replay</b> independently re-folds the ledger to
-          prove it's intact (it never re-runs a tool or calls the model).
+          The receipts. Every message you send becomes a recorded run; this is
+          the tamper-proof history of what actually happened — what the agent
+          tried, what the runtime allowed or blocked, and what it changed.
+          <b>Search</b> to find anything; leave it blank to browse <b>all
+          activity</b> by day; click any row to open that run's full story.
         </p>
         <form id="auditForm" class="inline-form">
-          <input id="auditSearch" placeholder="search everything — tasks, answers, events…" />
-          <input id="auditRunId" placeholder="run id (blank = all activity)" />
-          <button type="submit">Load</button>
+          <input id="auditSearch" placeholder="🔍 search tasks, answers, actions…" />
+          <input id="auditRunId" class="adv-only" placeholder="run id (optional)" />
+          <button type="submit">Search</button>
         </form>
         <div id="auditKinds" class="kind-chips">
-          <button type="button" class="chip on" data-kind="commit">✓ commits</button>
-          <button type="button" class="chip on" data-kind="rejection">⊘ rejections</button>
+          <button type="button" class="chip on" data-kind="commit">✓ committed</button>
+          <button type="button" class="chip on" data-kind="rejection">⊘ blocked</button>
           <button type="button" class="chip on" data-kind="pending_approval">⏸ approvals</button>
-          <button type="button" class="chip on" data-kind="delegation">⇄ delegations</button>
+          <button type="button" class="chip on" data-kind="delegation">⇄ delegated</button>
           <button type="button" class="chip on" data-kind="skill">✦ skills</button>
-          <button type="button" class="chip on" data-kind="root">◆ roots</button>
+          <button type="button" class="chip on" data-kind="root">◆ run starts</button>
         </div>
         <div id="replayBadge"></div>
         <div id="auditTrail" class="list"></div>

--- a/thymos/clients/desktop/src/main.js
+++ b/thymos/clients/desktop/src/main.js
@@ -1281,7 +1281,7 @@ async function loadAudit(runId) {
       if (log.length) {
         const head = document.createElement("div");
         head.className = "audit-subhead";
-        head.innerHTML = `<b>What happened</b><span class="meta"> · the run's live narrative (status: ${escapeHtml(snap.status || "?")})</span>`;
+        head.innerHTML = `<b>What happened</b><span class="meta"> · step by step, in plain English (${escapeHtml(snap.status || "?")})</span>`;
         trail.appendChild(head);
         log.forEach((e) => {
           const [g, cls] = glyphFor(e);
@@ -1306,7 +1306,7 @@ async function loadAudit(runId) {
     // --- Ledger chain: the authoritative, hash-chained record.
     const head2 = document.createElement("div");
     head2.className = "audit-subhead";
-    head2.innerHTML = `<b>Ledger chain</b><span class="meta"> · authoritative, content-addressed, replay-verified</span>`;
+    head2.innerHTML = `<b>The proof</b><span class="meta"> · the signed, hash-chained ledger replay re-verifies</span>`;
     trail.appendChild(head2);
     if (!list.length) {
       const note = document.createElement("div");
@@ -1317,10 +1317,12 @@ async function loadAudit(runId) {
       trail.appendChild(note);
     }
     list.forEach((e) => {
+      const [g, cls, label] = kindLabel(e.kind);
       const div = document.createElement("div");
       div.className = "item";
       div.innerHTML =
-        `<span class="meta">#${e.seq}</span><b>${escapeHtml(e.kind)}</b>` +
+        `<span class="glyph ${cls}">${g}</span><b>${escapeHtml(label)}</b>` +
+        `<span class="meta">#${e.seq}</span>` +
         `<span class="meta">${escapeHtml((e.commit_id || e.id || "").slice(0, 12))}</span>`;
       trail.appendChild(div);
     });
@@ -1355,6 +1357,21 @@ document.querySelectorAll("#auditKinds .chip").forEach((c) =>
     if (!$("auditRunId").value.trim() && !$("auditSearch")?.value.trim()) loadExplorer();
   }));
 
+// Plain-English label + glyph for a raw ledger entry kind, so the Audit view
+// reads as a story instead of jargon ("root" → "Run started").
+function kindLabel(kind) {
+  const k = (kind || "").toLowerCase();
+  if (k.includes("commit")) return ["✓", "commit", "Action committed"];
+  if (k.includes("reject")) return ["⊘", "deny", "Proposal rejected"];
+  if (k.includes("approval") || k.includes("pending") || k.includes("suspend"))
+    return ["⏸", "suspend", "Waiting for approval"];
+  if (k.includes("delegation")) return ["⇄", "permit", "Authority delegated"];
+  if (k.includes("skill")) return ["✦", "permit", "Skill applied"];
+  if (k.includes("root")) return ["◆", "intent", "Run started"];
+  if (k.includes("branch")) return ["⑂", "sys", "Branched"];
+  return ["·", "sys", kind || "entry"];
+}
+
 /* ---------- Ledger Explorer: all activity, grouped by day ---------- */
 // The cross-run timeline (RFC: mind-cognitive-graph, stage 1). Every entry is
 // a real ledger record; clicking one drills into that run's full trail.
@@ -1378,7 +1395,7 @@ async function loadExplorer() {
       [...kinds].some((k) => (e.kind || "").toLowerCase().includes(k)));
     trail.innerHTML = "";
     if (!shown.length) {
-      trail.innerHTML = "<div class='hint'>no ledger activity yet — chat with the agent and every governed action lands here</div>";
+      trail.innerHTML = "<div class='hint'>Nothing here yet — send the agent a message in Chat and every governed action it takes will be recorded here.</div>";
       return;
     }
     // Newest first, grouped by day.
@@ -1395,20 +1412,21 @@ async function loadExplorer() {
         trail.appendChild(h);
       }
       const run = byTraj[e.trajectory_id];
+      const [g, cls, label] = kindLabel(e.kind);
       const div = document.createElement("div");
       div.className = "item";
       div.innerHTML =
-        `<span class="meta">#${e.seq}</span><b>${escapeHtml(e.kind || "")}</b>` +
-        (run ? `<span class="meta">${escapeHtml(String(run.task || "").slice(0, 60))}</span>` : "") +
+        `<span class="glyph ${cls}">${g}</span><b>${escapeHtml(label)}</b>` +
+        (run ? `<span class="meta">“${escapeHtml(String(run.task || "").slice(0, 56))}”</span>` : "") +
         `<span class="meta">${ts ? new Date(ts).toLocaleTimeString() : ""}</span>`;
       if (run) {
         div.style.cursor = "pointer";
-        div.title = "open this run's full trail";
+        div.title = "open this run's full story";
         div.onclick = () => { $("auditRunId").value = run.run_id; loadAudit(run.run_id); };
       }
       trail.appendChild(div);
     });
-    badge.innerHTML = `<span class="meta">${shown.length} entries · click any to open its run · clear filters with the chips above</span>`;
+    badge.innerHTML = `<span class="meta">${shown.length} recorded actions · click any to open its run</span>`;
   } catch (e) { trail.innerHTML = `<div class='hint'>could not load activity: ${e}</div>`; }
 }
 

--- a/thymos/crates/thymos-cognition/src/anthropic.rs
+++ b/thymos/crates/thymos-cognition/src/anthropic.rs
@@ -615,12 +615,21 @@ fn build_system_prompt_text(writ: &Writ) -> String {
     let scopes_str = scopes.join(", ");
     let b = &writ.body.budget;
     format!(
-        "You are a cognition process operating inside the Thymos runtime.
+        "You are OpenThymos — a governed AI agent that can help with almost \
+anything: answering questions, reasoning through problems, writing and \
+explaining code, inspecting and editing files, running commands, fetching \
+data. Be genuinely useful, accurate, and proactive. Write naturally and \
+directly, like a sharp colleague; when you're unsure, say so.
 
-You do not take actions directly. You emit tool_use blocks that describe \
-PROPOSED actions. The runtime compiles each proposal, evaluates policy \
-against a bounded Capability Writ, and either commits the effect or rejects \
-the proposal. The runtime is the sole source of truth.
+What makes you different is HOW you act, not how much you can do. The creed of \
+this runtime: cognition proposes, the runtime governs, the ledger records. You \
+are the cognition. To take a real-world action you don't act directly — you \
+emit tool_use blocks describing PROPOSED actions. The runtime compiles each \
+proposal, evaluates policy against a signed Capability Writ, records the \
+decision, and either commits the effect or rejects it — and every commit is \
+appended to an auditable, replayable ledger. Treat this as a strength: it lets \
+the user trust you with real power. If a proposal is rejected, explain plainly \
+what was blocked and what would unblock it; never pretend it succeeded.
 
 Not every message needs a tool. If the user is greeting you, making small \
 talk, or asking something you can answer from your own knowledge, just reply \

--- a/thymos/crates/thymos-cognition/src/openai.rs
+++ b/thymos/crates/thymos-cognition/src/openai.rs
@@ -416,11 +416,24 @@ fn build_system_prompt(writ: &Writ) -> String {
     let scopes_str = scopes.join(", ");
     let b = &writ.body.budget;
     format!(
-        "You are a cognition process operating inside the Thymos runtime.\n\
+        "You are OpenThymos — a governed AI agent that can help with almost \
+         anything: answering questions, reasoning through problems, writing and \
+         explaining code, inspecting and editing files, running commands, and \
+         fetching data. Be genuinely useful, accurate, and proactive. Write \
+         naturally and directly, like a sharp colleague; when you're unsure, \
+         say so rather than guessing.\n\
          \n\
-         You do not take actions directly. You emit function calls that describe \
-         PROPOSED actions. The runtime evaluates policy against a bounded Capability \
-         Writ, and either commits the effect or rejects the proposal.\n\
+         What makes you different is HOW you act, not how much you can do. The \
+         creed of this runtime: cognition proposes, the runtime governs, the \
+         ledger records. You are the cognition. When a task needs a real-world \
+         effect, you don't perform it directly — you emit a function call \
+         describing the PROPOSED action. The runtime checks it against a signed \
+         Capability Writ (what you're authorized to do), records the decision, \
+         and either commits the effect or rejects it — and every committed \
+         action is appended to an auditable, replayable ledger. Treat this as a \
+         strength: it lets the user trust you with real power. If a proposal is \
+         rejected, explain plainly what was blocked and what would unblock it \
+         (usually a broader grant) — never pretend it succeeded.\n\
          \n\
          Not every message needs a tool. If the user is greeting you, making \
          small talk, or asking something you can answer from your own knowledge, \
@@ -598,9 +611,12 @@ fn build_system_prompt_jsonblock(writ: &Writ, tools: &ToolRegistry) -> String {
     let tools_block = tool_lines.join("\n");
 
     format!(
-        "You are a cognition process operating inside the Thymos runtime.\n\
+        "You are OpenThymos, a capable, friendly AI assistant. Help the user \
+         clearly, accurately, and naturally. You run inside a governed runtime: \
+         to take a real-world action you don't act directly — you propose it and \
+         the runtime checks it against a Capability Writ before it runs.\n\
          \n\
-         You do not take actions directly. To call a tool, emit one or more \
+         To call a tool, emit one or more \
          fenced JSON blocks in your reply. Each block must be a single JSON \
          object with this exact shape:\n\
          \n\


### PR DESCRIPTION
Two things: (1) the system prompt (all 3 adapters) now makes the model answer AS OpenThymos — a governed agent that helps with anything, states the creed, frames governance as a strength, explains rejections honestly — instead of as a generic chatbot; (2) the Audit tab is humanized: plain-English intro, ledger kinds rendered as 'Run started / Action committed / Proposal rejected' with glyphs, clearer section headers ('What happened' + 'The proof'), search-first layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)