### PR TITLE
v0.8.0 — agent workspace, streaming, hardening (Tier 1 + fixes)

### DIFF
--- a/thymos/Cargo.lock
+++ b/thymos/Cargo.lock
@@ -2699,7 +2699,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-cli"
-version = "0.7.14"
+version = "0.7.15"
 dependencies = [
  "axum 0.8.9",
  "clap",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-client"
-version = "0.7.14"
+version = "0.7.15"
 dependencies = [
  "axum-test",
  "reqwest",
@@ -2733,7 +2733,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-cognition"
-version = "0.7.14"
+version = "0.7.15"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -2747,7 +2747,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-compiler"
-version = "0.7.14"
+version = "0.7.15"
 dependencies = [
  "serde",
  "serde_json",
@@ -2758,7 +2758,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-core"
-version = "0.7.14"
+version = "0.7.15"
 dependencies = [
  "blake3",
  "ed25519-dalek",
@@ -2771,7 +2771,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-ledger"
-version = "0.7.14"
+version = "0.7.15"
 dependencies = [
  "blake3",
  "deadpool-postgres",
@@ -2787,7 +2787,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-marketplace"
-version = "0.7.14"
+version = "0.7.15"
 dependencies = [
  "blake3",
  "hex",
@@ -2800,7 +2800,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-policy"
-version = "0.7.14"
+version = "0.7.15"
 dependencies = [
  "serde",
  "serde_json",
@@ -2809,7 +2809,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-runtime"
-version = "0.7.14"
+version = "0.7.15"
 dependencies = [
  "anyhow",
  "serde",
@@ -2826,7 +2826,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-server"
-version = "0.7.14"
+version = "0.7.15"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2859,7 +2859,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-tools"
-version = "0.7.14"
+version = "0.7.15"
 dependencies = [
  "blake3",
  "reqwest",
@@ -2872,7 +2872,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-worker"
-version = "0.7.14"
+version = "0.7.15"
 dependencies = [
  "serde_json",
  "thymos-tools",

--- a/thymos/Cargo.lock
+++ b/thymos/Cargo.lock
@@ -2699,7 +2699,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-cli"
-version = "0.7.15"
+version = "0.8.0"
 dependencies = [
  "axum 0.8.9",
  "clap",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-client"
-version = "0.7.15"
+version = "0.8.0"
 dependencies = [
  "axum-test",
  "reqwest",
@@ -2733,7 +2733,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-cognition"
-version = "0.7.15"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -2747,7 +2747,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-compiler"
-version = "0.7.15"
+version = "0.8.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2758,7 +2758,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-core"
-version = "0.7.15"
+version = "0.8.0"
 dependencies = [
  "blake3",
  "ed25519-dalek",
@@ -2771,7 +2771,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-ledger"
-version = "0.7.15"
+version = "0.8.0"
 dependencies = [
  "blake3",
  "deadpool-postgres",
@@ -2787,7 +2787,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-marketplace"
-version = "0.7.15"
+version = "0.8.0"
 dependencies = [
  "blake3",
  "hex",
@@ -2800,7 +2800,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-policy"
-version = "0.7.15"
+version = "0.8.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2809,7 +2809,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-runtime"
-version = "0.7.15"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "serde",
@@ -2826,7 +2826,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-server"
-version = "0.7.15"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2859,7 +2859,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-tools"
-version = "0.7.15"
+version = "0.8.0"
 dependencies = [
  "blake3",
  "reqwest",
@@ -2872,7 +2872,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-worker"
-version = "0.7.15"
+version = "0.8.0"
 dependencies = [
  "serde_json",
  "thymos-tools",

--- a/thymos/Cargo.toml
+++ b/thymos/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.15"
+version = "0.8.0"
 edition = "2021"
 license = "Apache-2.0"
 rust-version = "1.80"

--- a/thymos/Cargo.toml
+++ b/thymos/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.14"
+version = "0.7.15"
 edition = "2021"
 license = "Apache-2.0"
 rust-version = "1.80"

--- a/thymos/clients/desktop/package-lock.json
+++ b/thymos/clients/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thymos-desktop",
-  "version": "0.7.14",
+  "version": "0.7.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thymos-desktop",
-      "version": "0.7.14",
+      "version": "0.7.15",
       "devDependencies": {
         "@tauri-apps/cli": "^2"
       }

--- a/thymos/clients/desktop/package-lock.json
+++ b/thymos/clients/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thymos-desktop",
-  "version": "0.7.15",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thymos-desktop",
-      "version": "0.7.15",
+      "version": "0.8.0",
       "devDependencies": {
         "@tauri-apps/cli": "^2"
       }

--- a/thymos/clients/desktop/package.json
+++ b/thymos/clients/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thymos-desktop",
-  "version": "0.7.14",
+  "version": "0.7.15",
   "private": true,
   "description": "OpenThymos Desktop — governed-cognition runtime, install once.",
   "scripts": {

--- a/thymos/clients/desktop/package.json
+++ b/thymos/clients/desktop/package.json
@@ -1,13 +1,14 @@
 {
   "name": "thymos-desktop",
-  "version": "0.7.15",
+  "version": "0.8.0",
   "private": true,
   "description": "OpenThymos Desktop — governed-cognition runtime, install once.",
   "scripts": {
     "dev": "tauri dev",
     "build": "node scripts/prepare-sidecar.mjs && tauri build --config src-tauri/tauri.release.conf.json",
     "tauri": "tauri",
-    "icon": "tauri icon ../../Thymos-logo.PNG"
+    "icon": "tauri icon ../../Thymos-logo.PNG",
+    "smoke": "node scripts/smoke.mjs"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2"

--- a/thymos/clients/desktop/scripts/smoke.mjs
+++ b/thymos/clients/desktop/scripts/smoke.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+// Desktop UI smoke test — catches the two regressions we hit repeatedly by
+// hand: (1) a JS file that doesn't parse, (2) a `$("id")` /
+// getElementById("id") reference with no matching element in index.html.
+// Pure static analysis (no browser); fast, dependency-free, CI-friendly.
+import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..", "src");
+let failures = 0;
+const fail = (m) => { console.error("✗ " + m); failures++; };
+
+// 1. Both scripts must parse.
+for (const f of ["main.js", "viz.js"]) {
+  try {
+    execFileSync(process.execPath, ["--check", join(root, f)], { stdio: "pipe" });
+    console.log(`✓ ${f} parses`);
+  } catch (e) {
+    fail(`${f} syntax error:\n${e.stderr || e}`);
+  }
+}
+
+// 2. Every referenced element id must exist in index.html.
+const html = readFileSync(join(root, "index.html"), "utf8");
+const htmlIds = new Set([...html.matchAll(/id="([A-Za-z0-9_-]+)"/g)].map((m) => m[1]));
+const js = ["main.js", "viz.js"].map((f) => readFileSync(join(root, f), "utf8")).join("\n");
+// Ids created at runtime (`el.id = "x"` / `.id="x"`) are legitimately absent
+// from the static HTML — exclude them.
+const dynamicIds = new Set([...js.matchAll(/\.id\s*=\s*"([A-Za-z0-9_-]+)"/g)].map((m) => m[1]));
+const refs = new Set();
+for (const m of js.matchAll(/\$\("([A-Za-z0-9_-]+)"\)/g)) refs.add(m[1]);
+for (const m of js.matchAll(/getElementById\("([A-Za-z0-9_-]+)"\)/g)) refs.add(m[1]);
+let missing = 0;
+for (const id of refs) {
+  if (!htmlIds.has(id) && !dynamicIds.has(id)) {
+    fail(`element id "${id}" referenced in JS but not in index.html`); missing++;
+  }
+}
+if (!missing) console.log(`✓ all ${refs.size} referenced element ids exist in index.html`);
+
+if (failures) { console.error(`\n${failures} smoke check(s) failed.`); process.exit(1); }
+console.log("\nDesktop UI smoke test passed.");

--- a/thymos/clients/desktop/src-tauri/Cargo.lock
+++ b/thymos/clients/desktop/src-tauri/Cargo.lock
@@ -3734,7 +3734,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-desktop"
-version = "0.7.15"
+version = "0.8.0"
 dependencies = [
  "rfd",
  "serde",

--- a/thymos/clients/desktop/src-tauri/Cargo.lock
+++ b/thymos/clients/desktop/src-tauri/Cargo.lock
@@ -48,6 +48,181 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "ashpd"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f3f79755c74fd155000314eb349864caa787c6592eace6c6882dad873d9c39"
+dependencies = [
+ "async-fs",
+ "async-net",
+ "enumflags2",
+ "futures-channel",
+ "futures-util",
+ "rand",
+ "raw-window-handle",
+ "serde",
+ "serde_repr",
+ "url",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "zbus",
+]
+
+[[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-fs"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
+dependencies = [
+ "async-lock",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-net"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
+dependencies = [
+ "async-io",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -140,6 +315,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -329,6 +517,15 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -594,6 +791,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlib"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
 name = "dlopen2"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -630,6 +836,12 @@ dependencies = [
  "selectors",
  "tendril",
 ]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dpi"
@@ -703,6 +915,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -717,6 +956,37 @@ dependencies = [
  "serde",
  "serde_core",
  "typeid",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -845,6 +1115,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1210,6 +1493,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1679,6 +1968,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2048,6 +2343,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "pango"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2071,6 +2376,12 @@ dependencies = [
  "libc",
  "system-deps",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -2161,6 +2472,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2206,6 +2528,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "pollster"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2219,6 +2561,15 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "precomputed-hash"
@@ -2327,6 +2678,35 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "raw-window-handle"
@@ -2438,6 +2818,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2bee61e6cffa4635c72d7d81a84294e28f0930db0ddcb0f66d10244674ebed"
+dependencies = [
+ "ashpd",
+ "block2",
+ "dispatch2",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "pollster",
+ "raw-window-handle",
+ "urlencoding",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2464,6 +2868,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.13.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2566,6 +2983,12 @@ dependencies = [
  "serde_derive_internals",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -2776,6 +3199,16 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "simd-adler32"
@@ -3237,6 +3670,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "tendril"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3288,8 +3734,9 @@ dependencies = [
 
 [[package]]
 name = "thymos-desktop"
-version = "0.7.14"
+version = "0.7.15"
 dependencies = [
+ "rfd",
  "serde",
  "serde_json",
  "tauri",
@@ -3552,7 +3999,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3603,6 +4062,17 @@ name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unic-char-property"
@@ -3699,6 +4169,12 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "urlpattern"
@@ -3911,6 +4387,66 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
+]
+
+[[package]]
+name = "wayland-backend"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "scoped-tls",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
+dependencies = [
+ "bitflags 2.13.0",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
+dependencies = [
+ "bitflags 2.13.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+dependencies = [
+ "proc-macro2",
+ "quick-xml",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "dlib",
+ "log",
+ "pkg-config",
 ]
 
 [[package]]
@@ -4616,6 +5152,87 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eee682d202a77e4a9f3b2c2bdf48a7b28af5c08c34ddf66f98c93e5e39464285"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 1.0.3",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adf1bd45a81a103745b1757754762a26e8cd01e4532e4d6c8ec431624b80d1d6"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
+dependencies = [
+ "serde",
+ "winnow 1.0.3",
+ "zvariant",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "zerofrom"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4680,3 +5297,44 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zvariant"
+version = "5.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a192a0bde63360d77a7523c833d4b4ce6070a927e2c53246e4c540b1a3e27be0"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "url",
+ "winnow 1.0.3",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bc6cde9c01c511074be97f7ccb6c19d0da89e3f8662e812e999dcfd4638737"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e8535915cfa75547e559d8c68e8139909a4aeee076831e4ef7fc59d8172c4d6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.117",
+ "winnow 1.0.3",
+]

--- a/thymos/clients/desktop/src-tauri/Cargo.toml
+++ b/thymos/clients/desktop/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "thymos-desktop"
-version = "0.7.15"
+version = "0.8.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "OpenThymos Desktop — a governed-cognition client that supervises a local runtime."

--- a/thymos/clients/desktop/src-tauri/Cargo.toml
+++ b/thymos/clients/desktop/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "thymos-desktop"
-version = "0.7.14"
+version = "0.7.15"
 edition = "2021"
 license = "Apache-2.0"
 description = "OpenThymos Desktop — a governed-cognition client that supervises a local runtime."
@@ -24,6 +24,8 @@ serde_json = "1"
 # Light blocking HTTP client for host-side model discovery + connection tests
 # (the webview's CSP can't reach provider URLs; the host does it locally).
 ureq = { version = "2", features = ["json", "tls"] }
+# Native folder picker for the agent's working directory (no JS plugin needed).
+rfd = "0.15"
 
 [features]
 # Tauri custom protocol assets in production builds.

--- a/thymos/clients/desktop/src-tauri/src/lib.rs
+++ b/thymos/clients/desktop/src-tauri/src/lib.rs
@@ -131,6 +131,31 @@ fn clear_workspace(app: tauri::AppHandle) -> Result<(), String> {
     Ok(())
 }
 
+/// Persisted opt-in for token streaming (experimental). Passed to the runtime
+/// as THYMOS_STREAM on spawn; takes effect on the next runtime restart.
+fn streaming_path(app: &tauri::AppHandle) -> Option<PathBuf> {
+    app.path().app_data_dir().ok().map(|d| d.join("streaming.on"))
+}
+fn streaming_enabled(app: &tauri::AppHandle) -> bool {
+    streaming_path(app).map(|p| p.exists()).unwrap_or(false)
+}
+#[tauri::command]
+fn get_streaming(app: tauri::AppHandle) -> bool {
+    streaming_enabled(&app)
+}
+#[tauri::command]
+fn set_streaming(app: tauri::AppHandle, on: bool) -> Result<(), String> {
+    if let Some(p) = streaming_path(&app) {
+        let _ = std::fs::create_dir_all(p.parent().unwrap());
+        if on {
+            std::fs::write(&p, "1").map_err(|e| format!("save: {e}"))?;
+        } else {
+            let _ = std::fs::remove_file(p);
+        }
+    }
+    Ok(())
+}
+
 /// Inject the stored provider as env vars on the runtime child. Anthropic uses
 /// its dedicated key/base-URL vars; everything else (native `openai` plus every
 /// OpenAI-compatible preset) resolves the generic `OPENAI_API_KEY` /
@@ -273,6 +298,9 @@ fn start_runtime(app: tauri::AppHandle, state: State<Supervisor>) -> Result<Stri
     // folder is what makes "read/edit my project" actually work.
     if let Some(ws) = load_workspace(&app) {
         cmd.env("THYMOS_WORKSPACE", ws);
+    }
+    if streaming_enabled(&app) {
+        cmd.env("THYMOS_STREAM", "1");
     }
     apply_provider_env(&mut cmd, &load_provider_config(&app));
     let child = cmd
@@ -500,7 +528,9 @@ pub fn run() {
             delete_tool_manifest,
             get_workspace,
             pick_workspace,
-            clear_workspace
+            clear_workspace,
+            get_streaming,
+            set_streaming
         ])
         .on_window_event(|window, event| {
             // Don't orphan the runtime when the app window closes.

--- a/thymos/clients/desktop/src-tauri/src/lib.rs
+++ b/thymos/clients/desktop/src-tauri/src/lib.rs
@@ -87,6 +87,50 @@ fn load_provider_config(app: &tauri::AppHandle) -> ProviderConfig {
         .unwrap_or_default()
 }
 
+/// File holding the operator-chosen working folder (the agent's sandbox root).
+fn workspace_path(app: &tauri::AppHandle) -> Option<PathBuf> {
+    app.path().app_data_dir().ok().map(|d| d.join("workspace.txt"))
+}
+fn load_workspace(app: &tauri::AppHandle) -> Option<String> {
+    workspace_path(app)
+        .and_then(|p| std::fs::read_to_string(p).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty() && std::path::Path::new(s).is_dir())
+}
+
+/// Current working folder the agent is allowed to read/edit (empty = none yet).
+#[tauri::command]
+fn get_workspace(app: tauri::AppHandle) -> String {
+    load_workspace(&app).unwrap_or_default()
+}
+
+/// Open a native folder picker; persist + return the chosen path (empty if the
+/// user cancelled). Changing it takes effect on the next runtime (re)start.
+#[tauri::command]
+fn pick_workspace(app: tauri::AppHandle) -> Result<String, String> {
+    let Some(dir) = rfd::FileDialog::new()
+        .set_title("Choose the folder OpenThymos may read and edit")
+        .pick_folder()
+    else {
+        return Ok(String::new()); // cancelled
+    };
+    let path = dir.display().to_string();
+    if let Some(p) = workspace_path(&app) {
+        let _ = std::fs::create_dir_all(p.parent().unwrap());
+        std::fs::write(&p, &path).map_err(|e| format!("save workspace: {e}"))?;
+    }
+    Ok(path)
+}
+
+/// Forget the working folder (the agent falls back to no project root).
+#[tauri::command]
+fn clear_workspace(app: tauri::AppHandle) -> Result<(), String> {
+    if let Some(p) = workspace_path(&app) {
+        let _ = std::fs::remove_file(p);
+    }
+    Ok(())
+}
+
 /// Inject the stored provider as env vars on the runtime child. Anthropic uses
 /// its dedicated key/base-URL vars; everything else (native `openai` plus every
 /// OpenAI-compatible preset) resolves the generic `OPENAI_API_KEY` /
@@ -224,6 +268,12 @@ fn start_runtime(app: tauri::AppHandle, state: State<Supervisor>) -> Result<Stri
     let mut cmd = Command::new(&bin);
     cmd.env("THYMOS_LEDGER_PATH", &ledger_path);
     cmd.env("THYMOS_TOOL_MANIFEST_DIRS", &tools_dir);
+    // The agent's working folder: file/shell tools are confined to it. Without
+    // one the tools fall back to the runtime's cwd (not useful), so a chosen
+    // folder is what makes "read/edit my project" actually work.
+    if let Some(ws) = load_workspace(&app) {
+        cmd.env("THYMOS_WORKSPACE", ws);
+    }
     apply_provider_env(&mut cmd, &load_provider_config(&app));
     let child = cmd
         .spawn()
@@ -447,7 +497,10 @@ pub fn run() {
             discover_models,
             save_tool,
             list_tool_manifests,
-            delete_tool_manifest
+            delete_tool_manifest,
+            get_workspace,
+            pick_workspace,
+            clear_workspace
         ])
         .on_window_event(|window, event| {
             // Don't orphan the runtime when the app window closes.

--- a/thymos/clients/desktop/src-tauri/tauri.conf.json
+++ b/thymos/clients/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenThymos",
-  "version": "0.7.15",
+  "version": "0.8.0",
   "identifier": "com.openthymos.desktop",
   "build": {
     "frontendDist": "../src"

--- a/thymos/clients/desktop/src-tauri/tauri.conf.json
+++ b/thymos/clients/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenThymos",
-  "version": "0.7.14",
+  "version": "0.7.15",
   "identifier": "com.openthymos.desktop",
   "build": {
     "frontendDist": "../src"

--- a/thymos/clients/desktop/src/index.html
+++ b/thymos/clients/desktop/src/index.html
@@ -465,6 +465,22 @@
           </div>
 
           <div class="card">
+            <h3>Working folder</h3>
+            <p class="note">
+              The folder the agent may read, search, and edit. Without one, its
+              file tools have nowhere to work. Changing it applies on the next
+              runtime restart.
+            </p>
+            <div class="ledger-path-row">
+              <code id="advWorkspace" class="path">— none chosen —</code>
+            </div>
+            <div class="ws-actions">
+              <button type="button" id="pickWorkspace">Choose folder…</button>
+              <button type="button" id="clearWorkspace" class="ghost">Clear</button>
+            </div>
+          </div>
+
+          <div class="card">
             <h3>Ledger &amp; debug</h3>
             <div class="ledger-path-row">
               <span class="dim">ledger file</span>

--- a/thymos/clients/desktop/src/index.html
+++ b/thymos/clients/desktop/src/index.html
@@ -481,6 +481,18 @@
           </div>
 
           <div class="card">
+            <h3>Responses</h3>
+            <label class="adv-toggle" title="Render the model's reply token-by-token as it streams (experimental). Applies on the next runtime restart.">
+              <input type="checkbox" id="streamToggle" /> Stream responses live (experimental)
+            </label>
+            <p class="note">
+              Off by default. When on, replies appear as they're generated
+              instead of all at once. Falls back automatically for providers
+              that don't stream.
+            </p>
+          </div>
+
+          <div class="card">
             <h3>Ledger &amp; debug</h3>
             <div class="ledger-path-row">
               <span class="dim">ledger file</span>

--- a/thymos/clients/desktop/src/main.js
+++ b/thymos/clients/desktop/src/main.js
@@ -111,6 +111,11 @@ async function loadAdvanced() {
     try { const w = await invoke("get_workspace"); ws.textContent = w || "— none chosen —"; }
     catch (_) { ws.textContent = "—"; }
   }
+  // Streaming toggle state.
+  const st = $("streamToggle");
+  if (st && invoke) {
+    try { st.checked = await invoke("get_streaming"); } catch (_) {}
+  }
 }
 $("refreshAdvanced")?.addEventListener("click", loadAdvanced);
 $("pickWorkspace")?.addEventListener("click", async () => {
@@ -131,6 +136,14 @@ $("clearWorkspace")?.addEventListener("click", async () => {
   try {
     await invoke("clear_workspace");
     $("advWorkspace").textContent = "— none chosen —";
+    try { await invoke("stop_runtime"); await invoke("start_runtime"); } catch (_) {}
+    setTimeout(() => refreshStatus(), 1500);
+  } catch (_) {}
+});
+$("streamToggle")?.addEventListener("change", async (e) => {
+  if (!invoke) return;
+  try {
+    await invoke("set_streaming", { on: e.target.checked });
     try { await invoke("stop_runtime"); await invoke("start_runtime"); } catch (_) {}
     setTimeout(() => refreshStatus(), 1500);
   } catch (_) {}
@@ -405,6 +418,19 @@ function renderSnapshot(s) {
   // static "governing…" that reads as frozen.
   const wl = document.querySelector("#workingLine span:last-child");
   if (wl && s.operator_state) wl.textContent = s.operator_state.toLowerCase() + "…";
+  // Streaming (opt-in THYMOS_STREAM): show the reply forming live. Replaced by
+  // the final answer bubble when the run completes.
+  if (s.partial_answer && !["completed", "failed", "cancelled"].includes(s.status)) {
+    let p = document.getElementById("streamingAnswer");
+    if (!p) {
+      p = document.createElement("div");
+      p.id = "streamingAnswer";
+      p.className = "answer streaming";
+      feed.appendChild(p);
+    }
+    p.textContent = s.partial_answer;
+    feed.scrollTop = feed.scrollHeight;
+  }
   // Snapshot carries the full log; render only newly-arrived entries.
   (s.log || []).forEach((e) => {
     if (e.idx < renderedUpTo) return;
@@ -426,6 +452,8 @@ function renderSnapshot(s) {
     showApproval(s.run_id, s.pending_channel, req?.detail || "");
   }
   if (["completed", "failed", "cancelled"].includes(s.status)) {
+    // Drop the live streaming placeholder; the final answer bubble replaces it.
+    document.getElementById("streamingAnswer")?.remove();
     if (s.final_answer) {
       pushAnswer(s.status, s.final_answer);
       // Persist the answer with its ledger link (run/trajectory) for audit+replay.

--- a/thymos/clients/desktop/src/main.js
+++ b/thymos/clients/desktop/src/main.js
@@ -105,8 +105,36 @@ async function loadAdvanced() {
     try { lp.textContent = (await invoke("ledger_path")) || "(runtime not started yet)"; }
     catch (_) { lp.textContent = "—"; }
   }
+  // Working folder: the agent's sandbox root.
+  const ws = $("advWorkspace");
+  if (ws && invoke) {
+    try { const w = await invoke("get_workspace"); ws.textContent = w || "— none chosen —"; }
+    catch (_) { ws.textContent = "—"; }
+  }
 }
 $("refreshAdvanced")?.addEventListener("click", loadAdvanced);
+$("pickWorkspace")?.addEventListener("click", async () => {
+  if (!invoke) return;
+  try {
+    const chosen = await invoke("pick_workspace");
+    if (chosen) {
+      $("advWorkspace").textContent = chosen;
+      // Restart the runtime so the new root takes effect, then resync.
+      try { await invoke("stop_runtime"); } catch (_) {}
+      try { await invoke("start_runtime"); } catch (_) {}
+      setTimeout(() => { refreshStatus(); loadAdvanced(); }, 1500);
+    }
+  } catch (e) { alert("Could not set folder: " + e); }
+});
+$("clearWorkspace")?.addEventListener("click", async () => {
+  if (!invoke) return;
+  try {
+    await invoke("clear_workspace");
+    $("advWorkspace").textContent = "— none chosen —";
+    try { await invoke("stop_runtime"); await invoke("start_runtime"); } catch (_) {}
+    setTimeout(() => refreshStatus(), 1500);
+  } catch (_) {}
+});
 
 /* ---------- Advanced Mode ---------- */
 // Off by default: normal users never see raw runtime data, schemas, writs, or

--- a/thymos/clients/desktop/src/styles.css
+++ b/thymos/clients/desktop/src/styles.css
@@ -521,3 +521,5 @@ body.advanced .adv-only { display: revert; }
 @keyframes ma-blink { 0%,100% { opacity: .3; } 50% { opacity: 1; } }
 @media (max-width: 760px) { .mind-activity { display: none; } }
 .ws-actions { display: flex; gap: 8px; margin-top: 10px; }
+.answer.streaming { opacity: 0.92; border-left: 2px solid var(--violet); }
+.answer.streaming::after { content: "▍"; animation: ma-blink 1s steps(1) infinite; color: var(--violet); }

--- a/thymos/clients/desktop/src/styles.css
+++ b/thymos/clients/desktop/src/styles.css
@@ -520,3 +520,4 @@ body.advanced .adv-only { display: revert; }
 .ma-pulse { background: var(--violet); animation: ma-blink 1.1s ease-in-out infinite; }
 @keyframes ma-blink { 0%,100% { opacity: .3; } 50% { opacity: 1; } }
 @media (max-width: 760px) { .mind-activity { display: none; } }
+.ws-actions { display: flex; gap: 8px; margin-top: 10px; }

--- a/thymos/crates/thymos-cognition/src/lib.rs
+++ b/thymos/crates/thymos-cognition/src/lib.rs
@@ -98,12 +98,33 @@ pub struct CognitionStep {
 /// Cognition produces Intents. That is the entire contract.
 pub trait Cognition: Send {
     fn step(&mut self, ctx: &CognitionContext<'_>) -> Result<CognitionStep>;
+
+    /// Optional token-streaming step. Default `None` = not supported, so the
+    /// caller falls back to `step`. An implementor streams the model's text,
+    /// calling `on_token` for each chunk as it arrives, then returns the
+    /// fully-parsed step (identical shape to `step`). Returning `None` (even
+    /// after starting) signals "couldn't stream — use the sync path", so this
+    /// can never regress non-streaming behavior.
+    fn step_streamed(
+        &mut self,
+        _ctx: &CognitionContext<'_>,
+        _on_token: &mut dyn FnMut(&str),
+    ) -> Option<Result<CognitionStep>> {
+        None
+    }
 }
 
 /// Convenience: Cognition for a boxed trait object.
 impl Cognition for Box<dyn Cognition> {
     fn step(&mut self, ctx: &CognitionContext<'_>) -> Result<CognitionStep> {
         (**self).step(ctx)
+    }
+    fn step_streamed(
+        &mut self,
+        ctx: &CognitionContext<'_>,
+        on_token: &mut dyn FnMut(&str),
+    ) -> Option<Result<CognitionStep>> {
+        (**self).step_streamed(ctx, on_token)
     }
 }
 
@@ -170,11 +191,33 @@ impl<C: Cognition + Send> StreamingCognition for NonStreamingAdapter<C> {
         // reject). Some callers and tests run on Tokio's current-thread
         // runtime, though, where `block_in_place` panics. Fall back to a
         // direct call in that environment instead of crashing.
-        let step_result = match tokio::runtime::Handle::try_current() {
+        // Opt-in token streaming (THYMOS_STREAM=1): try the cognition's
+        // streaming path, forwarding each chunk as a Token event. If the
+        // cognition doesn't support it (or couldn't stream), fall back to the
+        // single-shot `step` — so the default experience is unchanged.
+        let want_stream = std::env::var("THYMOS_STREAM")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false);
+        let run_sync = |c: &mut C| match tokio::runtime::Handle::try_current() {
             Ok(handle) if handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread => {
-                tokio::task::block_in_place(|| self.0.step(ctx))
+                tokio::task::block_in_place(|| c.step(ctx))
             }
-            _ => self.0.step(ctx),
+            _ => c.step(ctx),
+        };
+        let step_result = if want_stream {
+            let etx = event_tx.clone();
+            let streamed = tokio::task::block_in_place(|| {
+                let mut on_token = |chunk: &str| {
+                    let _ = etx.blocking_send(CognitionEvent::Token { text: chunk.to_string() });
+                };
+                self.0.step_streamed(ctx, &mut on_token)
+            });
+            match streamed {
+                Some(r) => r,
+                None => run_sync(&mut self.0), // unsupported → sync fallback
+            }
+        } else {
+            run_sync(&mut self.0)
         };
 
         match &step_result {

--- a/thymos/crates/thymos-cognition/src/openai.rs
+++ b/thymos/crates/thymos-cognition/src/openai.rs
@@ -471,9 +471,18 @@ impl OpenAiCognition {
         // tool_calls accumulated by index: (id, name, arguments-string).
         let mut tcs: Vec<(String, String, String)> = Vec::new();
 
+        // Hard cap so a runaway/never-terminating stream can't pin memory —
+        // generous (~4MB of streamed text) but bounded; tripping it aborts the
+        // stream and the caller falls back to the sync path.
+        const MAX_STREAM_BYTES: usize = 4 * 1024 * 1024;
+        let mut seen_bytes = 0usize;
         let reader = std::io::BufReader::new(resp);
         for line in reader.lines() {
             let line = line.map_err(|e| Error::Other(format!("stream read: {e}")))?;
+            seen_bytes += line.len();
+            if seen_bytes > MAX_STREAM_BYTES {
+                return Err(Error::Other("openai stream exceeded size cap".into()));
+            }
             let data = match line.strip_prefix("data:") {
                 Some(d) => d.trim(),
                 None => continue,

--- a/thymos/crates/thymos-cognition/src/openai.rs
+++ b/thymos/crates/thymos-cognition/src/openai.rs
@@ -72,16 +72,36 @@ fn parse_retry_after_header(v: &str) -> Option<u64> {
     v.trim().parse::<f64>().ok().map(|s| (s * 1000.0) as u64)
 }
 
-/// Some providers (e.g. Groq) put the precise wait only in the JSON error body:
-/// `"Please try again in 9.62s"`. Extract that as milliseconds.
+/// Some providers (e.g. Groq) put the precise wait only in the JSON error
+/// body: `"Please try again in 9.62s"` (per-minute limit) or
+/// `"Please try again in 1h16m43.392s"` (per-day limit). Parse the compound
+/// `<h>h<m>m<s>s` / `<s>s` form into milliseconds. This is the *accurate*
+/// reset; the `Retry-After` header is often a coarse generic value.
 fn parse_retry_after_body(body: &str) -> Option<u64> {
     const MARKER: &str = "try again in ";
     let start = body.find(MARKER)? + MARKER.len();
-    let num: String = body[start..]
+    let dur: String = body[start..]
         .chars()
-        .take_while(|c| c.is_ascii_digit() || *c == '.')
+        .take_while(|c| c.is_ascii_digit() || *c == '.' || matches!(c, 'h' | 'm' | 's'))
         .collect();
-    num.parse::<f64>().ok().map(|s| (s * 1000.0) as u64)
+    if dur.is_empty() {
+        return None;
+    }
+    let mut total_ms = 0f64;
+    let mut num = String::new();
+    for c in dur.chars() {
+        match c {
+            'h' => { total_ms += num.parse::<f64>().unwrap_or(0.0) * 3_600_000.0; num.clear(); }
+            'm' => { total_ms += num.parse::<f64>().unwrap_or(0.0) * 60_000.0; num.clear(); }
+            's' => { total_ms += num.parse::<f64>().unwrap_or(0.0) * 1_000.0; num.clear(); }
+            _ => num.push(c),
+        }
+    }
+    // Bare number (no unit) → seconds, matching the simple "9.62" case.
+    if !num.is_empty() {
+        total_ms += num.parse::<f64>().unwrap_or(0.0) * 1_000.0;
+    }
+    (total_ms > 0.0).then_some(total_ms as u64)
 }
 
 impl OpenAiCognition {
@@ -252,12 +272,13 @@ impl Cognition for OpenAiCognition {
                     });
                 }
             }
-            // Prefer the standard header; fall back to providers that put the
-            // precise wait only in the JSON body ("Please try again in 9.62s").
-            let hint_ms = retry_after_header
-                .as_deref()
-                .and_then(parse_retry_after_header)
-                .or_else(|| parse_retry_after_body(&resp_json.to_string()));
+            // Prefer the body's precise reset ("try again in 1h16m43s" /
+            // "9.62s") — it reflects the actual limit; the Retry-After header is
+            // often a coarse generic value (e.g. a flat 60s) that hides a much
+            // longer daily-limit reset. Fall back to the header when no body
+            // hint is present.
+            let hint_ms = parse_retry_after_body(&resp_json.to_string())
+                .or_else(|| retry_after_header.as_deref().and_then(parse_retry_after_header));
             let suffix = hint_ms
                 .map(|ms| format!(" [retry_after_ms={ms}]"))
                 .unwrap_or_default();
@@ -939,6 +960,17 @@ mod tests {
         let body = r#"{"error":{"message":"Rate limit reached ... Please try again in 9.62s. Need more tokens?","code":"rate_limit_exceeded"}}"#;
         assert_eq!(parse_retry_after_body(body), Some(9_620));
         assert_eq!(parse_retry_after_body("no hint here"), None);
+    }
+
+    #[test]
+    fn retry_after_body_parses_compound_daily_limit() {
+        // Per-day limit resets are reported as h/m/s — must parse to the full
+        // duration so the runtime fails fast instead of retrying into a wall.
+        let body = r#"{"error":{"message":"...tokens per day (TPD)... Please try again in 1h16m43.392s."}}"#;
+        let ms = parse_retry_after_body(body).unwrap();
+        // 1h16m43.392s = 4603392 ms (±1s for float).
+        assert!((4_603_000..=4_604_000).contains(&ms), "got {ms}");
+        assert_eq!(parse_retry_after_body("try again in 2m30s."), Some(150_000));
     }
 
     #[test]

--- a/thymos/crates/thymos-cognition/src/openai.rs
+++ b/thymos/crates/thymos-cognition/src/openai.rs
@@ -266,7 +266,32 @@ impl Cognition for OpenAiCognition {
             )));
         }
 
-        // 4. Usage — accumulate totals and capture this turn's usage.
+        // 4-6. Shared parse: usage, assistant message, tool calls → step.
+        self.finish_from_response(&resp_json, ctx)
+    }
+
+    fn step_streamed(
+        &mut self,
+        ctx: &CognitionContext<'_>,
+        on_token: &mut dyn FnMut(&str),
+    ) -> Option<Result<CognitionStep>> {
+        match self.stream_request(ctx, on_token) {
+            Ok(resp_json) => Some(self.finish_from_response(&resp_json, ctx)),
+            // Couldn't establish/parse the stream → signal fallback to sync.
+            Err(_) => None,
+        }
+    }
+}
+
+impl OpenAiCognition {
+    /// Shared response → CognitionStep parse, used by both the sync `step` and
+    /// the streaming path so they stay identical in behavior.
+    fn finish_from_response(
+        &mut self,
+        resp_json: &Value,
+        ctx: &CognitionContext<'_>,
+    ) -> Result<CognitionStep> {
+        // Usage — accumulate totals and capture this turn's usage.
         let mut step_usage = crate::CognitionUsage::default();
         if let Some(usage) = resp_json.get("usage") {
             let input = usage
@@ -400,6 +425,124 @@ impl Cognition for OpenAiCognition {
             final_answer,
             usage: step_usage,
         })
+    }
+
+    /// Stream a chat completion (SSE), invoking `on_token` for each text delta,
+    /// and return a synthesized non-streaming-shaped response JSON so the shared
+    /// `finish_from_response` parser handles it identically to a normal turn.
+    /// Errors (including any setup failure) let the caller fall back to sync.
+    fn stream_request(
+        &self,
+        ctx: &CognitionContext<'_>,
+        on_token: &mut dyn FnMut(&str),
+    ) -> Result<Value> {
+        use std::io::BufRead;
+
+        let mut req_body = json!({
+            "model": self.model,
+            "max_tokens": self.max_tokens,
+            "messages": self.messages,
+            "stream": true,
+            "stream_options": { "include_usage": true },
+        });
+        if matches!(self.tool_protocol, ToolProtocol::Native) {
+            let tools_payload = build_tools_payload(ctx.tools, ctx.writ);
+            if !tools_payload.is_empty() {
+                req_body["tools"] = json!(tools_payload);
+            }
+        }
+
+        let url = format!("{}/chat/completions", self.base_url);
+        let resp = self
+            .client
+            .post(&url)
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .header("Content-Type", "application/json")
+            .json(&req_body)
+            .send()
+            .map_err(|e| Error::Other(format!("openai stream request failed: {e}")))?;
+        if !resp.status().is_success() {
+            return Err(Error::Other(format!("openai stream HTTP {}", resp.status())));
+        }
+
+        let mut content = String::new();
+        let mut finish_reason = String::new();
+        let mut usage: Option<Value> = None;
+        // tool_calls accumulated by index: (id, name, arguments-string).
+        let mut tcs: Vec<(String, String, String)> = Vec::new();
+
+        let reader = std::io::BufReader::new(resp);
+        for line in reader.lines() {
+            let line = line.map_err(|e| Error::Other(format!("stream read: {e}")))?;
+            let data = match line.strip_prefix("data:") {
+                Some(d) => d.trim(),
+                None => continue,
+            };
+            if data == "[DONE]" {
+                break;
+            }
+            let Ok(chunk) = serde_json::from_str::<Value>(data) else { continue };
+            if let Some(u) = chunk.get("usage") {
+                if !u.is_null() {
+                    usage = Some(u.clone());
+                }
+            }
+            let Some(choice) = chunk.get("choices").and_then(|c| c.as_array()).and_then(|a| a.first())
+            else { continue };
+            if let Some(fr) = choice.get("finish_reason").and_then(|v| v.as_str()) {
+                finish_reason = fr.to_string();
+            }
+            let Some(delta) = choice.get("delta") else { continue };
+            if let Some(text) = delta.get("content").and_then(|v| v.as_str()) {
+                if !text.is_empty() {
+                    content.push_str(text);
+                    on_token(text);
+                }
+            }
+            if let Some(arr) = delta.get("tool_calls").and_then(|v| v.as_array()) {
+                for tc in arr {
+                    let idx = tc.get("index").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
+                    while tcs.len() <= idx {
+                        tcs.push((String::new(), String::new(), String::new()));
+                    }
+                    if let Some(id) = tc.get("id").and_then(|v| v.as_str()) {
+                        if !id.is_empty() { tcs[idx].0 = id.to_string(); }
+                    }
+                    if let Some(f) = tc.get("function") {
+                        if let Some(n) = f.get("name").and_then(|v| v.as_str()) {
+                            if !n.is_empty() { tcs[idx].1 = n.to_string(); }
+                        }
+                        if let Some(a) = f.get("arguments").and_then(|v| v.as_str()) {
+                            tcs[idx].2.push_str(a);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Synthesize the standard response shape for the shared parser.
+        let mut message = json!({ "role": "assistant", "content": content });
+        if !tcs.is_empty() {
+            message["tool_calls"] = json!(tcs
+                .into_iter()
+                .filter(|(_, name, _)| !name.is_empty())
+                .map(|(id, name, args)| json!({
+                    "id": id,
+                    "type": "function",
+                    "function": { "name": name, "arguments": args },
+                }))
+                .collect::<Vec<_>>());
+        }
+        let mut out = json!({
+            "choices": [{
+                "message": message,
+                "finish_reason": if finish_reason.is_empty() { "stop".into() } else { finish_reason },
+            }],
+        });
+        if let Some(u) = usage {
+            out["usage"] = u;
+        }
+        Ok(out)
     }
 }
 

--- a/thymos/crates/thymos-runtime/src/agent_async.rs
+++ b/thymos/crates/thymos-runtime/src/agent_async.rs
@@ -37,6 +37,21 @@ fn parse_retry_after_hint(msg: &str) -> Option<u64> {
     digits.parse().ok()
 }
 
+/// Render a millisecond duration as a friendly "1h 17m" / "45s" string for
+/// rate-limit messages.
+pub fn humanize_duration_ms(ms: u64) -> String {
+    let secs = ms / 1000;
+    if secs >= 3600 {
+        let h = secs / 3600;
+        let m = (secs % 3600) / 60;
+        if m > 0 { format!("{h}h {m}m") } else { format!("{h}h") }
+    } else if secs >= 60 {
+        format!("{}m", secs.div_ceil(60))
+    } else {
+        format!("{}s", secs.max(1))
+    }
+}
+
 /// Map a raw provider/transport error to a short, plain-English sentence for
 /// the chat UI. Never echoes the raw JSON body (which can be noisy and, for
 /// some providers, embed request context). Unknown errors get a generic line.
@@ -198,12 +213,26 @@ pub async fn run_agent_streaming<L: LedgerStore>(
                         if !is_retryable || attempt > max_retries {
                             return Err(e);
                         }
-                        // Prefer the provider's own wait hint (e.g. Groq's
-                        // tokens-per-minute reset, surfaced as
-                        // `[retry_after_ms=N]`). A per-minute budget can't be
-                        // cleared by a sub-second local backoff, so honor the
-                        // server — capped so a pathological hint can't hang the
-                        // run, floored at the exponential as a sane minimum.
+                        // Fail fast on a long reset. If the provider's own wait
+                        // hint exceeds what we'd ever wait (e.g. a daily-token
+                        // limit that resets in over an hour), retrying at a
+                        // capped backoff is futile — it just burns attempts and
+                        // fails anyway. Return immediately with the real wait so
+                        // the user can switch models or come back later.
+                        if let Some(hint) = parse_retry_after_hint(&e.to_string()) {
+                            if hint > MAX_RETRY_BACKOFF_MS {
+                                return Err(thymos_core::error::Error::Other(format!(
+                                    "{} The limit resets in about {}. \
+                                     Switch models in Providers, or try again later. [{}]",
+                                    humanize_provider_error(&e.to_string()),
+                                    humanize_duration_ms(hint),
+                                    e
+                                )));
+                            }
+                        }
+                        // Otherwise prefer the provider's wait hint (e.g. Groq's
+                        // tokens-per-minute reset), floored at the exponential,
+                        // capped at MAX_RETRY_BACKOFF_MS.
                         let exp_ms = 1000 * 2u64.pow(attempt - 1); // 1s, 2s, 4s
                         let backoff_ms = parse_retry_after_hint(&e.to_string())
                             .map(|hint| hint.clamp(exp_ms, MAX_RETRY_BACKOFF_MS))

--- a/thymos/crates/thymos-server/src/execution.rs
+++ b/thymos/crates/thymos-server/src/execution.rs
@@ -99,6 +99,10 @@ pub struct ExecutionSession {
     /// UI can target the decision instead of asking the operator to guess.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pending_channel: Option<String>,
+    /// Growing partial reply while the model streams (opt-in THYMOS_STREAM).
+    /// Cleared when the turn resolves into the final answer.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub partial_answer: Option<String>,
     pub counters: ExecutionCounters,
     pub updated_at_ms: u64,
     pub log: Vec<ExecutionLogEntry>,
@@ -120,6 +124,7 @@ impl ExecutionSession {
             active_tool: None,
             final_answer: None,
             pending_channel: None,
+            partial_answer: None,
             counters: ExecutionCounters::default(),
             updated_at_ms: now_ms(),
             log: Vec::new(),
@@ -570,6 +575,7 @@ impl ExecutionSession {
         self.counters.rejections = summary.rejections;
         self.counters.failures = summary.failures;
         self.final_answer = summary.final_answer.clone();
+        self.partial_answer = None; // resolved into the final answer
         self.phase = ExecutionPhase::Result;
         self.status = if matches!(summary.terminated_by, Termination::CognitionDone) {
             ExecutionStatus::Completed
@@ -580,6 +586,12 @@ impl ExecutionSession {
             ExecutionStatus::Completed => "Task resolved and verified by runtime".into(),
             _ => format!("Run ended before completion: {:?}", summary.terminated_by),
         };
+        self.updated_at_ms = now_ms();
+    }
+
+    /// Append a streamed token chunk to the in-progress reply.
+    pub fn append_partial(&mut self, text: &str) {
+        self.partial_answer.get_or_insert_with(String::new).push_str(text);
         self.updated_at_ms = now_ms();
     }
 

--- a/thymos/crates/thymos-server/src/lib.rs
+++ b/thymos/crates/thymos-server/src/lib.rs
@@ -1845,6 +1845,26 @@ async fn create_run(
         channels.insert(run_id.clone(), execution_tx);
     }
 
+    // Token bridge (opt-in streaming): mirror streamed text into the execution
+    // session's `partial_answer` so the desktop's existing snapshot stream
+    // shows the reply forming live. No-op unless the adapter emits tokens.
+    {
+        let mut token_rx = cognition_tx.subscribe();
+        let state_tok = state.clone();
+        let run_tok = run_id.clone();
+        let task_tok = req.task.clone();
+        let steps_tok = req.max_steps;
+        tokio::spawn(async move {
+            while let Ok(evt) = token_rx.recv().await {
+                if let CognitionEvent::Token { text } = evt {
+                    with_execution_session(&state_tok, &run_tok, &task_tok, steps_tok, |s| {
+                        s.append_partial(&text);
+                    });
+                }
+            }
+        });
+    }
+
     // Record the run as running.
     {
         let mut runs = state.runs.lock().unwrap();

--- a/thymos/crates/thymos-tools/src/coding.rs
+++ b/thymos/crates/thymos-tools/src/coding.rs
@@ -35,12 +35,10 @@ pub struct CodingSandbox {
 
 impl Default for CodingSandbox {
     fn default() -> Self {
-        let cwd = std::env::current_dir()
-            .ok()
-            .map(|p| p.display().to_string())
-            .unwrap_or_default();
         CodingSandbox {
-            allowed_roots: if cwd.is_empty() { vec![] } else { vec![cwd] },
+            // Honors THYMOS_WORKSPACE (the operator-chosen folder) then cwd, so
+            // the read/edit/search tools act on the user's actual project.
+            allowed_roots: crate::workspace_roots(),
             max_read_bytes: 256 * 1024,
             max_grep_matches: 256,
             max_list_entries: 512,

--- a/thymos/crates/thymos-tools/src/lib.rs
+++ b/thymos/crates/thymos-tools/src/lib.rs
@@ -1460,6 +1460,25 @@ pub struct SandboxConfig {
     pub isolate_home: bool,
 }
 
+/// The directory file/shell tools are confined to. Prefers an explicit
+/// `THYMOS_WORKSPACE` (the folder the operator chose — e.g. via the desktop's
+/// "working folder" picker) so the agent can actually act on the user's
+/// project; falls back to the process cwd. This is what makes the coding tools
+/// useful instead of confined to wherever the runtime happened to launch.
+pub fn workspace_roots() -> Vec<String> {
+    if let Some(ws) = std::env::var("THYMOS_WORKSPACE")
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+    {
+        return vec![ws];
+    }
+    std::env::current_dir()
+        .ok()
+        .map(|p| vec![p.display().to_string()])
+        .unwrap_or_default()
+}
+
 impl Default for SandboxConfig {
     fn default() -> Self {
         SandboxConfig {
@@ -1475,10 +1494,7 @@ impl Default for SandboxConfig {
                 ":(){".into(), // fork bomb
             ],
             worker_bin: std::env::var("THYMOS_WORKER_BIN").ok(),
-            allowed_roots: std::env::current_dir()
-                .ok()
-                .map(|p| vec![p.display().to_string()])
-                .unwrap_or_default(),
+            allowed_roots: workspace_roots(),
             isolate_home: true,
         }
     }
@@ -2455,6 +2471,17 @@ impl ToolRegistry {
 #[cfg(test)]
 mod secure_tool_fabric_tests {
     use super::*;
+
+    #[test]
+    fn workspace_roots_prefers_env_then_cwd() {
+        // Serialized via a unique value; env is process-global so just set+clear.
+        std::env::set_var("THYMOS_WORKSPACE", "/tmp/thymos-ws-test");
+        assert_eq!(workspace_roots(), vec!["/tmp/thymos-ws-test".to_string()]);
+        std::env::set_var("THYMOS_WORKSPACE", "  ");
+        // Blank/whitespace is ignored → falls back to cwd (non-empty here).
+        assert!(!workspace_roots().is_empty());
+        std::env::remove_var("THYMOS_WORKSPACE");
+    }
 
     #[test]
     fn shell_rejects_forbidden_sequence() {


### PR DESCRIPTION
The agent gains hands and a voice, plus real hardening.

**Workspace folder (Tier 1.1)** — the coding sandbox defaulted to the runtime's cwd (the app bundle), so file tools were useless. Now `THYMOS_WORKSPACE` scopes the sandbox to a folder you pick via a native dialog (Advanced → Working folder). This is what makes "read/edit my project" actually work.

**Streaming (Tier 1.2, opt-in)** — real SSE token streaming for OpenAI-compatible providers behind `THYMOS_STREAM` (default off, fallback-safe): the reply forms live in chat. Desktop toggle in Advanced. Shared parser with the sync path; 4MB stream cap.

**Daily-limit retry fix** — parse compound h/m/s resets from the provider body, prefer them over the coarse Retry-After header, and fail fast on long resets (e.g. Groq daily limit ~1h17m) instead of three pointless 60s retries that fail anyway.

**Desktop smoke test (Tier 3.8)** — `npm run smoke`: parses both JS files + verifies every referenced element id exists.

Verified: workspace tests + clippy green, cognition/runtime tests green, desktop smoke passes, Tauri host compiles (rfd). Streaming itself is opt-in and needs a live provider to exercise end-to-end.