### PR TITLE
Claude-style composer: slash commands + attach (v0.8.1)

### DIFF
--- a/thymos/Cargo.lock
+++ b/thymos/Cargo.lock
@@ -2699,7 +2699,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-cli"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "axum 0.8.9",
  "clap",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-client"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "axum-test",
  "reqwest",
@@ -2733,7 +2733,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-cognition"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -2747,7 +2747,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-compiler"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -2758,7 +2758,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-core"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "blake3",
  "ed25519-dalek",
@@ -2771,7 +2771,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-ledger"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "blake3",
  "deadpool-postgres",
@@ -2787,7 +2787,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-marketplace"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "blake3",
  "hex",
@@ -2800,7 +2800,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-policy"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -2809,7 +2809,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-runtime"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "serde",
@@ -2826,7 +2826,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-server"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2859,7 +2859,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-tools"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "blake3",
  "reqwest",
@@ -2872,7 +2872,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-worker"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "serde_json",
  "thymos-tools",

--- a/thymos/Cargo.toml
+++ b/thymos/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 license = "Apache-2.0"
 rust-version = "1.80"

--- a/thymos/clients/desktop/package-lock.json
+++ b/thymos/clients/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thymos-desktop",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thymos-desktop",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "devDependencies": {
         "@tauri-apps/cli": "^2"
       }

--- a/thymos/clients/desktop/package.json
+++ b/thymos/clients/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thymos-desktop",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "description": "OpenThymos Desktop — governed-cognition runtime, install once.",
   "scripts": {

--- a/thymos/clients/desktop/src-tauri/Cargo.lock
+++ b/thymos/clients/desktop/src-tauri/Cargo.lock
@@ -3734,7 +3734,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-desktop"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "rfd",
  "serde",

--- a/thymos/clients/desktop/src-tauri/Cargo.toml
+++ b/thymos/clients/desktop/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "thymos-desktop"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "OpenThymos Desktop — a governed-cognition client that supervises a local runtime."

--- a/thymos/clients/desktop/src-tauri/src/lib.rs
+++ b/thymos/clients/desktop/src-tauri/src/lib.rs
@@ -143,6 +143,57 @@ fn streaming_enabled(app: &tauri::AppHandle) -> bool {
 fn get_streaming(app: tauri::AppHandle) -> bool {
     streaming_enabled(&app)
 }
+/// Pick a file and return {name, content} (text only, capped). The agent gets
+/// the content as message context — host-side read so the webview CSP isn't
+/// involved. Binary/oversized files are rejected with a clear message.
+#[tauri::command]
+fn attach_file() -> Result<serde_json::Value, String> {
+    let Some(path) = rfd::FileDialog::new()
+        .set_title("Attach a file as context")
+        .pick_file()
+    else {
+        return Ok(serde_json::json!(null)); // cancelled
+    };
+    const MAX: u64 = 512 * 1024;
+    let meta = std::fs::metadata(&path).map_err(|e| format!("stat: {e}"))?;
+    if meta.len() > MAX {
+        return Err(format!("file is too large ({} KB; max 512 KB)", meta.len() / 1024));
+    }
+    let bytes = std::fs::read(&path).map_err(|e| format!("read: {e}"))?;
+    let content = String::from_utf8(bytes)
+        .map_err(|_| "file isn't UTF-8 text (binary files aren't supported)".to_string())?;
+    let name = path.file_name().map(|n| n.to_string_lossy().into_owned()).unwrap_or_default();
+    Ok(serde_json::json!({ "name": name, "content": content }))
+}
+
+/// Fetch a web page's text host-side (the webview CSP can't reach arbitrary
+/// URLs). Returns {url, content} with HTML stripped to readable text, capped.
+#[tauri::command]
+fn fetch_web(url: String) -> Result<serde_json::Value, String> {
+    let url = url.trim();
+    if !url.starts_with("http://") && !url.starts_with("https://") {
+        return Err("enter a full URL starting with http:// or https://".into());
+    }
+    let resp = ureq::get(url)
+        .timeout(std::time::Duration::from_secs(15))
+        .call()
+        .map_err(|e| format!("couldn't fetch: {e}"))?;
+    let raw = resp.into_string().map_err(|e| format!("read body: {e}"))?;
+    // Crude tag strip → readable text, capped so it can't blow the prompt.
+    let mut text = String::with_capacity(raw.len() / 2);
+    let mut in_tag = false;
+    for c in raw.chars() {
+        match c {
+            '<' => in_tag = true,
+            '>' => in_tag = false,
+            _ if !in_tag => text.push(c),
+            _ => {}
+        }
+    }
+    let text: String = text.split_whitespace().collect::<Vec<_>>().join(" ").chars().take(12_000).collect();
+    Ok(serde_json::json!({ "url": url, "content": text }))
+}
+
 #[tauri::command]
 fn set_streaming(app: tauri::AppHandle, on: bool) -> Result<(), String> {
     if let Some(p) = streaming_path(&app) {
@@ -530,7 +581,9 @@ pub fn run() {
             pick_workspace,
             clear_workspace,
             get_streaming,
-            set_streaming
+            set_streaming,
+            attach_file,
+            fetch_web
         ])
         .on_window_event(|window, event| {
             // Don't orphan the runtime when the app window closes.

--- a/thymos/clients/desktop/src-tauri/tauri.conf.json
+++ b/thymos/clients/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenThymos",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "identifier": "com.openthymos.desktop",
   "build": {
     "frontendDist": "../src"

--- a/thymos/clients/desktop/src/index.html
+++ b/thymos/clients/desktop/src/index.html
@@ -100,9 +100,21 @@
                 </p>
               </div>
             </div>
+            <!-- Attached context (files / web pages) as removable chips -->
+            <div id="attachChips" class="attach-chips" hidden></div>
+            <!-- Slash-command palette (appears when the message starts with /) -->
+            <div id="slashMenu" class="slash-menu" hidden></div>
+            <!-- "+" add-content menu -->
+            <div id="plusMenu" class="plus-menu" hidden>
+              <button type="button" data-add="file">📎 Attach file from computer</button>
+              <button type="button" data-add="web">🌐 Add a web page</button>
+              <button type="button" data-add="folder">📁 Set working folder</button>
+            </div>
             <form class="composer" id="composer">
+              <button type="button" id="plusBtn" class="composer-plus" title="Add content">＋</button>
               <textarea id="taskInput" rows="1" autocomplete="off"
-                placeholder="Message OpenThymos…   (Enter to send · Shift+Enter for a new line)"></textarea>
+                placeholder="Message OpenThymos…   ( / for commands · ＋ to attach · Enter to send )"></textarea>
+              <span id="modePill" class="mode-pill" title="Authority — type /auto, /edit, /plan to change">auto</span>
               <button type="button" id="regenBtn" class="ghost" disabled title="Re-run the last task on a fresh trajectory">↻</button>
               <button type="submit" id="sendBtn">Send</button>
               <button type="button" id="chatStop" class="danger" hidden>■ Stop</button>

--- a/thymos/clients/desktop/src/main.js
+++ b/thymos/clients/desktop/src/main.js
@@ -328,6 +328,10 @@ function renderModeUI() {
     b.classList.toggle("on", b.dataset.mode === m));
   const grants = $("grants");
   if (grants) grants.hidden = m !== "custom";
+  // The composer pill mirrors the active mode (the chat-rail mode row is now
+  // superseded by this + slash commands).
+  const pill = $("modePill");
+  if (pill) { pill.textContent = m; pill.className = "mode-pill mode-" + m; }
 }
 document.querySelectorAll("#modeRow .mode-chip").forEach((b) =>
   b.addEventListener("click", () => setMode(b.dataset.mode)));
@@ -655,7 +659,7 @@ function pushBubble(text) {
 }
 
 // Start a governed run from a task string. Shared by Send and Regenerate.
-async function startRun(task) {
+async function startRun(task, display) {
   if (!task || activeRunId) return;
   const welcome = feed.querySelector(".welcome");
   if (welcome) welcome.remove();
@@ -663,8 +667,11 @@ async function startRun(task) {
   const skills = selectedSkills();
   const scopes = effectiveScopes();
   lastTask = task;
-  pushBubble(task);
-  addMessage("user", task);
+  // Show the user's typed message (not the attachment-expanded task) in the
+  // bubble + history; the model still receives the full `task`.
+  const shown = display || task;
+  pushBubble(shown);
+  addMessage("user", shown);
   setBusy(true);
   try {
     const body = { task };
@@ -724,13 +731,117 @@ function openRunStream(run_id) {
   };
 }
 
+/* ---------- slash commands + attachments (Claude-style composer) ---------- */
+// Attached context (files / web pages) prepended to the next message.
+let attachments = []; // [{kind, label, content}]
+function renderAttachChips() {
+  const box = $("attachChips");
+  if (!box) return;
+  box.innerHTML = "";
+  box.hidden = attachments.length === 0;
+  attachments.forEach((a, i) => {
+    const chip = document.createElement("span");
+    chip.className = "attach-chip";
+    chip.innerHTML = `${a.kind === "web" ? "🌐" : "📎"} ${escapeHtml(a.label)} <button title="remove">×</button>`;
+    chip.querySelector("button").onclick = () => { attachments.splice(i, 1); renderAttachChips(); };
+    box.appendChild(chip);
+  });
+}
+// Prepend attached context to the task so the model sees it (recorded in the
+// run like any task text — auditable).
+function withAttachments(task) {
+  if (!attachments.length) return task;
+  const ctx = attachments
+    .map((a) => `### ${a.kind === "web" ? "Web page" : "File"}: ${a.label}\n${a.content}`)
+    .join("\n\n");
+  return `${ctx}\n\n---\n${task}`;
+}
+
+// Thymos-tuned slash commands. Each: name, hint, run(arg).
+const SLASH = [
+  { cmd: "/auto", hint: "Full authority (dangerous tools still ask)", run: () => setMode("auto") },
+  { cmd: "/edit", hint: "Read + local edits, no shell/network", run: () => setMode("edit") },
+  { cmd: "/plan", hint: "Read-only: inspect & propose, never change", run: () => setMode("plan") },
+  { cmd: "/grant", hint: "Pick exact tools (custom authority)", run: () => { setMode("custom"); document.querySelector('.tab[data-tab="chat"]')?.click(); } },
+  { cmd: "/model", hint: "Set model override — /model <name>", run: (a) => { const cm = $("chatModel"); if (cm) { cm.value = a || ""; cm.onchange?.(); } pushLine("sys", `— model: ${a || "(default)"}`); } },
+  { cmd: "/web", hint: "Attach a web page — /web <url>", run: (a) => addWeb(a) },
+  { cmd: "/audit", hint: "Open the Audit / ledger explorer", run: () => document.querySelector('.tab[data-tab="audit"]')?.click() },
+  { cmd: "/mind", hint: "Open the Mind graph", run: () => document.querySelector('.tab[data-tab="mind"]')?.click() },
+  { cmd: "/clear", hint: "Start a new chat", run: () => newChatSession() },
+  { cmd: "/help", hint: "List commands", run: () => pushLine("sys", "commands: " + SLASH.map((s) => s.cmd).join("  ")) },
+];
+function renderSlashMenu(q) {
+  const menu = $("slashMenu");
+  if (!menu) return;
+  const matches = SLASH.filter((s) => s.cmd.startsWith(q.split(" ")[0]));
+  if (!q.startsWith("/") || !matches.length) { menu.hidden = true; return; }
+  menu.innerHTML = matches.map((s) =>
+    `<button type="button" data-cmd="${s.cmd}"><b>${s.cmd}</b><span>${escapeHtml(s.hint)}</span></button>`).join("");
+  menu.hidden = false;
+  menu.querySelectorAll("button").forEach((b) => b.onclick = () => {
+    $("taskInput").value = b.dataset.cmd + " ";
+    menu.hidden = true; $("taskInput").focus();
+  });
+}
+// Returns true if the input was a handled command (don't start a run).
+function tryRunSlash(text) {
+  if (!text.startsWith("/")) return false;
+  const [cmd, ...rest] = text.split(/\s+/);
+  const entry = SLASH.find((s) => s.cmd === cmd);
+  if (!entry) { pushLine("deny", `✕ unknown command ${escapeHtml(cmd)} — /help`); return true; }
+  entry.run(rest.join(" ").trim());
+  return true;
+}
+async function addWeb(url) {
+  if (!url) { pushLine("sys", "— usage: /web https://example.com"); return; }
+  if (!invoke) { pushLine("deny", "✕ web fetch needs the desktop app"); return; }
+  pushLine("sys", `— fetching ${url}…`);
+  try {
+    const r = await invoke("fetch_web", { url });
+    attachments.push({ kind: "web", label: url, content: r.content });
+    renderAttachChips();
+    pushLine("sys", `— attached ${url} (${r.content.length} chars of context)`);
+  } catch (e) { pushLine("deny", `✕ ${e}`); }
+}
+
+// "+" menu.
+$("plusBtn")?.addEventListener("click", (e) => {
+  e.stopPropagation();
+  const m = $("plusMenu");
+  if (m) m.hidden = !m.hidden;
+});
+document.addEventListener("click", () => { const m = $("plusMenu"); if (m) m.hidden = true; });
+$("plusMenu")?.addEventListener("click", async (e) => {
+  const btn = e.target.closest("button[data-add]");
+  if (!btn) return;
+  $("plusMenu").hidden = true;
+  if (btn.dataset.add === "folder") { $("pickWorkspace") ? null : null; document.querySelector('.tab[data-tab="advanced"]')?.click(); setTimeout(() => $("pickWorkspace")?.click(), 200); return; }
+  if (btn.dataset.add === "web") { const u = prompt("Web page URL:"); if (u) addWeb(u.trim()); return; }
+  if (btn.dataset.add === "file") {
+    if (!invoke) { pushLine("deny", "✕ file attach needs the desktop app"); return; }
+    try {
+      const r = await invoke("attach_file");
+      if (r) { attachments.push({ kind: "file", label: r.name, content: r.content }); renderAttachChips(); }
+    } catch (e) { pushLine("deny", `✕ ${e}`); }
+  }
+});
+
 $("composer").addEventListener("submit", (ev) => {
   ev.preventDefault();
-  const task = $("taskInput").value.trim();
-  if (!task || activeRunId) return;
+  $("slashMenu").hidden = true;
+  const raw = $("taskInput").value.trim();
+  if (!raw || activeRunId) return;
+  // A slash command (alone) runs locally and never starts a governed run.
+  if (raw.startsWith("/") && tryRunSlash(raw)) {
+    $("taskInput").value = ""; autoGrow($("taskInput"));
+    return;
+  }
   $("taskInput").value = "";
   autoGrow($("taskInput"));
-  startRun(task);
+  const task = withAttachments(raw);
+  const note = attachments.length ? ` (+${attachments.length} attached)` : "";
+  attachments = []; renderAttachChips();
+  startRun(task, raw + note);
 });
 
 // Enter sends; Shift+Enter inserts a newline (ChatGPT/Claude convention).
@@ -745,7 +856,10 @@ $("taskInput").addEventListener("keydown", (e) => {
     $("composer").requestSubmit();
   }
 });
-$("taskInput").addEventListener("input", () => autoGrow($("taskInput")));
+$("taskInput").addEventListener("input", (e) => {
+  autoGrow($("taskInput"));
+  renderSlashMenu(e.target.value);
+});
 
 // Regenerate: re-run the last task (new trajectory, fresh writ).
 $("regenBtn")?.addEventListener("click", () => {

--- a/thymos/clients/desktop/src/styles.css
+++ b/thymos/clients/desktop/src/styles.css
@@ -523,3 +523,39 @@ body.advanced .adv-only { display: revert; }
 .ws-actions { display: flex; gap: 8px; margin-top: 10px; }
 .answer.streaming { opacity: 0.92; border-left: 2px solid var(--violet); }
 .answer.streaming::after { content: "▍"; animation: ma-blink 1s steps(1) infinite; color: var(--violet); }
+
+/* Claude-style composer: + button, slash palette, attachments, mode pill */
+.mode-row { display: none; } /* superseded by the composer mode pill + slash commands */
+.composer { position: relative; }
+.composer-plus {
+  flex: 0 0 auto; width: 34px; height: 34px; border-radius: 8px;
+  font-size: 20px; line-height: 1; background: var(--surface-2, #1b1230);
+  border: 1px solid var(--line); color: var(--muted); cursor: pointer;
+}
+.composer-plus:hover { color: var(--text); border-color: var(--violet); }
+.mode-pill {
+  flex: 0 0 auto; align-self: center; font-size: 11px; font-weight: 700;
+  padding: 3px 9px; border-radius: 999px; text-transform: lowercase;
+  background: rgba(124,92,255,.16); color: var(--violet-soft, #b998ff);
+  border: 1px solid var(--violet); cursor: default;
+}
+.mode-pill.mode-plan { background: rgba(69,224,255,.14); color: var(--cyan); border-color: var(--cyan); }
+.mode-pill.mode-edit { background: rgba(106,176,255,.14); color: #6ab0ff; border-color: #6ab0ff; }
+.attach-chips { display: flex; flex-wrap: wrap; gap: 6px; margin: 0 0 8px; }
+.attach-chip {
+  display: inline-flex; align-items: center; gap: 6px; font-size: 12px;
+  padding: 4px 8px; border-radius: 8px; background: var(--surface); border: 1px solid var(--line);
+}
+.attach-chip button { background: none; border: none; color: var(--muted); cursor: pointer; font-size: 14px; padding: 0; }
+.slash-menu, .plus-menu {
+  position: absolute; bottom: 100%; left: 0; margin-bottom: 8px; z-index: 20;
+  background: rgba(17,13,34,.98); border: 1px solid var(--line-2, var(--line));
+  border-radius: 10px; box-shadow: 0 10px 34px rgba(0,0,0,.5); overflow: hidden; min-width: 280px;
+}
+.slash-menu button, .plus-menu button {
+  display: flex; gap: 10px; align-items: baseline; width: 100%; text-align: left;
+  background: none; border: none; color: var(--text); padding: 9px 13px; cursor: pointer; font: inherit;
+}
+.slash-menu button:hover, .plus-menu button:hover { background: rgba(255,255,255,.05); }
+.slash-menu b { color: var(--violet-soft, #b998ff); font-family: ui-monospace, Menlo, monospace; }
+.slash-menu span { color: var(--muted); font-size: 12px; }


### PR DESCRIPTION
Replaces the grant/mode chip clutter with a clean composer: a '/' command palette tuned for Thymos (/auto /edit /plan /grant /model /web /audit /mind /clear /help — grants become a word, not a grid), and a '+' menu to attach a file or web page (host-side, capped, shown as chips, prepended as auditable context) or set the working folder. Compact mode pill replaces the rail mode-row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)