### PR TITLE
Composer layout fixes + grants → Advanced (v0.8.2)

### DIFF
--- a/thymos/Cargo.lock
+++ b/thymos/Cargo.lock
@@ -2699,7 +2699,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-cli"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "axum 0.8.9",
  "clap",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-client"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "axum-test",
  "reqwest",
@@ -2733,7 +2733,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-cognition"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -2747,7 +2747,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-compiler"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -2758,7 +2758,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-core"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "blake3",
  "ed25519-dalek",
@@ -2771,7 +2771,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-ledger"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "blake3",
  "deadpool-postgres",
@@ -2787,7 +2787,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-marketplace"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "blake3",
  "hex",
@@ -2800,7 +2800,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-policy"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -2809,7 +2809,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-runtime"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "serde",
@@ -2826,7 +2826,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-server"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2859,7 +2859,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-tools"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "blake3",
  "reqwest",
@@ -2872,7 +2872,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-worker"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "serde_json",
  "thymos-tools",

--- a/thymos/Cargo.toml
+++ b/thymos/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 license = "Apache-2.0"
 rust-version = "1.80"

--- a/thymos/clients/desktop/package-lock.json
+++ b/thymos/clients/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thymos-desktop",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thymos-desktop",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "devDependencies": {
         "@tauri-apps/cli": "^2"
       }

--- a/thymos/clients/desktop/package.json
+++ b/thymos/clients/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thymos-desktop",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "description": "OpenThymos Desktop — governed-cognition runtime, install once.",
   "scripts": {

--- a/thymos/clients/desktop/src-tauri/Cargo.lock
+++ b/thymos/clients/desktop/src-tauri/Cargo.lock
@@ -3734,7 +3734,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-desktop"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "rfd",
  "serde",

--- a/thymos/clients/desktop/src-tauri/Cargo.toml
+++ b/thymos/clients/desktop/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "thymos-desktop"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 license = "Apache-2.0"
 description = "OpenThymos Desktop — a governed-cognition client that supervises a local runtime."

--- a/thymos/clients/desktop/src-tauri/tauri.conf.json
+++ b/thymos/clients/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenThymos",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "identifier": "com.openthymos.desktop",
   "build": {
     "frontendDist": "../src"

--- a/thymos/clients/desktop/src/index.html
+++ b/thymos/clients/desktop/src/index.html
@@ -71,18 +71,6 @@
                 <button type="button" class="mode-chip" data-mode="custom"
                   title="Pick exact tools with the grant chips below.">Custom</button>
               </div>
-              <div class="grants" id="grants" title="What this chat is allowed to do — the writ scope. The runtime rejects anything not granted. No selection = everything granted.">
-                <span class="grant-label">grant</span>
-                <!-- Chips are built from the live tool registry once the
-                     runtime is up (see renderGrantChips). These are the
-                     offline fallback. -->
-                <button type="button" class="chip on" data-scope="fs_read">fs_read</button>
-                <button type="button" class="chip on" data-scope="grep">grep</button>
-                <button type="button" class="chip" data-scope="fs_patch">fs_patch</button>
-                <button type="button" class="chip" data-scope="shell">shell</button>
-                <button type="button" class="chip" data-scope="http">http</button>
-                <button type="button" class="chip" data-scope="test_run">test_run</button>
-              </div>
             </div>
           </aside>
 
@@ -100,25 +88,29 @@
                 </p>
               </div>
             </div>
-            <!-- Attached context (files / web pages) as removable chips -->
-            <div id="attachChips" class="attach-chips" hidden></div>
-            <!-- Slash-command palette (appears when the message starts with /) -->
-            <div id="slashMenu" class="slash-menu" hidden></div>
-            <!-- "+" add-content menu -->
-            <div id="plusMenu" class="plus-menu" hidden>
-              <button type="button" data-add="file">📎 Attach file from computer</button>
-              <button type="button" data-add="web">🌐 Add a web page</button>
-              <button type="button" data-add="folder">📁 Set working folder</button>
+            <!-- Composer wrap: the positioned anchor for the slash palette and
+                 "+" menu, so they pop up attached to the input (not the page). -->
+            <div class="composer-wrap">
+              <!-- Attached context (files / web pages) as removable chips -->
+              <div id="attachChips" class="attach-chips" hidden></div>
+              <!-- Slash-command palette (appears when the message starts with /) -->
+              <div id="slashMenu" class="slash-menu" hidden></div>
+              <!-- "+" add-content menu -->
+              <div id="plusMenu" class="plus-menu" hidden>
+                <button type="button" data-add="file">📎 Attach file from computer</button>
+                <button type="button" data-add="web">🌐 Add a web page</button>
+                <button type="button" data-add="folder">📁 Set working folder</button>
+              </div>
+              <form class="composer" id="composer">
+                <button type="button" id="plusBtn" class="composer-plus" title="Add content">＋</button>
+                <textarea id="taskInput" rows="1" autocomplete="off"
+                  placeholder="Message OpenThymos…   ( / for commands · ＋ to attach · Enter to send )"></textarea>
+                <span id="modePill" class="mode-pill" title="Authority — type /auto, /edit, /plan to change">auto</span>
+                <button type="button" id="regenBtn" class="ghost" disabled title="Re-run the last task on a fresh trajectory">↻</button>
+                <button type="submit" id="sendBtn">Send</button>
+                <button type="button" id="chatStop" class="danger" hidden>■ Stop</button>
+              </form>
             </div>
-            <form class="composer" id="composer">
-              <button type="button" id="plusBtn" class="composer-plus" title="Add content">＋</button>
-              <textarea id="taskInput" rows="1" autocomplete="off"
-                placeholder="Message OpenThymos…   ( / for commands · ＋ to attach · Enter to send )"></textarea>
-              <span id="modePill" class="mode-pill" title="Authority — type /auto, /edit, /plan to change">auto</span>
-              <button type="button" id="regenBtn" class="ghost" disabled title="Re-run the last task on a fresh trajectory">↻</button>
-              <button type="submit" id="sendBtn">Send</button>
-              <button type="button" id="chatStop" class="danger" hidden>■ Stop</button>
-            </form>
           </div>
         </div>
       </section>
@@ -470,10 +462,22 @@
             <h3>Authority</h3>
             <div id="advAuthority" class="state-card"></div>
             <p class="note">
-              Grants are the writ scope for new chats (left rail chips). Tools at
-              <b>high</b> risk (e.g. <code>shell</code>) always pause for your
-              approval — tune with <code>THYMOS_APPROVE_RISK</code>.
+              Set the mode in chat with <code>/auto</code>, <code>/edit</code>,
+              <code>/plan</code> — or pick exact tools below
+              (<code>/grant</code> brings you here). High-risk tools (e.g.
+              <code>shell</code>) always pause for your approval.
             </p>
+            <div class="grants" id="grants" title="Exact tools new chats may use (custom mode). No selection = everything granted.">
+              <span class="grant-label">tools</span>
+              <!-- Chips are rebuilt from the live registry (renderGrantChips);
+                   these are the offline fallback. -->
+              <button type="button" class="chip on" data-scope="fs_read">fs_read</button>
+              <button type="button" class="chip on" data-scope="grep">grep</button>
+              <button type="button" class="chip" data-scope="fs_patch">fs_patch</button>
+              <button type="button" class="chip" data-scope="shell">shell</button>
+              <button type="button" class="chip" data-scope="http">http</button>
+              <button type="button" class="chip" data-scope="test_run">test_run</button>
+            </div>
           </div>
 
           <div class="card">

--- a/thymos/clients/desktop/src/main.js
+++ b/thymos/clients/desktop/src/main.js
@@ -326,10 +326,11 @@ function renderModeUI() {
   const m = currentMode();
   document.querySelectorAll("#modeRow .mode-chip").forEach((b) =>
     b.classList.toggle("on", b.dataset.mode === m));
+  // The exact-tool picker lives in Advanced → Authority; it only applies in
+  // custom mode, so dim it otherwise (visible for discoverability).
   const grants = $("grants");
-  if (grants) grants.hidden = m !== "custom";
-  // The composer pill mirrors the active mode (the chat-rail mode row is now
-  // superseded by this + slash commands).
+  if (grants) grants.classList.toggle("inactive", m !== "custom");
+  // The composer pill mirrors the active mode (slash commands set it).
   const pill = $("modePill");
   if (pill) { pill.textContent = m; pill.className = "mode-pill mode-" + m; }
 }
@@ -762,7 +763,7 @@ const SLASH = [
   { cmd: "/auto", hint: "Full authority (dangerous tools still ask)", run: () => setMode("auto") },
   { cmd: "/edit", hint: "Read + local edits, no shell/network", run: () => setMode("edit") },
   { cmd: "/plan", hint: "Read-only: inspect & propose, never change", run: () => setMode("plan") },
-  { cmd: "/grant", hint: "Pick exact tools (custom authority)", run: () => { setMode("custom"); document.querySelector('.tab[data-tab="chat"]')?.click(); } },
+  { cmd: "/grant", hint: "Pick exact tools (custom authority)", run: () => { setMode("custom"); document.querySelector('.tab[data-tab="advanced"]')?.click(); } },
   { cmd: "/model", hint: "Set model override — /model <name>", run: (a) => { const cm = $("chatModel"); if (cm) { cm.value = a || ""; cm.onchange?.(); } pushLine("sys", `— model: ${a || "(default)"}`); } },
   { cmd: "/web", hint: "Attach a web page — /web <url>", run: (a) => addWeb(a) },
   { cmd: "/audit", hint: "Open the Audit / ledger explorer", run: () => document.querySelector('.tab[data-tab="audit"]')?.click() },

--- a/thymos/clients/desktop/src/styles.css
+++ b/thymos/clients/desktop/src/styles.css
@@ -559,3 +559,21 @@ body.advanced .adv-only { display: revert; }
 .slash-menu button:hover, .plus-menu button:hover { background: rgba(255,255,255,.05); }
 .slash-menu b { color: var(--violet-soft, #b998ff); font-family: ui-monospace, Menlo, monospace; }
 .slash-menu span { color: var(--muted); font-size: 12px; }
+
+/* ---------- composer layout fixes (v0.8.2) ---------- */
+/* Anchor for the slash palette + "+" menu so they attach to the input. */
+.composer-wrap { position: relative; }
+/* A display class must not defeat the hidden attribute. */
+.attach-chips[hidden], .slash-menu[hidden], .plus-menu[hidden] { display: none !important; }
+/* Align the + button and mode pill with the input/buttons row. */
+.composer-plus { height: 44px; width: 42px; align-self: flex-end; font-size: 22px; }
+.mode-pill { align-self: flex-end; margin-bottom: 13px; }
+/* Chat fills the window instead of stopping at 72vh. */
+.chat-shell { height: calc(100vh - 200px); min-height: 460px; }
+/* Exact-tool picker (Advanced → Authority): wrap cleanly; dim unless custom. */
+#tab-advanced .grants { display: flex; flex-wrap: wrap; gap: 4px; align-items: center; margin-top: 10px; }
+#tab-advanced .grants.inactive { opacity: .45; }
+#tab-advanced .grants.inactive::after {
+  content: "applies in custom mode — type /grant in chat"; flex-basis: 100%;
+  font-size: 11.5px; color: var(--muted); opacity: .9; margin-top: 4px;
+}


### PR DESCRIPTION
Fixes v0.8.1 regressions: slash/+ menus now anchor to the composer (were positioned against the page), hidden works on the attach strip, + button and mode pill align with the input row, chat fills the window (was capped at 72vh), and the grant-chip row moves out of the chat rail into Advanced → Authority (dimmed with an explainer unless custom mode; /grant jumps there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)