### PR TITLE
Roadmap batch 2: diff approvals, token meter, anchor memory, SSRF guard (v0.8.3)

### DIFF
--- a/thymos/Cargo.lock
+++ b/thymos/Cargo.lock
@@ -2699,7 +2699,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-cli"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "axum 0.8.9",
  "clap",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-client"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "axum-test",
  "reqwest",
@@ -2733,7 +2733,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-cognition"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -2747,7 +2747,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-compiler"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -2758,7 +2758,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-core"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "blake3",
  "ed25519-dalek",
@@ -2771,7 +2771,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-ledger"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "blake3",
  "deadpool-postgres",
@@ -2787,7 +2787,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-marketplace"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "blake3",
  "hex",
@@ -2800,7 +2800,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-policy"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -2809,7 +2809,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-runtime"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "serde",
@@ -2826,7 +2826,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-server"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2859,7 +2859,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-tools"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "blake3",
  "reqwest",
@@ -2872,7 +2872,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-worker"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "serde_json",
  "thymos-tools",

--- a/thymos/Cargo.toml
+++ b/thymos/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.2"
+version = "0.8.3"
 edition = "2021"
 license = "Apache-2.0"
 rust-version = "1.80"

--- a/thymos/clients/desktop/package-lock.json
+++ b/thymos/clients/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thymos-desktop",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thymos-desktop",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "devDependencies": {
         "@tauri-apps/cli": "^2"
       }

--- a/thymos/clients/desktop/package.json
+++ b/thymos/clients/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thymos-desktop",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "private": true,
   "description": "OpenThymos Desktop — governed-cognition runtime, install once.",
   "scripts": {

--- a/thymos/clients/desktop/src-tauri/Cargo.lock
+++ b/thymos/clients/desktop/src-tauri/Cargo.lock
@@ -3734,7 +3734,7 @@ dependencies = [
 
 [[package]]
 name = "thymos-desktop"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "rfd",
  "serde",

--- a/thymos/clients/desktop/src-tauri/Cargo.toml
+++ b/thymos/clients/desktop/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "thymos-desktop"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2021"
 license = "Apache-2.0"
 description = "OpenThymos Desktop — a governed-cognition client that supervises a local runtime."

--- a/thymos/clients/desktop/src-tauri/src/lib.rs
+++ b/thymos/clients/desktop/src-tauri/src/lib.rs
@@ -174,6 +174,36 @@ fn fetch_web(url: String) -> Result<serde_json::Value, String> {
     if !url.starts_with("http://") && !url.starts_with("https://") {
         return Err("enter a full URL starting with http:// or https://".into());
     }
+    // Basic SSRF guard: this fetch is user-initiated, but content it returns
+    // becomes model context — block loopback/private/link-local targets so a
+    // pasted link can't read the local runtime or LAN services.
+    let host = url
+        .split("://")
+        .nth(1)
+        .unwrap_or("")
+        .split(['/', ':', '?', '#'])
+        .next()
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    let private = host == "localhost"
+        || host.ends_with(".local")
+        || host.starts_with("127.")
+        || host.starts_with("10.")
+        || host.starts_with("192.168.")
+        || host.starts_with("169.254.")
+        || host == "0.0.0.0"
+        || host == "::1"
+        || host == "[::1]"
+        || (host.starts_with("172.")
+            && host
+                .split('.')
+                .nth(1)
+                .and_then(|o| o.parse::<u8>().ok())
+                .map(|o| (16..=31).contains(&o))
+                .unwrap_or(false));
+    if private {
+        return Err("local/private addresses can't be attached as web context".into());
+    }
     let resp = ureq::get(url)
         .timeout(std::time::Duration::from_secs(15))
         .call()

--- a/thymos/clients/desktop/src-tauri/tauri.conf.json
+++ b/thymos/clients/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenThymos",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "identifier": "com.openthymos.desktop",
   "build": {
     "frontendDist": "../src"

--- a/thymos/clients/desktop/src/main.js
+++ b/thymos/clients/desktop/src/main.js
@@ -610,6 +610,45 @@ $("chatStop")?.addEventListener("click", async () => {
   }
 });
 
+// Render the suspended proposal's CONCRETE action: for fs_patch a real
+// before→after diff, for shell the command, otherwise pretty args. Reads the
+// full proposal from the ledger's pending_approval entry (the approval reason
+// only carries a truncated preview).
+async function renderPendingAction(runId, container) {
+  try {
+    const res = await getJSON(`/audit/entries?run_id=${encodeURIComponent(runId)}&kind=pending_approval&limit=5`);
+    const entries = res.entries || [];
+    const pa = entries[entries.length - 1]?.payload;
+    const plan = pa?.type === "pending_approval" ? pa?.proposal?.body?.plan : null;
+    if (!plan) return;
+    const box = document.createElement("div");
+    box.className = "approval-action";
+    const args = plan.args || {};
+    if (plan.tool === "fs_patch") {
+      const path = args.path || "?";
+      if (args.mode === "replace") {
+        box.innerHTML =
+          `<div class="aa-head">✏️ edit <code>${escapeHtml(path)}</code></div>` +
+          `<pre class="aa-del">- ${escapeHtml(String(args.anchor || "").slice(0, 600))}</pre>` +
+          `<pre class="aa-add">+ ${escapeHtml(String(args.replacement || "").slice(0, 600))}</pre>`;
+      } else {
+        box.innerHTML =
+          `<div class="aa-head">✏️ write <code>${escapeHtml(path)}</code> (full file)</div>` +
+          `<pre class="aa-add">${escapeHtml(String(args.content || "").slice(0, 800))}</pre>`;
+      }
+    } else if (plan.tool === "shell") {
+      box.innerHTML =
+        `<div class="aa-head">⌨ run command</div>` +
+        `<pre class="aa-cmd">$ ${escapeHtml(String(args.command || args.cmd || JSON.stringify(args)).slice(0, 600))}</pre>`;
+    } else {
+      box.innerHTML =
+        `<div class="aa-head">▣ ${escapeHtml(plan.tool || "action")}</div>` +
+        `<pre class="aa-cmd">${escapeHtml(JSON.stringify(args, null, 2).slice(0, 700))}</pre>`;
+    }
+    container.appendChild(box);
+  } catch (_) { /* ledger entry not readable — the reason text still shows */ }
+}
+
 function showApproval(runId, channel, why) {
   if (document.querySelector(`.approval-row[data-run="${runId}"]`)) return;
   const row = document.createElement("div");
@@ -622,6 +661,8 @@ function showApproval(runId, channel, why) {
     w.textContent = String(why).slice(0, 400);
     row.appendChild(w);
   }
+  // Async: enrich with the concrete proposed action (diff / command).
+  renderPendingAction(runId, row);
   const chan = document.createElement("input");
   chan.value = channel || "ops"; // prefilled with the actual pending channel
   chan.style.maxWidth = "120px";

--- a/thymos/clients/desktop/src/styles.css
+++ b/thymos/clients/desktop/src/styles.css
@@ -577,3 +577,15 @@ body.advanced .adv-only { display: revert; }
   content: "applies in custom mode — type /grant in chat"; flex-basis: 100%;
   font-size: 11.5px; color: var(--muted); opacity: .9; margin-top: 4px;
 }
+
+/* Approval card: the concrete proposed action (diff / command) */
+.approval-action { flex-basis: 100%; margin: 6px 0 2px; }
+.aa-head { font-size: 12.5px; font-weight: 700; color: var(--text); margin-bottom: 5px; }
+.aa-head code { color: var(--cyan); }
+.approval-action pre {
+  margin: 0 0 4px; padding: 7px 10px; border-radius: 8px; overflow-x: auto;
+  font-size: 12px; font-family: ui-monospace, Menlo, monospace; white-space: pre-wrap; word-break: break-word;
+}
+.aa-del { background: rgba(255,107,138,.10); border: 1px solid rgba(255,107,138,.3); color: #ff9eb3; }
+.aa-add { background: rgba(70,211,154,.10); border: 1px solid rgba(70,211,154,.3); color: #7fe3b6; }
+.aa-cmd { background: var(--bg-2, rgba(0,0,0,.25)); border: 1px solid var(--line); color: var(--cyan); }

--- a/thymos/clients/desktop/src/viz.js
+++ b/thymos/clients/desktop/src/viz.js
@@ -109,6 +109,7 @@ function labelSprite(text, cssColor) {
   return s;
 }
 const hex = (n) => "#" + n.toString(16).padStart(6, "0");
+const fmtK = (n) => (n >= 1000 ? (n / 1000).toFixed(1) + "k" : String(n || 0));
 
 function init() {
   const container = document.getElementById("mindCanvas");
@@ -681,6 +682,9 @@ function renderRunState(id, snap, health, replay) {
       : "",
     `<span><span class="ms-label">commits</span><span class="ms-val">${c.commits ?? 0}</span></span>`,
     `<span><span class="ms-label">rejections</span><span class="ms-val">${c.rejections ?? 0}</span></span>`,
+    (snap.tokens_in || snap.tokens_out)
+      ? `<span><span class="ms-label">tokens</span><span class="ms-val">${fmtK(snap.tokens_in)}↑ ${fmtK(snap.tokens_out)}↓</span></span>`
+      : "",
     (c.approvals_pending ?? 0) > 0
       ? `<span class="badge warn">⏸ ${c.approvals_pending} awaiting approval</span>`
       : "",

--- a/thymos/crates/thymos-runtime/src/agent.rs
+++ b/thymos/crates/thymos-runtime/src/agent.rs
@@ -144,6 +144,13 @@ pub enum AgentTraceEvent {
         delay_ms: u64,
         message: String,
     },
+    /// Token usage the provider reported for one cognition step — lets
+    /// surfaces show live consumption.
+    UsageUpdated {
+        step_index: u32,
+        input_tokens: u64,
+        output_tokens: u64,
+    },
     RunFinished {
         trajectory_id: String,
         steps_executed: u32,

--- a/thymos/crates/thymos-runtime/src/agent_async.rs
+++ b/thymos/crates/thymos-runtime/src/agent_async.rs
@@ -269,6 +269,18 @@ pub async fn run_agent_streaming<L: LedgerStore>(
 
         steps_executed += 1;
 
+        // Surface this step's provider-reported token usage (zero for mock).
+        if step.usage.input_tokens > 0 || step.usage.output_tokens > 0 {
+            emit_event(
+                trace_tx.as_ref(),
+                AgentTraceEvent::UsageUpdated {
+                    step_index: step_idx,
+                    input_tokens: step.usage.input_tokens,
+                    output_tokens: step.usage.output_tokens,
+                },
+            );
+        }
+
         if step.intents.is_empty() {
             final_answer = step.final_answer;
             terminated_by = Termination::CognitionDone;

--- a/thymos/crates/thymos-runtime/tests/risk_gate.rs
+++ b/thymos/crates/thymos-runtime/tests/risk_gate.rs
@@ -121,6 +121,21 @@ fn at_threshold_suspends() {
         }
         other => panic!("expected suspension, got {other:?}"),
     }
+    // The ledger's pending_approval entry must expose the full proposed plan
+    // at payload.PendingApproval.proposal.body.plan — the desktop's approval
+    // card reads exactly this path to render the concrete action (diff/cmd).
+    let entries = rt
+        .ledger
+        .query_entries(None, Some("pending_approval"), None, None, Some(10))
+        .unwrap();
+    assert_eq!(entries.len(), 1);
+    let v = serde_json::to_value(&entries[0].payload).unwrap();
+    assert_eq!(v["type"].as_str(), Some("pending_approval"));
+    assert_eq!(
+        v.pointer("/proposal/body/plan/tool").and_then(|t| t.as_str()),
+        Some("risky_write")
+    );
+    assert!(v.pointer("/proposal/body/plan/args").is_some());
 }
 
 #[test]

--- a/thymos/crates/thymos-server/src/execution.rs
+++ b/thymos/crates/thymos-server/src/execution.rs
@@ -103,6 +103,9 @@ pub struct ExecutionSession {
     /// Cleared when the turn resolves into the final answer.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub partial_answer: Option<String>,
+    /// Provider-reported token usage accumulated across this run's steps.
+    pub tokens_in: u64,
+    pub tokens_out: u64,
     pub counters: ExecutionCounters,
     pub updated_at_ms: u64,
     pub log: Vec<ExecutionLogEntry>,
@@ -125,6 +128,8 @@ impl ExecutionSession {
             final_answer: None,
             pending_channel: None,
             partial_answer: None,
+            tokens_in: 0,
+            tokens_out: 0,
             counters: ExecutionCounters::default(),
             updated_at_ms: now_ms(),
             log: Vec::new(),
@@ -509,6 +514,17 @@ impl ExecutionSession {
                     None,
                     None,
                 );
+            }
+            AgentTraceEvent::UsageUpdated {
+                input_tokens,
+                output_tokens,
+                ..
+            } => {
+                // Accumulate provider-reported tokens; no log entry (it would
+                // be noise) — the live strip reads the totals.
+                self.tokens_in += input_tokens;
+                self.tokens_out += output_tokens;
+                self.updated_at_ms = now_ms();
             }
             AgentTraceEvent::RunFinished {
                 trajectory_id,

--- a/thymos/crates/thymos-server/src/lib.rs
+++ b/thymos/crates/thymos-server/src/lib.rs
@@ -486,9 +486,7 @@ fn compose_agent_task(task: &str, history: &[HistoryTurn]) -> String {
     if history.is_empty() {
         return task.to_string();
     }
-    let mut turns: Vec<String> = Vec::new();
-    let mut used = 0usize;
-    for t in history.iter().rev().take(MAX_HISTORY_TURNS) {
+    let render = |t: &HistoryTurn| {
         let role = if t.role.eq_ignore_ascii_case("assistant") {
             "assistant"
         } else {
@@ -498,21 +496,35 @@ fn compose_agent_task(task: &str, history: &[HistoryTurn]) -> String {
         if t.text.trim().chars().count() > MAX_HISTORY_TURN_CHARS {
             text.push('…');
         }
-        let line = format!("{role}: {text}");
+        format!("{role}: {text}")
+    };
+    // Anchor + recency: the FIRST turn usually states what the conversation is
+    // about, so reserve it; then fill the remaining budget with the newest
+    // turns. Long conversations keep both their topic and their present.
+    let anchor = render(&history[0]);
+    let mut used = anchor.len();
+    let mut turns: Vec<String> = Vec::new();
+    for t in history.iter().skip(1).rev().take(MAX_HISTORY_TURNS) {
+        let line = render(t);
         if used + line.len() > MAX_HISTORY_CHARS {
             break;
         }
         used += line.len();
         turns.push(line);
     }
-    if turns.is_empty() {
-        return task.to_string();
-    }
     turns.reverse();
+    let gap = history.len() > turns.len() + 1;
+    let mut body = anchor;
+    if gap {
+        body.push_str("\n[… earlier turns omitted …]");
+    }
+    if !turns.is_empty() {
+        body.push('\n');
+        body.push_str(&turns.join("\n"));
+    }
     format!(
         "## Conversation so far (context only — answer the current message)\n{}\n\n## Current message\n{}",
-        turns.join("\n"),
-        task
+        body, task
     )
 }
 
@@ -3206,15 +3218,18 @@ mod history_tests {
     }
 
     #[test]
-    fn history_is_capped_keeping_newest() {
-        // 40 long turns blow the budget; the newest must survive.
+    fn history_is_capped_keeping_anchor_and_newest() {
+        // 40 long turns blow the budget; the FIRST (topic anchor) and the
+        // newest survive, the middle is dropped with an omission marker.
         let h: Vec<HistoryTurn> = (0..40)
             .map(|i| turn("user", &format!("turn-{i} {}", "x".repeat(900))))
             .collect();
         let out = compose_agent_task("t", &h);
-        assert!(out.len() < MAX_HISTORY_CHARS + 200);
-        assert!(out.contains("turn-39"));
-        assert!(!out.contains("turn-0 "));
+        assert!(out.len() < MAX_HISTORY_CHARS + 1200);
+        assert!(out.contains("turn-0 "), "anchor turn kept");
+        assert!(out.contains("turn-39"), "newest turn kept");
+        assert!(!out.contains("turn-5 "), "middle dropped");
+        assert!(out.contains("earlier turns omitted"));
     }
 
     #[test]


### PR DESCRIPTION
Approval cards render the concrete suspended action (fs_patch as a real before→after diff, shell as the command) read from the ledger's pending_approval entry — payload path locked by a runtime test. Live token meter (per-step UsageUpdated → session totals → Mind strip). Conversation memory keeps the first turn as a topic anchor plus newest within budget. fetch_web refuses loopback/private hosts. Auto-updater + semantic search deferred pending signing/embedding decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)